### PR TITLE
Hardening: per-module audit + deferred-gaps remediation

### DIFF
--- a/src/Auto3D/ASE/geometry.py
+++ b/src/Auto3D/ASE/geometry.py
@@ -61,9 +61,11 @@ def opt_geometry(
         ... )
     """
     ev2hatree = 1 / hartree2ev
-    # Create output path in the same directory as the input file
+    # Create output path in the same directory as the input file.
+    # splitext (not split(".")) so an input like 'batch.v2.sdf' keeps 'batch.v2'
+    # instead of collapsing to 'batch' and risking output collisions.
     dir = os.path.dirname(path)
-    stem = os.path.basename(path).split(".")[0]
+    stem = os.path.splitext(os.path.basename(path))[0]
     if os.path.exists(model_name):  # custom NNP passed as a file path
         basename = stem + "_userNNP_opt.sdf"
     else:
@@ -88,6 +90,11 @@ def opt_geometry(
     mols = list(Chem.SDMolSupplier(outpath, removeHs=False))
     with Chem.SDWriter(outpath) as f:
         for mol in mols:
+            # Skip records that failed to re-parse or lack E_tot rather than
+            # crashing here, which would discard the entire (already completed)
+            # optimization run on a single bad record.
+            if mol is None or not mol.HasProp('E_tot'):
+                continue
             e = float(mol.GetProp('E_tot')) * ev2hatree
             mol.SetProp('E_tot', str(e))
             f.write(mol)

--- a/src/Auto3D/batch_opt/ANI2xt_no_rep.py
+++ b/src/Auto3D/batch_opt/ANI2xt_no_rep.py
@@ -2,7 +2,6 @@ import os
 
 import torch
 import torch.nn as nn
-import torchani
 
 from Auto3D.utils import ANI2XT_INDEX, hartree2ev
 
@@ -20,6 +19,12 @@ ani_2xt_dict = os.path.join(root, "models/ani2xt_no_repulsion.pt")
 class ANI2xt(nn.Module):
     def __init__(self, device, state_dict=ani_2xt_dict, periodic_table_index=False):
         super().__init__()
+        # torchani is an optional dependency, imported lazily so that merely
+        # importing this module (e.g. via Auto3D.ASE.thermo, which only
+        # references the ANI2xt class) never requires torchani. It is only
+        # needed to build the AEV computer below.
+        import torchani
+
         # setup constants and construct an AEV computer
         Rcr = 5.2000e+00
         Rca = 3.5000e+00

--- a/src/Auto3D/batch_opt/ANI2xt_no_rep.py
+++ b/src/Auto3D/batch_opt/ANI2xt_no_rep.py
@@ -144,6 +144,12 @@ class ANI2xt(nn.Module):
 
         Returns:
             Tensor of shape (batch,) with molecular energies in eV
+
+        Note:
+            Energies are computed in float32 (coords dtype). Self-atomic energy
+            shifts cancel in conformer energy differences (same atom counts), so
+            the float32 path does not affect ranking; absolute energies carry a
+            float32 ULP (~4e-3 eV) at typical total-energy magnitudes.
         """
         if self.periodic:
             # Convert atomic numbers to sequential indices

--- a/src/Auto3D/batch_opt/fire_optimizer.py
+++ b/src/Auto3D/batch_opt/fire_optimizer.py
@@ -117,7 +117,13 @@ class FIRE:
         a3 = self.a.unsqueeze(-1).unsqueeze(-1)
         v_norm = self.v.flatten(-2, -1).norm(p=2, dim=-1, keepdim=True).unsqueeze(-1)
         f_norm = forces.flatten(-2, -1).norm(p=2, dim=-1, keepdim=True).unsqueeze(-1)
-        v_mixed = (1.0 - a3) * self.v + a3 * v_norm * forces / f_norm
+        # Clamp the force-norm denominator: a molecule can be "progressing"
+        # (v.f > 0) while its float32 force-norm underflows to 0 (forces so small
+        # their squares round to zero, e.g. ~1e-24), which makes forces / f_norm
+        # produce inf/NaN that is then selected into self.v and corrupts that
+        # conformer for the rest of the run. clamp_min is a no-op for any real
+        # force norm (>> 1e-30) and only guards the degenerate near-zero limit.
+        v_mixed = (1.0 - a3) * self.v + a3 * v_norm * forces / f_norm.clamp_min(1e-30)
 
         # v: mixed where progressing, reset to zero otherwise.
         prog3 = progressing.unsqueeze(-1).unsqueeze(-1)

--- a/src/Auto3D/batch_opt/optimization_engine.py
+++ b/src/Auto3D/batch_opt/optimization_engine.py
@@ -230,14 +230,20 @@ def n_steps(
         if n >= 10 and (istep % (n // 10)) == 0:
             print_stats(state, patience)
 
-    # Energy stored during the loop is evaluated at the pre-step geometry, while
-    # the stored coordinates are post-step. Recompute energy once at the final
-    # geometry so state['energy'] is consistent with state['coord'].
-    # (Forces are recomputed too by the adapters but discarded; grad must be
-    # enabled because the adapters differentiate internally for forces.)
+    # Energy and fmax stored during the loop are evaluated at the pre-step
+    # geometry, while the stored coordinates are post-step (the loop always takes
+    # one FIRE step after measuring forces). Recompute both once at the final
+    # geometry so state['energy'] and state['fmax'] correspond to the reported
+    # state['coord']. The adapters differentiate internally for forces, so grad
+    # must be enabled; the forces were previously discarded.
     final_coord = state['coord'].detach().clone().requires_grad_(True)
-    e_final, _ = state['nn'].forward_batched(final_coord, state['numbers'], state['charges'])
+    e_final, f_final = state['nn'].forward_batched(final_coord, state['numbers'], state['charges'])
     state['energy'] = e_final.detach().to(state['energy'].dtype)
+    # Zero padded-atom force slots before the reduction, matching the in-loop
+    # convergence check, so reported fmax is independent of how the model treats
+    # ghost atoms.
+    f_final = f_final.detach().masked_fill((state['numbers'] == species_pad).unsqueeze(-1), 0.0)
+    state['fmax'] = f_final.norm(dim=-1).max(dim=-1)[0].to(state['fmax'].dtype)
 
     if istep == (n):
         logger.info("Reaching maximum optimization step:")

--- a/src/Auto3D/cli/commands/config.py
+++ b/src/Auto3D/cli/commands/config.py
@@ -131,6 +131,13 @@ def execute_config_show(config_file: Path | None = None) -> None:
 
 def execute_config_validate(config_file: Path) -> None:
     """Validate a configuration file."""
+    if not config_file.exists():
+        print_error(
+            f"Config file not found: {config_file}",
+            hint="Run 'auto3d config init' to create one.",
+        )
+        raise SystemExit(1)
+
     try:
         config = load_yaml_config(config_file)
 

--- a/src/Auto3D/cli/commands/models.py
+++ b/src/Auto3D/cli/commands/models.py
@@ -174,6 +174,10 @@ ENGINE_INFO = {
 def execute_models_info(engine: str) -> None:
     """Display detailed information about an engine."""
     engine_upper = engine.upper()
+    # 'aimnet2' is the canonical registry name that 'AIMNET' aliases (and the
+    # default engine), so route it to the AIMNET entry instead of "Unknown".
+    if engine_upper == "AIMNET2":
+        engine_upper = "AIMNET"
 
     if engine_upper not in ENGINE_INFO:
         print_error(

--- a/src/Auto3D/config.py
+++ b/src/Auto3D/config.py
@@ -113,6 +113,12 @@ class Auto3DOptions:
     allow_tf32: bool = False
     """Enable TF32 for faster matmul on Ampere+ GPUs (less precise). Default False."""
 
+    # Derived/internal
+    input_format: str | None = None
+    """Input file format ('smi' or 'sdf'), inferred from the input suffix during
+    setup. Declared as a real field (rather than a dynamic attribute) so it
+    survives dataclasses.replace()/pickling and stays in the dict-like API."""
+
     def __post_init__(self):
         """Normalize string values to lowercase and validate ranges."""
         self.tauto_engine = self.tauto_engine.lower()

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -91,13 +91,16 @@ def _filter_within_cluster(
     if len(mols) <= 1:
         return list(mols)
 
+    # Strip Hs once per molecule (O(n)), not once per comparison (O(n^2)).
+    # GetBestRMS on the no-H forms is symmetric, so results are unchanged. The
+    # ORIGINAL (H-explicit) mols are returned; no-H forms are comparison-only.
     unique: list[Chem.Mol] = []
+    unique_noH: list[Chem.Mol] = []
     for mol_i in mols:
-        is_unique = True
         mol_i_noH = Chem.RemoveHs(mol_i)
+        is_unique = True
 
-        for mol_j in unique:
-            mol_j_noH = Chem.RemoveHs(mol_j)
+        for mol_j_noH in unique_noH:
             try:
                 # Temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # Removing Hs speeds up the calculation
@@ -111,5 +114,6 @@ def _filter_within_cluster(
 
         if is_unique:
             unique.append(mol_i)
+            unique_noH.append(mol_i_noH)
 
     return unique

--- a/src/Auto3D/isomer_engine.py
+++ b/src/Auto3D/isomer_engine.py
@@ -199,9 +199,17 @@ class RDKitIsomer:
                     line = isomer.strip() + '\t' + new_name + '\n'
                     f.write(line)
 
-    def embed_conformer(self, smi: str) -> Chem.Mol:
-        """Embed multiple 3D conformers for a SMILES string."""
-        mol = Chem.AddHs(Chem.MolFromSmiles(smi))
+    def embed_conformer(self, smi: str) -> Chem.Mol | None:
+        """Embed multiple 3D conformers for a SMILES string.
+
+        Returns None if the SMILES cannot be parsed, mirroring the parallel
+        worker (_embed_single) so a single unparseable SMILES is skipped rather
+        than crashing the whole serial embedding loop on AddHs(None).
+        """
+        mol_noh = Chem.MolFromSmiles(smi)
+        if mol_noh is None:
+            return None
+        mol = Chem.AddHs(mol_noh)
         if self.n_conformers is None:
             # Compute the conformer budget on the H-complete (AddHs) mol so the
             # SMILES and SDF paths agree, and on the RICHER side: RDKit's
@@ -274,6 +282,11 @@ class RDKitIsomer:
         with Chem.SDWriter(self.enumerated_sdf) as writer:
             for smi, name in tqdm(smi_name_tuples):
                 mol = self.embed_conformer(smi)
+                if mol is None:
+                    logger.warning(
+                        f"Skipping molecule {name!r}: failed to parse {smi!r}"
+                    )
+                    continue
                 for i in range(mol.GetNumConformers()):
                     # Relieve atom clashes (MMFF, UFF fallback) and keep the
                     # conformer only if it ends up clash-free.

--- a/src/Auto3D/isomers/parallel_embed.py
+++ b/src/Auto3D/isomers/parallel_embed.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 
 from rdkit import Chem
 from rdkit.Chem import AllChem
@@ -122,6 +123,12 @@ def embed_conformers_parallel(
         for future in futures:
             try:
                 yield from future.result()
+            except BrokenProcessPool:
+                # A worker died (e.g. OOM-killed): the pool is broken and EVERY
+                # remaining future will also raise this. Surface it loudly --
+                # the broad except below would otherwise swallow it per-future
+                # and silently drop the whole tail of the batch as warnings.
+                raise
             except Exception as e:
                 # Per-molecule boundary: a single molecule's failure (including
                 # RDKit's Boost.Python.ArgumentError, which is a TypeError and so

--- a/src/Auto3D/isomers/parallel_embed.py
+++ b/src/Auto3D/isomers/parallel_embed.py
@@ -2,9 +2,8 @@
 """Parallel conformer embedding using multiprocessing."""
 from __future__ import annotations
 
-import pickle
-from concurrent.futures import ProcessPoolExecutor, as_completed
-from typing import Iterator
+from collections.abc import Iterator
+from concurrent.futures import ProcessPoolExecutor
 
 from rdkit import Chem
 from rdkit.Chem import AllChem
@@ -117,11 +116,16 @@ def embed_conformers_parallel(
             for smi, name in smiles_names
         }
 
-        for future in as_completed(futures):
+        # Iterate in submission order (not as_completed) so the emitted molecule
+        # order is deterministic and matches the serial path; all futures are
+        # already running concurrently, so this costs no parallelism.
+        for future in futures:
             try:
-                results = future.result()
-                for mol, conf_idx, conf_id in results:
-                    yield mol, conf_idx, conf_id
-            except (ValueError, RuntimeError, KeyError, pickle.PicklingError) as e:
+                yield from future.result()
+            except Exception as e:
+                # Per-molecule boundary: a single molecule's failure (including
+                # RDKit's Boost.Python.ArgumentError, which is a TypeError and so
+                # escaped the previous narrow except) must not abort the whole
+                # batch and silently drop every remaining molecule.
                 smi, name = futures[future]
                 logger.warning(f"Failed to embed {name}: {type(e).__name__}: {e}")

--- a/src/Auto3D/tautomer.py
+++ b/src/Auto3D/tautomer.py
@@ -23,8 +23,10 @@ def select_tautomers(sdf: str, k: int | None = None, window: float | None = None
     logger.info("Begin to select stable tautomers based on their conformer energies...")
     results = []
     if (k is not None) and (window is not None):
-        raise ValueError("Only k OR window needs to be specified")        
-    
+        raise ValueError("Only k OR window needs to be specified")
+    if (k is not None) and (k < 1):
+        raise ValueError(f"tauto_k must be >= 1, got {k}")
+
     supplier = Chem.SDMolSupplier(sdf, removeHs=False)
     mols = [m for m in supplier if m is not None]
     for mol in mols:
@@ -32,6 +34,9 @@ def select_tautomers(sdf: str, k: int | None = None, window: float | None = None
             mol.ClearProp("E_rel(kcal/mol)")  # conformer-level energy, not tautomer-level
 
     titles = [mol.GetProp("_Name") for mol in mols]
+    # Tautomers of one input molecule are named "id@tautN", so the base ID is
+    # the part before '@' -- this is the real tautomer-grouping separator (see
+    # test_select_tautomers_groups_by_id), distinct from the '_' conformer index.
     ids = [title.split("@")[0].strip() for title in titles]
     energies = [float(mol.GetProp("E_tot")) * hartree2kcalpermol for mol in mols]
     df = pd.DataFrame({"id": ids, "energy": energies, "mol": mols})
@@ -66,7 +71,10 @@ def select_tautomers(sdf: str, k: int | None = None, window: float | None = None
         
 
     folder = os.path.dirname(sdf)
-    basename = os.path.basename(sdf).split(".")[0].strip() + "_top_tautomers.sdf"
+    # splitext (not split(".")) so an input like 'mol.v2.sdf' keeps 'mol.v2'
+    # instead of collapsing to 'mol' and risking output collisions.
+    stem = os.path.splitext(os.path.basename(sdf))[0].strip()
+    basename = stem + "_top_tautomers.sdf"
     output_path = os.path.join(folder, basename)
     with Chem.SDWriter(output_path) as w:
         for mol in results:

--- a/src/Auto3D/torch_config.py
+++ b/src/Auto3D/torch_config.py
@@ -97,10 +97,14 @@ def configure_torch(config: TorchConfig | None = None) -> None:
         import numpy as np
         np.random.seed(config.random_seed)
 
-    if config.deterministic:
-        torch.use_deterministic_algorithms(True)
-        # cuDNN deterministic mode
-        torch.backends.cudnn.deterministic = True
+    # Set deterministic flags unconditionally so a later configure_torch() with
+    # deterministic=False actually turns determinism back off (previously these
+    # were only ever set to True, making them write-once-sticky). warn_only=True
+    # so AIMNet2/ANI scatter / masked index-put ops -- which have no
+    # deterministic CUDA kernel -- warn instead of raising and aborting the very
+    # optimization loop deterministic mode is meant to make reproducible.
+    torch.use_deterministic_algorithms(config.deterministic, warn_only=True)
+    torch.backends.cudnn.deterministic = config.deterministic
 
 
 # Note: We intentionally do NOT apply any default configuration on module import.

--- a/src/Auto3D/torch_config.py
+++ b/src/Auto3D/torch_config.py
@@ -83,9 +83,16 @@ def configure_torch(config: TorchConfig | None = None) -> None:
     if config is None:
         config = TorchConfig()
 
-    # Precision settings
+    # Precision settings. Set both the legacy allow_tf32 booleans (back-compat
+    # for torch < 2.9) and the modern fp32_precision knob (canonical on torch
+    # >= 2.9, where allow_tf32 is deprecated). "ieee" = full FP32, "tf32" = TF32.
+    fp32_mode = "tf32" if config.allow_tf32 else "ieee"
     torch.backends.cuda.matmul.allow_tf32 = config.allow_tf32
     torch.backends.cudnn.allow_tf32 = config.allow_tf32
+    if hasattr(torch.backends.cuda.matmul, "fp32_precision"):
+        torch.backends.cuda.matmul.fp32_precision = fp32_mode
+    if hasattr(torch.backends.cudnn, "fp32_precision"):
+        torch.backends.cudnn.fp32_precision = fp32_mode
     torch.backends.cudnn.benchmark = config.cudnn_benchmark
 
     # Reproducibility settings

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -11,11 +11,10 @@ This module provides:
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 import numpy as np
 from rdkit import Chem
-from rdkit.Chem import AllChem, rdMolAlign, rdMolDescriptors, rdMolTransforms, rdmolops
+from rdkit.Chem import AllChem, rdMolAlign, rdMolDescriptors, rdmolops, rdMolTransforms
 
 from Auto3D.constants import (
     CONFORMER_MULTIPLIER,
@@ -375,7 +374,7 @@ def amend_mol(
     mol: Chem.Mol,
     sanitize: bool = False,
     check_valid: bool = False,
-) -> Optional[Chem.Mol]:
+) -> Chem.Mol | None:
     """Attempt to fix or validate a molecule.
 
     This function can optionally sanitize a molecule and check its validity.

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -508,15 +508,20 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
             mols_.append(mol)
     mols = mols_
 
-    # Remove similar structures
+    # Remove similar structures. Strip Hs once per molecule (O(n)) instead of on
+    # both sides of every comparison (O(n^2)); GetBestRMS on no-H forms is
+    # symmetric so results are unchanged. The ORIGINAL (H-explicit) mols are
+    # returned; no-H forms are comparison-only.
     unique_mols: list[Chem.Mol] = []
+    unique_noH: list[Chem.Mol] = []
     for mol_i in mols:
+        mol_i_noH = Chem.RemoveHs(mol_i)
         unique = True
-        for mol_j in unique_mols:
+        for mol_j_noH in unique_noH:
             try:
                 # temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # removing Hs speeds up the calculation
-                rmsd = rdMolAlign.GetBestRMS(Chem.RemoveHs(mol_i), Chem.RemoveHs(mol_j))
+                rmsd = rdMolAlign.GetBestRMS(mol_i_noH, mol_j_noH)
             except RuntimeError:
                 # Incomparable pair: treat as distinct (not a duplicate) so the
                 # conformer is kept. Using 0 would make it look like a perfect
@@ -527,4 +532,5 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
                 break
         if unique:
             unique_mols.append(mol_i)
+            unique_noH.append(mol_i_noH)
     return unique_mols

--- a/src/Auto3D/utils/file_ops.py
+++ b/src/Auto3D/utils/file_ops.py
@@ -370,14 +370,16 @@ def housekeeping(job_name: str, folder: str, optimized_structures: str) -> None:
         if str(file) != optimized_structures:
             shutil.move(str(file), folder)
 
-    try:
-        files1 = list(Path(".").glob("oeomega_*"))
-        files2 = list(Path(".").glob("flipper_*"))
-        files = files1 + files2
-        for file in files:
-            shutil.move(str(file), folder)
-    except OSError:
-        pass
+    # Sweep OpenEye omega/flipper logfiles the binaries drop in the CWD. Guard
+    # each move individually: with multi-GPU optimizers running concurrently a
+    # peer may move/remove a file first, and a single bare try used to abandon
+    # the rest of the sweep on the first such error. (Diagnostic logs only.)
+    for file in list(Path(".").glob("oeomega_*")) + list(Path(".").glob("flipper_*")):
+        try:
+            if file.exists():
+                shutil.move(str(file), folder)
+        except OSError:
+            pass
 
 
 def create_chunk_meta_names(path: str, dir: str) -> dict[str, str]:

--- a/src/Auto3D/utils/logging_config.py
+++ b/src/Auto3D/utils/logging_config.py
@@ -40,9 +40,12 @@ def configure_logging(verbose: bool = False) -> None:
     auto3d_logger = logging.getLogger("Auto3D")
     auto3d_logger.setLevel(level)
 
-    # Only add handler if none exists (avoid duplicates)
+    # Only add handler if none exists (avoid duplicates).
+    # Diagnostics go to stderr, never stdout: the workflow logs INFO lines
+    # (e.g. "Output path: ...") during a run, and `auto3d run --json` must keep
+    # stdout a clean, parseable JSON document.
     if not auto3d_logger.handlers:
-        handler = logging.StreamHandler(sys.stdout)
+        handler = logging.StreamHandler(sys.stderr)
         handler.setLevel(level)
         # Simple format - just the message (like print)
         formatter = logging.Formatter('%(message)s')

--- a/src/Auto3D/utils/stereochemistry.py
+++ b/src/Auto3D/utils/stereochemistry.py
@@ -190,15 +190,23 @@ def get_stereo_info(smi: str) -> OrderedDict[int, str]:
         smi: SMILES string to parse.
 
     Returns:
-        OrderedDict mapping character positions to stereo symbols (@ or @@),
-        sorted by position.
+        OrderedDict mapping character positions to tetrahedral stereo symbols
+        (@ or @@), sorted by position. Multi-letter stereo-class descriptors
+        (@SP, @TH, @OH, @TB, @AL for square-planar/tetrahedral-explicit/
+        octahedral/trigonal-bipyramidal/allene centers) are deliberately
+        excluded: create_enantiomer can only invert plain @/@@ by string
+        surgery, and treating @SP1 as a bare @ used to splice it into the
+        invalid token @@SP1, silently aborting the molecule's enumeration.
 
     Example:
         >>> get_stereo_info('C[C@H](O)[C@@H](F)Cl')
         OrderedDict([(2, '@'), (9, '@@')])
     """
     dct: dict[int, str] = {}
-    regex1 = re.compile("[^@]@[^@]")
+    # A bare tetrahedral '@' is never immediately followed by two uppercase
+    # letters, whereas every multi-letter stereo class is (SP/TH/OH/TB/AL), so
+    # the negative lookahead skips those without matching legitimate '@'/'@@'.
+    regex1 = re.compile("[^@]@(?![A-Z][A-Z])[^@]")
     regex2 = re.compile("@@")
 
     # match @
@@ -231,6 +239,13 @@ def no_enantiomer(smi: str, smiles: list[str]) -> bool:
         tar = smiles[i]
         if tar != smi:
             stereo_infoj = list(get_stereo_info(tar).values())
+            # A different number of stereo markers means a different set of
+            # stereocenters, so the two cannot be enantiomers. Skip rather than
+            # calling no_enantiomer_helper, which raises on a length mismatch --
+            # that ValueError used to bubble up and make amend_configuration
+            # abandon the whole molecule's enumeration.
+            if len(stereo_infoi) != len(stereo_infoj):
+                continue
             if no_enantiomer_helper(stereo_infoi, stereo_infoj):
                 return False
     return True

--- a/src/Auto3D/utils/validation.py
+++ b/src/Auto3D/utils/validation.py
@@ -8,7 +8,7 @@ import os
 import pickle
 import warnings
 from pathlib import Path
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import torch
 from rdkit import Chem
@@ -17,9 +17,11 @@ from rdkit.Chem.rdMolDescriptors import (
 )
 
 from Auto3D.exceptions import (
-    GPUError,
-    DependencyError,
     ConfigurationError,
+    DependencyError,
+    FileFormatError,
+    GPUError,
+    InputValidationError,
     ModelLoadError,
 )
 from Auto3D.utils.logging_config import get_logger
@@ -108,6 +110,11 @@ def check_input(args: Any) -> None:
         ANI, only_aimnet_smiles = check_smi_format(args)
     elif args.input_format == "sdf":
         ANI, only_aimnet_smiles = check_sdf_format(args)
+    else:
+        raise FileFormatError(
+            f"Input file type is not supported. Only .smi and .sdf are supported, "
+            f"but input_format is {args.input_format!r}."
+        )
 
     logger.info("Suggestions for choosing isomer_engine and optimizing_engine: ")
     if ANI:
@@ -144,7 +151,7 @@ def check_smi_format(args: Any) -> tuple[bool, list[str]]:
             - only_aimnet_smiles: List of SMILES that require AIMNET (contain non-ANI elements or charged)
 
     Raises:
-        ValueError: If SMILES or ID is empty in any line.
+        InputValidationError: If a non-blank line lacks a SMILES and an ID.
     """
     ANI_elements = {1, 6, 7, 8, 9, 16, 17}
     ANI = True
@@ -155,14 +162,21 @@ def check_smi_format(args: Any) -> tuple[bool, list[str]]:
     for line in data:
         if line.isspace():
             continue
-        smiles, id = tuple(line.strip().split())
-        if len(smiles) == 0:
-            raise ValueError(f"Empty SMILES string in line: {line.strip()!r}")
-        if len(id) == 0:
-            raise ValueError(f"Empty ID in line: {line.strip()!r}")
+        # Tolerate ragged rows the way the rest of the pipeline does: the chunk
+        # loader reads only the first two whitespace columns (usecols=[0, 1]), so
+        # trailing tokens (e.g. an inline comment column) must not be rejected
+        # here. split() never yields empty tokens, so a present SMILES/ID is
+        # guaranteed non-empty.
+        parts = line.split()
+        if len(parts) < 2:
+            raise InputValidationError(
+                "Each non-blank line must contain a SMILES and an ID separated by "
+                f"whitespace, but got: {line.strip()!r}"
+            )
+        smiles = parts[0]  # parts[1] is the ID; its presence is enforced above
         smiles_all.append(smiles)
 
-    logger.info(f"\tThere are {len(data)} SMILES in the input file {args.path}.")
+    logger.info(f"\tThere are {len(smiles_all)} SMILES in the input file {args.path}.")
     logger.info("\tAll SMILES and IDs are valid.")
 
     # Check number of unspecified atomic stereo center
@@ -306,14 +320,20 @@ def check_valid_configuration(
                 if idx >= torch.cuda.device_count():
                     errors.append(f"GPU index {idx} is invalid. Available GPUs: {torch.cuda.device_count()}")
 
-    # Check optimizing_engine
+    # Check optimizing_engine. Besides the named engines, any name starting with
+    # "aimnet2" is a valid AIMNet registry model (aimnet2-2025, aimnet2-nse,
+    # aimnet2-pd, ...) resolved lazily by model_factory, matching the CLI schema.
     valid_engines = {"ANI2x", "ANI2xt", "AIMNET"}
-    if optimizing_engine not in valid_engines:
-        if not Path(optimizing_engine).exists():
-            errors.append(
-                f"optimizing_engine must be one of {valid_engines} or a valid path to a custom model. "
-                f"Got: {optimizing_engine}"
-            )
+    if (
+        optimizing_engine not in valid_engines
+        and not optimizing_engine.lower().startswith("aimnet2")
+        and not Path(optimizing_engine).exists()
+    ):
+        errors.append(
+            f"optimizing_engine must be one of {valid_engines}, an aimnet registry "
+            f"name (aimnet2, aimnet2-2025, ...), or a valid path to a custom model. "
+            f"Got: {optimizing_engine}"
+        )
 
     # Check isomer_engine
     valid_isomer_engines = {"rdkit", "omega"}

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -80,12 +80,14 @@ class WorkflowOrchestrator:
         torch_config = TorchConfig(allow_tf32=self.config.allow_tf32)
         configure_torch(torch_config)
 
-        # Phase 1: Validation and setup
-        self._validate_input()
-        self._setup_job_directory()
-        self._setup_logging()
-
         try:
+            # Phase 1: Validation and setup. Kept inside the try so the encoded
+            # temp file written by _validate_input is cleaned up even when a
+            # later setup step (job dir creation, logging) raises.
+            self._validate_input()
+            self._setup_job_directory()
+            self._setup_logging()
+
             # Phase 2: Prepare chunks
             chunk_info = self._prepare_chunks()
 
@@ -99,8 +101,11 @@ class WorkflowOrchestrator:
         finally:
             # Always flush the daemon logger and remove the temporary encoded
             # input file, even when a phase raises partway through.
+            # input_path stays at its Path() default (the cwd, a directory)
+            # until _validate_input assigns the encoded file, so is_file()
+            # guards against ever unlinking anything but a real encoded input.
             self._shutdown_logging()
-            if self.input_path.exists():
+            if self.input_path.is_file():
                 self.input_path.unlink()
 
     def _validate_input(self) -> None:
@@ -113,17 +118,20 @@ class WorkflowOrchestrator:
         if self.config.path is None:
             raise ConfigurationError("Please specify the input file path.")
 
-        # Encode IDs for internal processing
-        encoded_path, self.id_mapping = encode_ids(self.config.path)
-        self.input_path = Path(encoded_path)
-
-        # Validate file format
-        self.input_format = self.input_path.suffix[1:]  # Remove leading dot
+        # Validate file format BEFORE encoding so an unsupported extension
+        # raises FileFormatError (not a generic ValueError from encode_ids) and
+        # no encoded temp file is written for input we are about to reject. The
+        # encoded file keeps the source suffix, so this format is authoritative.
+        self.input_format = Path(self.config.path).suffix[1:]  # Remove leading dot
         if self.input_format not in ("smi", "sdf"):
             raise FileFormatError(
                 f"Input file type is not supported. Only .smi and .sdf are supported. "
                 f"But the input file is {self.input_format}."
             )
+
+        # Encode IDs for internal processing
+        encoded_path, self.id_mapping = encode_ids(self.config.path)
+        self.input_path = Path(encoded_path)
 
         # Store format in config for downstream use
         self.config["input_format"] = self.input_format

--- a/src/Auto3D/workflow_workers.py
+++ b/src/Auto3D/workflow_workers.py
@@ -125,44 +125,66 @@ def optim_rank_wrapper(
         if sdf_path_dir_job == "Done":
             break
         enumerated_sdf, path, dir, job = sdf_path_dir_job
-        logger.info(f"\n\nOptimizing on job{job}")
-        meta = create_chunk_meta_names(path, dir)
+        # Isolate each chunk: a single failing chunk (a molecule the optimizer
+        # chokes on, a CUDA OOM, an isomer step that produced nothing, an mkdir
+        # collision) must not kill this worker and silently drop every chunk
+        # still queued behind it. Log it and move on to the next chunk.
+        try:
+            logger.info(f"\n\nOptimizing on job{job}")
+            meta = create_chunk_meta_names(path, dir)
 
-        # Optimizing step
-        opt_config = args.to_optimization_config()
-        optimized_og = meta["optimized_og"]
-        optimizing_engine = args.optimizing_engine
-        if args.use_gpu:
-            device = torch.device(f"cuda:{gpu_idx}")
-        else:
-            device = torch.device("cpu")
-        optimizer = optimizing(enumerated_sdf, optimized_og,
-                               optimizing_engine, device, opt_config)
-        optimizer.run()
+            # Optimizing step
+            opt_config = args.to_optimization_config()
+            optimized_og = meta["optimized_og"]
+            optimizing_engine = args.optimizing_engine
+            if args.use_gpu:
+                device = torch.device(f"cuda:{gpu_idx}")
+            else:
+                device = torch.device("cpu")
+            optimizer = optimizing(enumerated_sdf, optimized_og,
+                                   optimizing_engine, device, opt_config)
+            optimizer.run()
 
-        # Ranking step
-        output = meta["output"]
-        duplicate_threshold = args.threshold
-        k = args.k
-        window = args.window
-        rank_engine = ranking(optimized_og,
-                              output, duplicate_threshold, k=k, window=window)
-        conformers.append(rank_engine.run())
+            # optimizing.run() returns early without writing optimized_og when
+            # the isomer step yielded an empty/missing SDF for this chunk. Skip
+            # ranking rather than letting RDKit raise on a nonexistent path; the
+            # chunk simply contributes no conformers.
+            if not os.path.exists(optimized_og):
+                logger.warning(
+                    f"job{job}: no optimized structures were produced; "
+                    "skipping ranking for this chunk."
+                )
+                continue
 
-        # Housekeeping
-        housekeeping_folder = meta["housekeeping_folder"]
-        os.mkdir(housekeeping_folder)
-        housekeeping(dir, housekeeping_folder, output)
-        #Conpress verbose folder
-        housekeeping_folder_gz = housekeeping_folder + ".tar.gz"
-        with tarfile.open(housekeeping_folder_gz, "w:gz") as tar:
-            tar.add(housekeeping_folder, arcname=Path(housekeeping_folder).name)
-        shutil.rmtree(housekeeping_folder)
-        if not args.verbose:
-            try:  # Clusters does not support send2trash
-                send2trash(housekeeping_folder_gz)
-            except OSError:
-                os.remove(housekeeping_folder_gz)
+            # Ranking step
+            output = meta["output"]
+            duplicate_threshold = args.threshold
+            k = args.k
+            window = args.window
+            rank_engine = ranking(optimized_og,
+                                  output, duplicate_threshold, k=k, window=window)
+            conformers.append(rank_engine.run())
+
+            # Housekeeping
+            housekeeping_folder = meta["housekeeping_folder"]
+            os.mkdir(housekeeping_folder)
+            housekeeping(dir, housekeeping_folder, output)
+            #Conpress verbose folder
+            housekeeping_folder_gz = housekeeping_folder + ".tar.gz"
+            with tarfile.open(housekeeping_folder_gz, "w:gz") as tar:
+                tar.add(housekeeping_folder, arcname=Path(housekeeping_folder).name)
+            shutil.rmtree(housekeeping_folder)
+            if not args.verbose:
+                try:  # Clusters does not support send2trash
+                    send2trash(housekeeping_folder_gz)
+                except OSError:
+                    os.remove(housekeeping_folder_gz)
+        except Exception:
+            logger.exception(
+                f"job{job} failed during optimization/ranking; "
+                "skipping this chunk and continuing with the rest."
+            )
+            continue
     return conformers
 
 def logger_process(queue: Queue[LogRecord | None], logging_path: str) -> None:

--- a/tests/test_ase_geometry.py
+++ b/tests/test_ase_geometry.py
@@ -14,3 +14,48 @@ def test_opt_geometry_names_output_by_model(monkeypatch, tmp_path):
 
     out = geo.opt_geometry(str(sdf), "AIMNET")
     assert out.endswith("mols_AIMNET_opt.sdf")
+
+
+def test_opt_geometry_skips_none_and_missing_etot(monkeypatch, tmp_path):
+    """A None record or one lacking E_tot must be skipped, not crash the run
+    (which would discard the whole completed optimization)."""
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    import Auto3D.ASE.geometry as geo
+
+    sdf = tmp_path / "mols.sdf"
+    sdf.write_text("")  # contents irrelevant; optimizing + supplier are stubbed
+
+    good = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+    AllChem.EmbedMolecule(good, randomSeed=1)
+    good.SetProp("_Name", "good")
+    good.SetProp("E_tot", "-100.0")  # eV
+    no_etot = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+    AllChem.EmbedMolecule(no_etot, randomSeed=2)
+    no_etot.SetProp("_Name", "no_etot")  # deliberately missing E_tot
+
+    class _Stub:
+        def __init__(self, *a, **k):
+            pass
+
+        def run(self):
+            pass
+
+    monkeypatch.setattr(geo, "optimizing", _Stub)
+    # The re-read supplier yields a None record, a record with no E_tot, and a
+    # good one; only the good one should survive into the rewritten output.
+    monkeypatch.setattr(
+        geo.Chem, "SDMolSupplier", lambda *a, **k: [None, no_etot, good]
+    )
+    monkeypatch.setattr(geo.torch.cuda, "is_available", lambda: False)
+
+    out = geo.opt_geometry(str(sdf), "AIMNET")  # must not raise
+
+    # Read the written file as text (the rdkit.Chem.SDMolSupplier monkeypatch
+    # is module-global, so re-reading via it would return the stub list, not
+    # the file). Only the good record should have been written.
+    with open(out) as fh:
+        text = fh.read()
+    assert "good" in text
+    assert "no_etot" not in text

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -261,6 +261,7 @@ def test_run_with_nonexistent_file(runner):
 def test_json_output_is_pure_json(runner, tmp_path_cwd, monkeypatch):
     """--json stdout must be parseable even when the k/window warning fires."""
     import json
+
     from Auto3D.cli.app import app
 
     smi = tmp_path_cwd / "in.smi"
@@ -337,3 +338,19 @@ def test_models_info_aimnet2_pd(runner):
     result = runner.invoke(app, ["models", "info", "aimnet2-pd"])
     assert result.exit_code == 0
     assert "Pd" in result.stdout
+
+
+def test_models_info_aimnet2_alias(runner):
+    """models info aimnet2 (the canonical default) must resolve to the AIMNET entry."""
+    from Auto3D.cli.app import app
+    result = runner.invoke(app, ["models", "info", "aimnet2"])
+    assert result.exit_code == 0
+    assert "AIMNet2" in result.stdout
+
+
+def test_config_validate_missing_file(runner, tmp_path_cwd):
+    """config validate on a missing file should fail with a not-found hint."""
+    from Auto3D.cli.app import app
+    result = runner.invoke(app, ["config", "validate", "nonexistent.yaml"])
+    assert result.exit_code == 1
+    assert "not found" in result.stderr

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,27 @@
 """Unit tests for the config module."""
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from Auto3D.config import Auto3DOptions
+
+
+def test_input_format_is_real_field_surviving_replace():
+    """input_format must be a declared field so dataclasses.replace() preserves it.
+
+    It was previously set as a dynamic attribute via __setitem__, which
+    replace() silently dropped -- a latent AttributeError for any consumer
+    reading it off a replace()'d config copy.
+    """
+    cfg = Auto3DOptions(path="x.smi", k=1)
+    assert cfg.input_format is None          # declared default
+    cfg["input_format"] = "smi"              # dict-like write, as workflow.py does
+    assert cfg.input_format == "smi"
+    assert "input_format" in cfg.keys()      # part of the dict-like contract
+    cfg2 = replace(cfg, batchsize_atoms=2048)
+    assert cfg2.input_format == "smi"        # survives replace()
 
 
 class TestAuto3DOptions:
@@ -147,14 +165,12 @@ def test_capacity_default_matches_across_layers():
 
 
 def test_negative_k_rejected():
-    import pytest
     from Auto3D.config import Auto3DOptions
     with pytest.raises(ValueError):
         Auto3DOptions(path="x.smi", k=-1)
 
 
 def test_negative_window_rejected():
-    import pytest
     from Auto3D.config import Auto3DOptions
     with pytest.raises(ValueError):
         Auto3DOptions(path="x.smi", window=-0.5)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -186,6 +186,53 @@ class TestFilterUniqueBehavior:
         assert len(original_result) == len(optimized_result)
 
 
+def test_filter_within_cluster_removehs_is_linear_and_nondestructive(monkeypatch):
+    """RemoveHs runs once per molecule (O(n)) AND is non-destructive: returned
+    conformers keep their explicit hydrogens and exact H positions. This is a
+    correctness invariant, not just perf -- the MLIP requires explicit H and the
+    final geometries written to SDF must retain the optimized H coordinates. The
+    no-H form is a throwaway copy used only for the RMSD comparison.
+    """
+    import numpy as np
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    from Auto3D import filtering
+
+    # Five DISTINCT conformers of one molecule so all survive as unique,
+    # maximizing inner-loop comparisons (the O(n^2) path strips Hs each pair).
+    mols = []
+    base = Chem.AddHs(Chem.MolFromSmiles("CCCCO"))
+    cids = AllChem.EmbedMultipleConfs(base, numConfs=5, randomSeed=1)
+    for cid in cids:
+        m = Chem.Mol(base, confId=int(cid))
+        m.SetProp("E_tot", "0.0")
+        m.SetProp("Converged", "true")
+        mols.append(m)
+    n_atoms = base.GetNumAtoms()  # heavy + explicit H (15 for CCCCO)
+    orig_pos = {id(m): m.GetConformer().GetPositions().copy() for m in mols}
+
+    calls = {"n": 0}
+    real_removehs = filtering.Chem.RemoveHs
+
+    def counting(mol, *a, **k):
+        calls["n"] += 1
+        return real_removehs(mol, *a, **k)
+
+    monkeypatch.setattr(filtering.Chem, "RemoveHs", counting)
+
+    result = filtering._filter_within_cluster(mols, rmsd_threshold=0.01)
+
+    # O(n): RemoveHs called once per input, never per pair.
+    assert calls["n"] == len(mols)
+    assert len(result) == len(mols)
+    # Non-destructive: returned mols keep explicit H and byte-identical positions.
+    for m in result:
+        assert m.GetNumAtoms() == n_atoms
+        assert any(a.GetAtomicNum() == 1 for a in m.GetAtoms())
+        assert np.array_equal(m.GetConformer().GetPositions(), orig_pos[id(m)])
+
+
 def test_rmsd_failure_keeps_both(monkeypatch):
     from rdkit import Chem
     from rdkit.Chem import AllChem, rdMolAlign

--- a/tests/test_fire_optimizer.py
+++ b/tests/test_fire_optimizer.py
@@ -2,7 +2,6 @@
 """Unit tests for the FIRE optimizer module."""
 from __future__ import annotations
 
-import pytest
 import torch
 
 from Auto3D.batch_opt.fire_optimizer import FIRE
@@ -134,6 +133,30 @@ class TestFIREStep:
         # Should not exceed maxstep
         assert displacement_norm.max() <= optimizer.maxstep + 1e-6
 
+    def test_fire_tiny_progressing_forces_stay_finite(self):
+        """Underflowing force norms must not inject inf/NaN.
+
+        A molecule can be 'progressing' (v.f > 0) while its float32 force norm
+        underflows to exactly 0 -- forces so small (~1e-24) that their squares
+        round to zero. Without clamping the force-norm denominator, forces /
+        f_norm becomes inf/NaN, is selected into the velocity, and permanently
+        corrupts that conformer. Guard: the step must stay finite.
+        """
+        coord = torch.zeros(1, 2, 3)
+        optimizer = FIRE(coord)
+        optimizer.v = torch.full((1, 2, 3), 1e-10)  # finite v_norm
+        forces = torch.full((1, 2, 3), 1e-24)       # f^2 underflows to 0 in fp32
+
+        # Precondition: this configuration really does trigger the degenerate
+        # branch (progressing molecule with a zeroed force norm).
+        vf = (forces * optimizer.v).flatten(-2, -1).sum(-1)
+        f_norm = forces.flatten(-2, -1).norm(p=2, dim=-1)
+        assert (vf > 0).all() and float(f_norm) == 0.0
+
+        new_coord = optimizer(coord, forces)
+        assert torch.isfinite(new_coord).all()
+        assert torch.isfinite(optimizer.v).all()
+
 
 class TestFIREClean:
     """Tests for FIRE optimizer clean method."""
@@ -227,8 +250,6 @@ class TestFIREMultipleSteps:
         # Provide consistent forces in same direction
         forces = torch.ones(1, 10, 3) * 0.1
 
-        initial_dt = optimizer.dt[0].item()
-
         # Apply multiple steps with consistent force direction
         for _ in range(10):
             coord = optimizer(coord, forces)
@@ -250,9 +271,6 @@ class TestFIREMultipleSteps:
         forces_positive = torch.ones(1, 5, 3) * 0.1
         for _ in range(5):
             coord = optimizer(coord, forces_positive)
-
-        # Store velocity magnitude
-        v_before_reversal = optimizer.v.norm().item()
 
         # Reverse force direction - should trigger reset
         forces_negative = -torch.ones(1, 5, 3) * 0.1
@@ -314,7 +332,7 @@ class TestFIRETorchScript:
 
         # TorchScript classes have specific attributes
         # This test verifies the @torch.jit.script decorator worked
-        assert hasattr(optimizer, '__call__')
+        assert callable(optimizer)
         assert hasattr(optimizer, 'clean')
 
     def test_fire_works_in_jit_context(self):
@@ -335,6 +353,7 @@ class TestFIRETorchScript:
 def test_fire_trajectory_golden():
     """FIRE must produce a deterministic trajectory; guards the branchless rewrite."""
     import torch
+
     from Auto3D.batch_opt.fire_optimizer import FIRE
 
     torch.manual_seed(0)

--- a/tests/test_isomer_engine_hardening.py
+++ b/tests/test_isomer_engine_hardening.py
@@ -73,6 +73,27 @@ class TestInvalidSmilesDoesNotAbort:
         assert "valid_mol" in engine.enumerate
         assert "invalid_mol" not in engine.enumerate
 
+    def test_embed_conformer_returns_none_on_unparseable(self, tmp_path):
+        """embed_conformer must return None (not crash on AddHs(None)) for an
+        unparseable SMILES, mirroring the parallel worker."""
+        smi = tmp_path / "in.smi"
+        smi.write_text("CCO mol1\n")
+        engine = _make_engine(str(tmp_path), smi)
+        assert engine.embed_conformer("invalid_smiles_xyz") is None
+        assert engine.embed_conformer("CCO").GetNumConformers() >= 1
+
+    def test_run_serial_embedding_skips_unparseable(self, tmp_path):
+        """The serial embedding loop must skip an unparseable SMILES and still
+        write the valid one, matching the parallel path's behavior."""
+        smi = tmp_path / "in.smi"
+        smi.write_text("CCO mol1\n")
+        engine = _make_engine(str(tmp_path), smi)
+        engine._run_serial_embedding([("CCO", "good"), ("invalid_xyz", "bad")])
+        mols = [m for m in Chem.SDMolSupplier(engine.enumerated_sdf) if m is not None]
+        names = {m.GetProp("_Name").rsplit("_", 1)[0] for m in mols}
+        assert "good" in names
+        assert "bad" not in names
+
     def test_tautomer_rd_taut_skips_invalid(self, tmp_path):
         """TautomerEngine.rd_taut must skip invalid SMILES, not abort."""
         infile = tmp_path / "in.smi"

--- a/tests/test_lazy_torchani_import.py
+++ b/tests/test_lazy_torchani_import.py
@@ -1,0 +1,34 @@
+"""The optional torchani extra must not be required just to import thermo."""
+from __future__ import annotations
+
+import builtins
+import sys
+
+
+def test_thermo_imports_with_torchani_blocked(monkeypatch):
+    """Importing Auto3D.ASE.thermo (and using its pure-Python helpers) must work
+    even when torchani cannot be imported. torchani is only needed to *construct*
+    an ANI2xt model, not to import the module that references the class.
+    """
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "torchani" or name.startswith("torchani."):
+            raise ImportError("torchani blocked for this test")
+        return real_import(name, *args, **kwargs)
+
+    # Drop cached copies so the re-import re-runs module-level code under the block.
+    for mod in list(sys.modules):
+        if mod.startswith("Auto3D.ASE.thermo") or mod.startswith(
+            "Auto3D.batch_opt.ANI2xt_no_rep"
+        ):
+            sys.modules.pop(mod, None)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+    import Auto3D.ASE.thermo as thermo  # must NOT raise ModuleNotFoundError  # noqa: I001
+
+    from rdkit import Chem
+
+    # A pure-Python helper that does not touch torchani must work.
+    assert thermo._symmetry_number(Chem.MolFromSmiles("CCO")) == 1

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,31 @@
+"""Tests for Auto3D.utils.logging_config."""
+from __future__ import annotations
+
+import logging
+import sys
+
+from Auto3D.utils.logging_config import configure_logging
+
+
+def test_configure_logging_uses_stderr_not_stdout():
+    """The Auto3D logger must write to stderr so --json stdout stays clean.
+
+    Workflow INFO lines (e.g. "Output path: ...") propagate to the root
+    "Auto3D" logger; if its handler targeted stdout they would corrupt the
+    JSON document emitted by `auto3d run --json`.
+    """
+    auto3d_logger = logging.getLogger("Auto3D")
+    saved = auto3d_logger.handlers[:]
+    auto3d_logger.handlers = []
+    try:
+        configure_logging(verbose=False)
+        streams = [
+            h.stream
+            for h in auto3d_logger.handlers
+            if isinstance(h, logging.StreamHandler)
+        ]
+        assert streams, "configure_logging attached no StreamHandler"
+        assert all(s is sys.stderr for s in streams)
+        assert sys.stdout not in streams
+    finally:
+        auto3d_logger.handlers = saved

--- a/tests/test_model_caching.py
+++ b/tests/test_model_caching.py
@@ -27,6 +27,7 @@ class TestModelCaching:
 
     def test_different_models_create_different_instances(self):
         """Test that different model names create different instances."""
+        pytest.importorskip("torchani")  # ANI2xt requires the optional ani extra
         device = torch.device("cpu")
         model_aimnet = create_model("AIMNET", device)
         model_ani2xt = create_model("ANI2xt", device)
@@ -41,6 +42,7 @@ class TestModelCaching:
 
     def test_clear_cache_removes_models(self):
         """Test that clear_cache removes all cached models."""
+        pytest.importorskip("torchani")  # ANI2xt requires the optional ani extra
         device = torch.device("cpu")
         create_model("AIMNET", device)
         create_model("ANI2xt", device)
@@ -57,6 +59,7 @@ class TestModelCaching:
 
     def test_get_cache_info_returns_size(self):
         """Test that get_cache_info returns correct size."""
+        pytest.importorskip("torchani")  # ANI2xt requires the optional ani extra
         device = torch.device("cpu")
         assert ModelFactory.get_cache_info()["size"] == 0
         create_model("AIMNET", device)

--- a/tests/test_optimization_engine.py
+++ b/tests/test_optimization_engine.py
@@ -7,9 +7,8 @@ optimization loop for batch geometry optimization.
 from __future__ import annotations
 
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 import torch
 
 from Auto3D.batch_opt.optimization_engine import n_steps, print_stats
@@ -294,6 +293,7 @@ class TestNSteps:
 
 def test_fmax_ignores_padded_atoms():
     import torch
+
     from Auto3D.batch_opt.optimization_engine import n_steps
 
     class MockNN:
@@ -315,6 +315,7 @@ def test_fmax_ignores_padded_atoms():
 
 def test_stored_energy_matches_stored_coord():
     import torch
+
     from Auto3D.batch_opt.optimization_engine import n_steps
 
     class MockNN:
@@ -336,6 +337,45 @@ def test_stored_energy_matches_stored_coord():
     n_steps(state, n=50, opttol=0.01, patience=40)
     recomputed = (state["coord"] ** 2).sum().item()
     assert abs(state["energy"].item() - recomputed) < 1e-3
+
+
+def test_stored_fmax_matches_stored_coord():
+    """Reported fmax must be the force norm at the reported (final) geometry.
+
+    The loop measures forces at the pre-step geometry then always takes one more
+    FIRE step, so the in-loop fmax lagged the stored post-step coordinates by a
+    full step. fmax is now recomputed at the final geometry alongside energy.
+    Running a still-moving molecule for only a few steps (no convergence) makes
+    the one-step lag large, so this fails if fmax is not recomputed: with the
+    harmonic potential E = sum(coord^2), F = -2*coord, the reported fmax must
+    equal max-over-atoms of |2*coord| at the final coordinates.
+    """
+    import torch
+
+    from Auto3D.batch_opt.optimization_engine import n_steps
+
+    class MockNN:
+        def forward_batched(self, coord, numbers, charges):
+            e = (coord ** 2).sum(dim=(1, 2))
+            f = -2.0 * coord
+            return e, f
+
+    # Start far from the minimum and take only a few steps with an
+    # unreachable tolerance, so the molecule is still moving fast at the end
+    # and the pre-step/post-step force norms differ well above the tolerance.
+    coord = torch.full((1, 2, 3), 2.0, dtype=torch.float)
+    state = {
+        "coord": coord.clone(),
+        "numbers": torch.ones(1, 2, dtype=torch.long),
+        "charges": torch.zeros(1, dtype=torch.long),
+        "nn": MockNN(),
+        "converged_mask": torch.zeros(1, dtype=torch.bool),
+        "fmax": torch.full((1,), 999.0),
+        "energy": torch.full((1,), float("inf"), dtype=torch.double),
+    }
+    n_steps(state, n=3, opttol=1e-9, patience=1000)
+    recomputed_fmax = (2.0 * state["coord"]).norm(dim=-1).max(dim=-1)[0]
+    assert abs(state["fmax"].item() - recomputed_fmax.item()) < 1e-5
 
 
 class TestNStepsIntegration:

--- a/tests/test_parallel_embed.py
+++ b/tests/test_parallel_embed.py
@@ -1,8 +1,19 @@
 # tests/test_parallel_embed.py
 """Tests for parallel conformer embedding module."""
+import multiprocessing as mp
+import os
+from concurrent.futures.process import BrokenProcessPool
+
+import pytest
 from rdkit import Chem
 
 from Auto3D.isomers.parallel_embed import _embed_single, embed_conformers_parallel
+
+
+def _suicide_embed(smi, name, n_conformers, threshold, np_threads):
+    """Module-level worker (picklable) that abruptly kills its process, breaking
+    the pool. Used to exercise the BrokenProcessPool path."""
+    os._exit(1)
 
 
 class TestEmbedSingle:
@@ -199,3 +210,26 @@ class TestEmbedConformersParallel:
             if name not in first_seen:
                 first_seen.append(name)
         assert first_seen == ["ring12", "s1", "s2", "s3"]
+
+    def test_parallel_embed_reraises_broken_pool(self, monkeypatch):
+        """A killed worker (broken pool) must surface loudly, not be swallowed.
+
+        The per-molecule `except Exception` that catches RDKit failures would
+        otherwise also catch BrokenProcessPool on every remaining future and
+        silently drop the whole tail of the batch as warnings. An OOM-killed
+        worker is the realistic trigger.
+        """
+        if mp.get_start_method() != "fork":
+            pytest.skip("relies on fork to propagate the monkeypatched worker into the pool")
+
+        # Replace the worker with one that kills its process mid-task.
+        monkeypatch.setattr(
+            "Auto3D.isomers.parallel_embed._embed_single", _suicide_embed
+        )
+
+        with pytest.raises(BrokenProcessPool):
+            list(
+                embed_conformers_parallel(
+                    [("C", "m1"), ("CC", "m2")], n_conformers=1, n_workers=1
+                )
+            )

--- a/tests/test_parallel_embed.py
+++ b/tests/test_parallel_embed.py
@@ -1,6 +1,5 @@
 # tests/test_parallel_embed.py
 """Tests for parallel conformer embedding module."""
-import pytest
 from rdkit import Chem
 
 from Auto3D.isomers.parallel_embed import _embed_single, embed_conformers_parallel
@@ -173,3 +172,30 @@ class TestEmbedConformersParallel:
         assert any("methane" in cid for cid in conf_ids)
         assert any("ethane" in cid for cid in conf_ids)
         assert not any("bad_mol" in cid for cid in conf_ids)
+
+    def test_parallel_embed_preserves_input_order(self):
+        """Output molecule order must match input order, not completion order.
+
+        The parallel path iterates futures in submission order (not
+        as_completed), so it matches the deterministic serial path. A larger
+        molecule placed first would, under as_completed, finish after the small
+        ones and appear out of order.
+        """
+        smiles_names = [
+            ("C1CCCCCCCCCCC1", "ring12"),  # larger -> slower to embed
+            ("C", "s1"),
+            ("CC", "s2"),
+            ("CCC", "s3"),
+        ]
+        results = list(embed_conformers_parallel(
+            smiles_names,
+            n_conformers=3,
+            n_workers=4,
+        ))
+
+        first_seen = []
+        for _, _, conf_id in results:
+            name = conf_id.rsplit("_", 1)[0]
+            if name not in first_seen:
+                first_seen.append(name)
+        assert first_seen == ["ring12", "s1", "s2", "s3"]

--- a/tests/test_stereochemistry_validation.py
+++ b/tests/test_stereochemistry_validation.py
@@ -6,12 +6,61 @@ ValueError exceptions that provide informative error messages.
 """
 
 import pytest
-from Auto3D.utils.stereochemistry import enantiomer, no_enantiomer_helper
+
+from Auto3D.utils.stereochemistry import (
+    create_enantiomer,
+    enantiomer,
+    no_enantiomer,
+    no_enantiomer_helper,
+)
+
+
+class TestCreateEnantiomerStereoClasses:
+    """create_enantiomer must not corrupt non-tetrahedral stereo descriptors."""
+
+    @pytest.mark.parametrize(
+        "smi",
+        ["F[Po@SP1](Cl)(Br)I", "[C@TH1](F)(Cl)(Br)I"],
+    )
+    def test_nontetrahedral_tokens_stay_valid(self, smi):
+        """@SP/@TH/... must be left intact, not spliced into invalid @@SP1.
+
+        Treating a multi-letter stereo class as a bare '@' used to insert a
+        second '@', producing an unparseable SMILES that aborted the whole
+        molecule's stereo enumeration.
+        """
+        from rdkit import Chem
+        out = create_enantiomer(smi)
+        assert Chem.MolFromSmiles(out) is not None, out
+        assert "@@SP" not in out and "@@TH" not in out
+
+    def test_tetrahedral_inversion_still_works(self):
+        """Plain tetrahedral centers must still be inverted."""
+        assert create_enantiomer("C[C@H](O)F") == "C[C@@H](O)F"
+
+
+class TestNoEnantiomerLengthMismatch:
+    """no_enantiomer must tolerate isomers with differing stereo-marker counts."""
+
+    def test_mismatched_marker_counts_does_not_raise(self):
+        """Comparisons between different-length stereo infos are skipped, not
+        raised, so amend_configuration no longer abandons the molecule."""
+        # One marker vs two markers in the group: not enantiomers -> True.
+        result = no_enantiomer(
+            "C[C@H](O)CC", ["C[C@H](O)CC", "C[C@@H](O)[C@@H](F)Cl"]
+        )
+        assert result is True
+
+    def test_true_enantiomer_still_detected(self):
+        """A genuine enantiomer (same length, all inverted) still returns False."""
+        result = no_enantiomer("C[C@H](O)F", ["C[C@H](O)F", "C[C@@H](O)F"])
+        assert result is False
 
 
 def test_detect_stereo_change():
     from rdkit import Chem
     from rdkit.Chem import AllChem
+
     from Auto3D.utils.stereo_check import stereo_changed
 
     m = Chem.AddHs(Chem.MolFromSmiles("C[C@H](O)Cl"))

--- a/tests/test_tautomer_select.py
+++ b/tests/test_tautomer_select.py
@@ -10,6 +10,7 @@ def test_select_tautomers_groups_by_id(tmp_path):
     """select_tautomers must not crash on pandas 3.x and must keep top-k per id."""
     from rdkit import Chem
     from rdkit.Chem import AllChem
+
     from Auto3D.tautomer import select_tautomers
 
     sdf = tmp_path / "in.sdf"
@@ -27,3 +28,23 @@ def test_select_tautomers_groups_by_id(tmp_path):
     names = sorted(m.GetProp("_Name") for m in mols)
     assert names == ["molA", "molB"]  # one top tautomer per id
     assert not any(m.HasProp("E_rel(kcal/mol)") for m in mols)
+
+
+def test_select_tautomers_rejects_nonpositive_k(tmp_path):
+    """k < 1 used to silently drop every tautomer (out_mols0[:0]); now rejected."""
+    import pytest
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    from Auto3D.tautomer import select_tautomers
+
+    sdf = tmp_path / "in.sdf"
+    with Chem.SDWriter(str(sdf)) as w:
+        m = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        AllChem.EmbedMolecule(m, randomSeed=1)
+        m.SetProp("_Name", "molA@taut1")
+        m.SetProp("E_tot", "-1.0")
+        w.write(m)
+
+    with pytest.raises(ValueError, match="tauto_k"):
+        select_tautomers(str(sdf), k=0)

--- a/tests/test_torch_config.py
+++ b/tests/test_torch_config.py
@@ -1,5 +1,6 @@
 # tests/test_torch_config.py
 """Tests for TorchConfig and configure_torch functionality."""
+import pytest
 import torch
 
 
@@ -81,6 +82,28 @@ class TestConfigureTorch:
         config = TorchConfig(allow_tf32=False)
         configure_torch(config)
         assert torch.backends.cuda.matmul.allow_tf32 is False
+
+    def test_configure_torch_sets_fp32_precision_when_available(self):
+        """On torch with the modern fp32_precision API, allow_tf32 must map to
+        the precision mode ('ieee' for False, 'tf32' for True). cudnn.fp32_precision
+        is the decisive check: unlike cuda.matmul, torch does NOT auto-sync it from
+        the legacy allow_tf32 flag, so this fails unless configure_torch sets it."""
+        from Auto3D.torch_config import TorchConfig, configure_torch
+
+        matmul = torch.backends.cuda.matmul
+        cudnn = torch.backends.cudnn
+        if not hasattr(matmul, "fp32_precision") or not hasattr(cudnn, "fp32_precision"):
+            pytest.skip("torch too old for fp32_precision API")
+
+        configure_torch(TorchConfig(allow_tf32=False))
+        assert matmul.fp32_precision == "ieee"
+        assert cudnn.fp32_precision == "ieee"
+
+        configure_torch(TorchConfig(allow_tf32=True))
+        assert matmul.fp32_precision == "tf32"
+        assert cudnn.fp32_precision == "tf32"
+
+        configure_torch(TorchConfig(allow_tf32=False))  # restore default
 
     def test_configure_torch_deterministic_is_reversible(self):
         """deterministic must turn back off on a later config (was write-once).

--- a/tests/test_torch_config.py
+++ b/tests/test_torch_config.py
@@ -1,6 +1,5 @@
 # tests/test_torch_config.py
 """Tests for TorchConfig and configure_torch functionality."""
-import pytest
 import torch
 
 
@@ -83,6 +82,29 @@ class TestConfigureTorch:
         configure_torch(config)
         assert torch.backends.cuda.matmul.allow_tf32 is False
 
+    def test_configure_torch_deterministic_is_reversible(self):
+        """deterministic must turn back off on a later config (was write-once).
+
+        Previously the deterministic flags were only ever set to True, so a
+        process that enabled a reproducible run could never restore fast mode.
+        warn_only=True is also asserted so AIMNet2/ANI scatter ops warn instead
+        of raising under deterministic mode.
+        """
+        from Auto3D.torch_config import TorchConfig, configure_torch
+
+        try:
+            configure_torch(TorchConfig(deterministic=True))
+            assert torch.are_deterministic_algorithms_enabled() is True
+            assert torch.is_deterministic_algorithms_warn_only_enabled() is True
+            assert torch.backends.cudnn.deterministic is True
+
+            configure_torch(TorchConfig(deterministic=False))
+            assert torch.are_deterministic_algorithms_enabled() is False
+            assert torch.backends.cudnn.deterministic is False
+        finally:
+            # Restore the default (non-deterministic) global state.
+            configure_torch(TorchConfig(deterministic=False))
+
 
 class TestAuto3DOptionsAllowTf32:
     """Tests for allow_tf32 option in Auto3DOptions."""
@@ -123,6 +145,7 @@ class TestBatchoptNoHardcodedTF32:
 
         # Import batchopt - it should NOT change the TF32 setting
         import importlib
+
         import Auto3D.batch_opt.batchopt
         importlib.reload(Auto3D.batch_opt.batchopt)
 
@@ -131,10 +154,9 @@ class TestBatchoptNoHardcodedTF32:
 
     def test_tf32_can_be_toggled_after_batchopt_import(self):
         """TF32 settings should be changeable after batchopt is imported."""
-        from Auto3D.torch_config import TorchConfig, configure_torch
-
         # Import batchopt first
         import Auto3D.batch_opt.batchopt  # noqa: F401
+        from Auto3D.torch_config import TorchConfig, configure_torch
 
         # Then configure TF32 - this should work
         configure_torch(TorchConfig(allow_tf32=True))

--- a/tests/test_utils_chemistry.py
+++ b/tests/test_utils_chemistry.py
@@ -609,6 +609,42 @@ class TestFilterUnique:
         # Large threshold should definitely merge identical mols
         assert len(unique_mols_large) == 1
 
+    def test_filter_unique_removehs_is_linear_and_nondestructive(self, monkeypatch):
+        """Legacy filter_unique strips Hs once per molecule (not per comparison) and
+        returns the originals with explicit H + exact positions intact."""
+        import numpy as np
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        from Auto3D.utils import chemistry
+
+        base = Chem.AddHs(Chem.MolFromSmiles("CCCCO"))
+        cids = AllChem.EmbedMultipleConfs(base, numConfs=5, randomSeed=1)
+        mols = []
+        for cid in cids:
+            m = Chem.Mol(base, confId=int(cid))
+            m.SetProp("Converged", "true")
+            mols.append(m)
+        n_atoms = base.GetNumAtoms()
+        orig_pos = {id(m): m.GetConformer().GetPositions().copy() for m in mols}
+
+        calls = {"n": 0}
+        real_removehs = chemistry.Chem.RemoveHs
+
+        def counting(mol, *a, **k):
+            calls["n"] += 1
+            return real_removehs(mol, *a, **k)
+
+        monkeypatch.setattr(chemistry.Chem, "RemoveHs", counting)
+
+        result = chemistry.filter_unique(mols, crit=0.01)
+        assert calls["n"] == len(mols)  # once per input, never per pair
+        assert len(result) == len(mols)
+        for m in result:
+            assert m.GetNumAtoms() == n_atoms
+            assert any(a.GetAtomicNum() == 1 for a in m.GetAtoms())
+            assert np.array_equal(m.GetConformer().GetPositions(), orig_pos[id(m)])
+
     def test_rmsd_failure_keeps_both(self, monkeypatch):
         """An incomparable pair (RMSD raises) must NOT be treated as a duplicate.
 

--- a/tests/test_utils_file_ops.py
+++ b/tests/test_utils_file_ops.py
@@ -1029,5 +1029,44 @@ class TestIterSmiRecords:
             list(iter_smi_records(str(p), on_malformed="bogus"))
 
 
+def test_housekeeping_omega_sweep_is_per_file_robust(tmp_path, monkeypatch):
+    """A vanished/peer-moved oeomega_* file must not abort moving the rest."""
+    import os
+
+    from Auto3D.utils.file_ops import housekeeping
+
+    job = tmp_path / "job"
+    job.mkdir()
+    dest = tmp_path / "verbose"
+    dest.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    # Two omega logfiles; the FIRST one encountered (by counter) will "disappear".
+    (cwd / "oeomega_a.log").write_text("a")
+    (cwd / "oeomega_b.log").write_text("b")
+
+    real_move = __import__("shutil").move
+    call_count = {"n": 0}
+
+    def flaky_move(src, dst):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Simulate a peer worker having already moved the first file.
+            if os.path.exists(src):
+                os.remove(src)
+            raise OSError("already gone")
+        return real_move(src, dst)
+
+    monkeypatch.setattr("Auto3D.utils.file_ops.shutil.move", flaky_move)
+
+    housekeeping(str(job), str(dest), str(job / "out.sdf"))  # must not raise
+
+    # Exactly one of the two logfiles must have been successfully moved.
+    moved = list(dest.glob("oeomega_*.log"))
+    assert len(moved) == 1, f"Expected 1 moved file, got {[f.name for f in moved]}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -6,14 +6,13 @@ import pytest
 from rdkit import Chem
 
 from Auto3D.config import Auto3DOptions
+from Auto3D.utils.chemistry import check_connectivity, filter_unique
 from Auto3D.utils.validation import (
     check_input,
-    check_smi_format,
     check_sdf_format,
+    check_smi_format,
     check_valid_configuration,
 )
-from Auto3D.utils.chemistry import check_connectivity, filter_unique
-
 
 # Set up test file paths
 folder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -80,6 +79,29 @@ class TestCheckSmiFormat:
         # Should be ANI compatible (organic molecules with H, C, N, O, F, S, Cl)
         assert ani_compatible is True
         assert len(only_aimnet) == 0
+
+    def test_check_smi_format_tolerates_extra_columns(self, tmp_path):
+        """Lines with >2 whitespace columns must be accepted.
+
+        The chunk loader reads only the first two columns (usecols=[0, 1]), so
+        a trailing comment column must not make validation reject input the rest
+        of the pipeline happily ingests (previously raised 'too many values to
+        unpack').
+        """
+        smi = tmp_path / "ragged.smi"
+        smi.write_text("CCO ethanol inline_comment_column\nCCN amine\n")
+        args = Auto3DOptions(str(smi), k=1, enumerate_isomer=True, use_gpu=False)
+        ani, _ = check_smi_format(args)
+        assert ani is True
+
+    def test_check_smi_format_rejects_missing_id(self, tmp_path):
+        """A non-blank line with only a SMILES (no ID) raises InputValidationError."""
+        from Auto3D.exceptions import InputValidationError
+        smi = tmp_path / "noid.smi"
+        smi.write_text("CCO\n")
+        args = Auto3DOptions(str(smi), k=1, enumerate_isomer=True, use_gpu=False)
+        with pytest.raises(InputValidationError):
+            check_smi_format(args)
 
 
 class TestCheckSdfFormat:
@@ -249,6 +271,17 @@ class TestCheckValidConfiguration:
             optimizing_engine="INVALID",
         )
         assert any("optimizing_engine" in e.lower() for e in errors)
+
+    def test_accepts_aimnet_registry_names(self):
+        """Registry engine names must validate, matching model_factory/CLI schema."""
+        for name in ("aimnet2", "aimnet2-2025", "aimnet2-nse", "aimnet2-pd"):
+            errors = check_valid_configuration(
+                path=path_example_smi,
+                k=1,
+                use_gpu=False,
+                optimizing_engine=name,
+            )
+            assert not any("optimizing_engine" in e.lower() for e in errors), (name, errors)
 
     def test_invalid_isomer_engine(self):
         """Test that invalid isomer_engine returns error."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -113,6 +113,7 @@ class TestCheckInputExceptions:
 
     def test_only_aimnet_molecules_with_ani2x_raises_configuration_error(self, tmp_path):
         """Should raise ConfigurationError when molecules require AIMNET but ANI2x selected."""
+        pytest.importorskip("torchani")  # ANI2x dependency check fires before element check
         # Create a SMILES file with a charged molecule (requires AIMNET)
         smi_file = tmp_path / "charged.smi"
         smi_file.write_text("[NH4+] ammonium\n")

--- a/tests/test_validation_errors.py
+++ b/tests/test_validation_errors.py
@@ -1,7 +1,9 @@
 """Tests for validation error handling in Auto3D.utils.validation module.
 
-These tests verify that validation functions raise ValueError (not AssertionError)
-for invalid input data, ensuring reliable validation even with Python's -O flag.
+These tests verify that validation functions raise real exceptions (not
+AssertionError) for invalid input data, ensuring reliable validation even with
+Python's -O flag. The .smi reader raises the structured InputValidationError so
+the CLI's `except Auto3DError` path produces an actionable hint.
 """
 import tempfile
 from pathlib import Path
@@ -10,14 +12,15 @@ from unittest.mock import MagicMock
 import pytest
 from rdkit import Chem
 
-from Auto3D.utils.validation import check_smi_format, check_sdf_format
+from Auto3D.exceptions import InputValidationError
+from Auto3D.utils.validation import check_sdf_format, check_smi_format
 
 
 class TestCheckSmiFormatErrors:
     """Tests for error handling in check_smi_format function."""
 
-    def test_missing_id_raises_value_error(self):
-        """Missing ID (single token per line) should raise ValueError, not AssertionError."""
+    def test_missing_id_raises_input_validation_error(self):
+        """Missing ID (single token per line) should raise InputValidationError."""
         # Create file with only SMILES, no ID
         content = "CCO\n"  # Only SMILES, no ID
 
@@ -29,14 +32,14 @@ class TestCheckSmiFormatErrors:
             args.path = f.name
             args.enumerate_isomer = False
 
-            # Should raise ValueError (not AssertionError)
-            with pytest.raises(ValueError):
+            # Should raise the structured InputValidationError (not AssertionError)
+            with pytest.raises(InputValidationError):
                 check_smi_format(args)
 
         Path(f.name).unlink()
 
-    def test_only_whitespace_id_raises_value_error(self):
-        """Line with only whitespace after SMILES should raise ValueError."""
+    def test_only_whitespace_id_raises_input_validation_error(self):
+        """Line with only whitespace after SMILES should raise InputValidationError."""
         content = "CCO   \n"  # SMILES with trailing whitespace only, no ID
 
         with tempfile.NamedTemporaryFile(mode='w', suffix='.smi', delete=False) as f:
@@ -47,8 +50,8 @@ class TestCheckSmiFormatErrors:
             args.path = f.name
             args.enumerate_isomer = False
 
-            # Should raise ValueError for missing ID (unpacking fails)
-            with pytest.raises(ValueError):
+            # split() drops the trailing whitespace, leaving a single token (no ID)
+            with pytest.raises(InputValidationError):
                 check_smi_format(args)
 
         Path(f.name).unlink()
@@ -92,7 +95,12 @@ class TestCheckSmiFormatErrors:
         Path(f.name).unlink()
 
     def test_multiple_tokens_accepted(self):
-        """Lines with extra tokens after SMILES and ID should be accepted."""
+        """Lines with extra tokens after SMILES and ID should be accepted.
+
+        The chunk loader reads only the first two whitespace columns
+        (usecols=[0, 1]), so validation must tolerate trailing columns rather
+        than crash on 'too many values to unpack'.
+        """
         content = "CCO ethanol extra_info more_data\n"
 
         with tempfile.NamedTemporaryFile(mode='w', suffix='.smi', delete=False) as f:
@@ -103,10 +111,10 @@ class TestCheckSmiFormatErrors:
             args.path = f.name
             args.enumerate_isomer = False
 
-            # Should raise ValueError (too many values to unpack with current impl)
-            # This verifies the strict 2-token format is enforced
-            with pytest.raises(ValueError):
-                check_smi_format(args)
+            # Should NOT raise: only the first two columns (SMILES, ID) are used.
+            ani, only_aimnet = check_smi_format(args)
+            assert isinstance(ani, bool)
+            assert isinstance(only_aimnet, list)
 
         Path(f.name).unlink()
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -2,9 +2,8 @@
 """Tests for workflow orchestration, including multi-GPU handling."""
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -17,8 +16,8 @@ class TestWorkflowExceptions:
 
     def test_validate_input_missing_path_raises_configuration_error(self, tmp_path):
         """Should raise ConfigurationError when path is None."""
-        from Auto3D.workflow import WorkflowOrchestrator
         from Auto3D.config import Auto3DOptions
+        from Auto3D.workflow import WorkflowOrchestrator
 
         config = Auto3DOptions(
             path=None,  # Missing path
@@ -32,8 +31,8 @@ class TestWorkflowExceptions:
 
     def test_validate_input_unsupported_format_raises_file_format_error(self, tmp_path):
         """Should raise FileFormatError for unsupported input format."""
-        from Auto3D.workflow import WorkflowOrchestrator
         from Auto3D.config import Auto3DOptions
+        from Auto3D.workflow import WorkflowOrchestrator
 
         # Create a test file with unsupported extension
         unsupported_file = tmp_path / "test.xyz"
@@ -57,8 +56,8 @@ class TestWorkflowExceptions:
 
     def test_validate_input_missing_k_and_window_raises_configuration_error(self, tmp_path):
         """Should raise ConfigurationError when neither k nor window specified."""
-        from Auto3D.workflow import WorkflowOrchestrator
         from Auto3D.config import Auto3DOptions
+        from Auto3D.workflow import WorkflowOrchestrator
 
         # Create a valid .smi file
         smi_file = tmp_path / "test.smi"
@@ -82,8 +81,8 @@ class TestWorkflowExceptions:
 
     def test_finalize_output_no_structures_raises_optimization_error(self, tmp_path):
         """Should raise OptimizationError when no 3D structures converged."""
-        from Auto3D.workflow import WorkflowOrchestrator
         from Auto3D.config import Auto3DOptions
+        from Auto3D.workflow import WorkflowOrchestrator
 
         config = Auto3DOptions(
             path=str(tmp_path / "test.smi"),
@@ -112,9 +111,10 @@ class TestChunkCreation:
         This tests the fix for issue #86 where multi-GPU with fewer molecules
         than GPUs caused OSError due to empty SDF files.
         """
+        from pathlib import Path
+
         from Auto3D.chunk_manager import ChunkManager
         from Auto3D.config import Auto3DOptions
-        from pathlib import Path
 
         # Create a minimal config - we won't run the full pipeline
         config = Auto3DOptions(
@@ -152,9 +152,10 @@ class TestChunkCreation:
 
     def test_all_chunks_with_data(self, tmp_path):
         """All chunks with data should be created."""
+        from pathlib import Path
+
         from Auto3D.chunk_manager import ChunkManager
         from Auto3D.config import Auto3DOptions
-        from pathlib import Path
 
         config = Auto3DOptions(
             path=str(tmp_path / "test.smi"),
@@ -193,6 +194,7 @@ class TestIsomerWrapperFailure:
     def test_isomer_wrapper_emits_sentinels_on_failure(self, monkeypatch):
         """If isomer generation raises, every optimizer must still get a 'Done' sentinel."""
         import multiprocessing as mp
+
         from Auto3D.auto3D import isomer_wrapper
         from Auto3D.config import Auto3DOptions
 
@@ -217,9 +219,11 @@ class TestOptimizerEmptyInput:
 
     def test_optimizer_handles_missing_file(self, tmp_path, caplog):
         """Optimizer should gracefully handle missing input files."""
-        from Auto3D.batch_opt.batchopt import optimizing
         import logging
+
         import torch
+
+        from Auto3D.batch_opt.batchopt import optimizing
 
         device = torch.device("cpu")
         config = {
@@ -240,9 +244,11 @@ class TestOptimizerEmptyInput:
 
     def test_optimizer_handles_empty_file(self, tmp_path, caplog):
         """Optimizer should gracefully handle empty input files."""
-        from Auto3D.batch_opt.batchopt import optimizing
         import logging
+
         import torch
+
+        from Auto3D.batch_opt.batchopt import optimizing
 
         device = torch.device("cpu")
         config = {
@@ -266,21 +272,121 @@ class TestOptimizerEmptyInput:
 
 
 def test_workers_importable_from_workflow_workers():
-    from Auto3D.workflow_workers import isomer_wrapper, optim_rank_wrapper, logger_process
+    from Auto3D.workflow_workers import isomer_wrapper, logger_process, optim_rank_wrapper
     assert all(callable(f) for f in (isomer_wrapper, optim_rank_wrapper, logger_process))
+
+
+def test_optim_rank_wrapper_isolates_failing_chunks(tmp_path, monkeypatch):
+    """A chunk that raises must not kill the worker or drop chunks queued behind it.
+
+    Previously the optimizer worker's consume loop had no per-chunk exception
+    handling, so one bad chunk (a molecule the optimizer chokes on, a CUDA OOM,
+    an mkdir collision, or an empty isomer SDF) killed the whole process and
+    silently dropped every remaining chunk -- with the parent still reporting
+    success on the partial output. Now each chunk is isolated.
+    """
+    import queue as queue_mod
+
+    from Auto3D import workflow_workers as ww
+    from Auto3D.config import Auto3DOptions
+
+    attempted = []
+
+    class _BoomOptimizing:
+        def __init__(self, in_f, out_f, engine, device, config):
+            self._enumerated = in_f
+
+        def run(self):
+            attempted.append(self._enumerated)
+            raise RuntimeError("optimizer blew up on this chunk")
+
+    # Replace the heavy optimizing class (which would build a real model) with
+    # one that always raises, so we exercise only the loop's failure isolation.
+    monkeypatch.setattr(ww, "optimizing", _BoomOptimizing)
+
+    q: queue_mod.Queue = queue_mod.Queue()
+    d1 = tmp_path / "job1"
+    d1.mkdir()
+    d2 = tmp_path / "job2"
+    d2.mkdir()
+    q.put(("enum1.sdf", str(tmp_path / "c1.smi"), str(d1), 1))
+    q.put(("enum2.sdf", str(tmp_path / "c2.smi"), str(d2), 2))
+    q.put("Done")
+    logq: queue_mod.Queue = queue_mod.Queue()
+
+    args = Auto3DOptions(path="x.smi", k=1, use_gpu=False)
+
+    # Must return normally (not propagate the RuntimeError) ...
+    result = ww.optim_rank_wrapper(args, q, logq, gpu_idx=0)
+    # ... and BOTH chunks must have been attempted: the loop continued past the
+    # first chunk's failure instead of dying on it.
+    assert attempted == ["enum1.sdf", "enum2.sdf"]
+    assert result == []  # neither failing chunk produced conformers
+
+
+def test_unsupported_extension_rejected_before_encoding(tmp_path):
+    """Bad extensions must be rejected before encode_ids writes a temp file.
+
+    Validating the suffix after encoding raised a generic ValueError from
+    encode_ids and left an orphaned *_encoded file on disk.
+    """
+    from Auto3D.config import Auto3DOptions
+    from Auto3D.workflow import WorkflowOrchestrator
+
+    bad = tmp_path / "mol.xyz"
+    bad.write_text("stuff\n")
+    orch = WorkflowOrchestrator(Auto3DOptions(path=str(bad), k=1))
+
+    with patch("Auto3D.workflow.encode_ids") as enc:
+        with pytest.raises(FileFormatError, match="not supported"):
+            orch._validate_input()
+        enc.assert_not_called()  # format is validated before any encoding
+
+    assert not list(tmp_path.glob("*_encoded*"))
+
+
+def test_encoded_input_cleaned_up_when_setup_fails(tmp_path, monkeypatch):
+    """The encoded temp file must be removed even when a setup phase fails.
+
+    encode_ids writes a *_encoded file during phase-1 setup. That setup now runs
+    inside run()'s try/finally, so a failure in a later setup step (job-dir
+    creation, logging start) no longer leaks the encoded file beside the input.
+    """
+    from Auto3D.config import Auto3DOptions
+    from Auto3D.workflow import WorkflowOrchestrator
+
+    smi = tmp_path / "mol.smi"
+    smi.write_text("CCO ethanol\n")
+    orch = WorkflowOrchestrator(Auto3DOptions(path=str(smi), k=1))
+
+    # Fail after _validate_input has already written the encoded temp file.
+    monkeypatch.setattr(
+        orch, "_setup_logging", MagicMock(side_effect=RuntimeError("boom"))
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        orch.run()
+
+    # The encoded temp file written during _validate_input must be gone, and no
+    # *_encoded file may be left orphaned next to the input.
+    assert orch.input_path != Path()
+    assert not orch.input_path.exists()
+    assert not list(tmp_path.glob("*_encoded*"))
 
 
 def test_finalize_raises_when_all_outputs_empty(tmp_path):
     import pytest
+
     from Auto3D.config import Auto3DOptions
-    from Auto3D.workflow import WorkflowOrchestrator
     from Auto3D.exceptions import OptimizationError
+    from Auto3D.workflow import WorkflowOrchestrator
 
     orch = WorkflowOrchestrator(Auto3DOptions(path="x.smi", k=1))
     orch.job_dir = tmp_path
     orch.input_path = tmp_path / "x_encoded.smi"
     orch.input_path.write_text("CCO 0\n")
-    job = tmp_path / "job1"; job.mkdir()
+    job = tmp_path / "job1"
+    job.mkdir()
     (job / "x_3d.sdf").write_text("")  # converged nothing -> empty SDF
     orch.id_mapping = {"a": 0}
 


### PR DESCRIPTION
## Summary

Two-phase hardening pass over the Auto3D pipeline. Every change is a bug fix, robustness guard, or non-destructive perf improvement; no functional API changes. Each fix ships a regression test that fails without it.

### Phase 1 — per-module audit (8 commits)
- **Optimizer core:** guard FIRE against float32 force-norm underflow (was injecting inf/NaN); report `fmax` at the final geometry instead of one FIRE step stale.
- **Orchestration:** isolate each optimizer chunk so one bad chunk no longer kills the worker and silently drops all remaining chunks; stop leaking the encoded temp file when a setup phase fails; reject unsupported extensions before encoding.
- **Config/validation:** declare `input_format` as a real `Auto3DOptions` field (survives `dataclasses.replace()`); tolerate ragged `.smi` rows; accept aimnet registry engine names.
- **Isomer/embedding:** make parallel embedding robust (broaden the per-worker except so RDKit `ArgumentError` no longer aborts the batch) and deterministic (submission order); guard the serial path against unparseable SMILES.
- **Stereochemistry:** stop SMILES string-surgery from corrupting non-tetrahedral centers (`@SP`/`@TH`/`@OH`/`@TB`) into invalid SMILES that aborted enumeration; tolerate differing stereo-marker counts.
- **Logging:** route library logging to stderr so `auto3d run --json` stdout stays clean, parseable JSON.
- **CLI/tautomer:** resolve `aimnet2` in `models info`; reject `tauto_k < 1` (silently dropped all tautomers); add a not-found guard to `config validate`.
- **torch_config/ASE:** make deterministic mode reversible and non-fatal (`warn_only=True`); guard the post-optimization ASE geometry re-read against `None`/missing-`E_tot` records.

### Phase 2 — deferred-gaps remediation (8 commits)
- **Decouple the test suite from the optional `torchani` extra:** lazy import in `ANI2xt_no_rep` so `Auto3D.ASE.thermo` (and the pure-Python thermo helpers) import without torchani; `pytest.importorskip` on the genuinely-ANI tests. The suite now runs clean without the extra (previously 11 failures + 1 collection abort).
- **TF32 precision:** pin via the modern `fp32_precision` API on torch ≥2.9 (legacy `allow_tf32` is deprecated), guarded by `hasattr`.
- **O(n²) → O(n) RMSD dedup:** strip Hs once per conformer instead of per comparison, in both `filtering.py` and `chemistry.py`. Non-destructive — returned conformers keep explicit hydrogens and exact H coordinates (verified independently and asserted in tests, since the MLIP and final geometries need explicit H).
- **Concurrency:** per-file guard on the omega/flipper temp-file sweep in `housekeeping`.
- **Docs:** clarify ANI2xt float32 energy precision (self-energies cancel across conformers, so ranking is unaffected).

Implementation plan: `docs/superpowers/plans/2026-06-11-hardening-gaps-remediation.md`.

## Test Plan
- [ ] `pytest tests/ -q` → 623 passed, 8 skipped (the ANI/torchani tests skip gracefully when the optional `ani` extra is absent), 0 failed, 0 errors.
- [ ] `ruff check src/Auto3D/` — no new lint introduced by these changes.
- [ ] With the `ani` extra installed, the 8 skipped tests run and pass (ANI2xt construction/validation paths).