### PR TITLE
docs: refresh for v3.5 (remove deleted ensemble, fix version floors, document aimnet/extras/registry models)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: "2"
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.11"
 
 python:
   install:

--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -54,8 +54,8 @@ Quick Settings Reference
    # Balanced (default)
    auto3d run input.smi --k=1 --engine=AIMNET --gpu
 
-   # High accuracy (for final production runs)
-   AUTO3D_USE_ENSEMBLE=1 auto3d run input.smi --k=1 --engine=AIMNET --gpu
+   # Specialized chemistry (pick a different registry model)
+   auto3d run input.smi --k=1 --engine=aimnet2-nse --gpu
 
 Configuration Presets
 ~~~~~~~~~~~~~~~~~~~~~
@@ -219,9 +219,6 @@ Control Auto3D behavior via environment variables:
    # Enable torch.compile for ANI models
    export AUTO3D_COMPILE_MODEL=1
 
-   # Use AIMNET ensemble (slower, highest accuracy)
-   export AUTO3D_USE_ENSEMBLE=1
-
    # Set OpenEye license path
    export OE_LICENSE=/path/to/oe_license.txt
 
@@ -238,9 +235,9 @@ Control Auto3D behavior via environment variables:
    * - ``AUTO3D_COMPILE_MODEL``
      - ``0``
      - Enable torch.compile() for ANI models
-   * - ``AUTO3D_USE_ENSEMBLE``
-     - ``0``
-     - Use AIMNET 8-model ensemble
+   * - ``AIMNET_CACHE_DIR``
+     - ``~/.cache/aimnet``
+     - Override cache directory for auto-downloaded AIMNet2 models
    * - ``OE_LICENSE``
      - (none)
      - OpenEye license for Omega isomer engine
@@ -494,10 +491,22 @@ Available Models
      - Supported Elements
      - Charges
      - Speed
-   * - ``AIMNET``
+   * - ``AIMNET`` (= ``aimnet2``)
      - H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I
      - Neutral + charged
      - Fast (default)
+   * - ``aimnet2-2025``
+     - H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I
+     - Neutral + charged
+     - Updated AIMNet2 release
+   * - ``aimnet2-nse``
+     - H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I
+     - Neutral + charged
+     - Open-shell / radical chemistry
+   * - ``aimnet2-pd``
+     - AIMNet2 elements + Pd
+     - Neutral + charged
+     - Palladium-containing systems
    * - ``ANI2x``
      - H, C, N, O, F, S, Cl
      - Neutral only
@@ -507,21 +516,28 @@ Available Models
      - Neutral only
      - Ultra-fast
 
-Single Model vs Ensemble (AIMNET)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Choosing an AIMNet2 Registry Model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Auto3D uses a single AIMNet2 model for ~35x faster optimization:
+Auto3D always uses a single AIMNet2 model (served by the ``aimnet`` package)
+for fast optimization; there is no multi-model ensemble. The default
+``AIMNET`` engine resolves to ``aimnet2``, and that single model is accurate
+enough for conformer generation and ranking. For specialized chemistry, select
+a different registry model, which is auto-downloaded on first use:
 
 .. code:: console
 
-   # Default: single model (fast)
+   # Default: aimnet2
    auto3d run input.smi --k=1 --gpu
 
-   # Ensemble: highest accuracy (slower)
-   AUTO3D_USE_ENSEMBLE=1 auto3d run input.smi --k=1 --gpu
+   # Updated AIMNet2 release
+   auto3d run input.smi --k=1 --engine=aimnet2-2025 --gpu
 
-The single model is accurate enough for conformer generation and ranking.
-Use ensemble only when you need the most accurate absolute energies.
+   # Open-shell / radical chemistry
+   auto3d run input.smi --k=1 --engine=aimnet2-nse --gpu
+
+   # Palladium-containing systems
+   auto3d run input.smi --k=1 --engine=aimnet2-pd --gpu
 
 Model Factory API (Python)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -564,8 +580,12 @@ If you encounter CUDA out-of-memory errors:
    EOF
    auto3d run input.smi --k=1 -c low_memory.yaml --gpu
 
-   # 2. Disable ensemble
-   AUTO3D_USE_ENSEMBLE=0 auto3d run input.smi --k=1 --gpu
+   # 2. Process fewer molecules per GB of RAM
+   cat > low_memory.yaml << EOF
+   batchsize_atoms: 512
+   capacity: 20
+   EOF
+   auto3d run input.smi --k=1 -c low_memory.yaml --gpu
 
    # 3. Use CPU as fallback
    auto3d run input.smi --k=1 --no-gpu

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -85,7 +85,7 @@ Run conformer generation on input molecules.
      - Energy window in kcal/mol (alternative to ``--k``)
    * - ``--engine``
      - AIMNET
-     - Optimization engine: ``AIMNET``, ``ANI2x``, ``ANI2xt``
+     - Optimization engine: ``AIMNET`` (= ``aimnet2``), any aimnet registry name (``aimnet2-2025``, ``aimnet2-nse``, ``aimnet2-pd``, ...), ``ANI2x``, ``ANI2xt``, or a path to a custom model
    * - ``--gpu`` / ``--no-gpu``
      - --no-gpu
      - Enable/disable GPU acceleration
@@ -120,6 +120,12 @@ Run conformer generation on input molecules.
 
    # Use ANI2x engine
    auto3d run molecules.smi --k=1 --engine=ANI2x
+
+   # Use a specialized AIMNet2 registry model (auto-downloaded on first use)
+   auto3d run molecules.smi --k=1 --engine=aimnet2-nse
+
+   # Use a custom NNP by file path
+   auto3d run molecules.smi --k=1 --engine=/path/to/my_model.pt
 
    # JSON output for scripting
    auto3d run molecules.smi --k=1 --json
@@ -409,8 +415,8 @@ Environment Variables
      - Description
    * - ``AUTO3D_COMPILE_MODEL``
      - Set to ``1`` to enable torch.compile() for ANI models
-   * - ``AUTO3D_USE_ENSEMBLE``
-     - Set to ``1`` to use AIMNET 8-model ensemble (slower, more accurate)
+   * - ``AIMNET_CACHE_DIR``
+     - Override the cache directory for auto-downloaded AIMNet2 models (default ``~/.cache/aimnet``)
    * - ``OE_LICENSE``
      - Path to OpenEye license file (for Omega isomer engine)
    * - ``CUDA_VISIBLE_DEVICES``

--- a/docs/source/howto/drug_discovery.rst
+++ b/docs/source/howto/drug_discovery.rst
@@ -585,6 +585,14 @@ Best Practices
 
       auto3d run hits.smi --k=10 --engine=AIMNET --gpu
 
+   For specialized chemistry, select a different AIMNet2 registry model:
+   ``aimnet2-nse`` for open-shell / radical species, or ``aimnet2-pd`` for
+   palladium-containing compounds (auto-downloaded on first use).
+
+   .. code:: console
+
+      auto3d run radicals.smi --k=10 --engine=aimnet2-nse --gpu
+
 3. **Consider tautomers**: Enable for drug-like molecules with N-H or O-H groups
 
    .. code:: console

--- a/docs/source/howto/hpc.rst
+++ b/docs/source/howto/hpc.rst
@@ -95,12 +95,13 @@ For limited GPU memory:
        use_gpu=True,
    )
 
-Or use single model instead of ensemble:
+If memory is still tight, also lower ``capacity`` so fewer molecules are held
+per GB of RAM:
 
 .. code:: console
 
-   export AUTO3D_USE_ENSEMBLE=0
-   auto3d run input.smi --k=1 --gpu
+   auto3d run input.smi --k=1 --gpu -c low_memory.yaml
+   # low_memory.yaml: batchsize_atoms: 512  /  capacity: 20
 
 Chunked Processing
 ~~~~~~~~~~~~~~~~~~
@@ -244,17 +245,23 @@ From fastest to slowest:
 
 1. **ANI2xt**: Ultra-fast, good for screening
 2. **ANI2x**: Very fast, well-validated
-3. **AIMNET single**: Fast, most versatile (default)
-4. **AIMNET ensemble**: Slower, highest accuracy
+3. **AIMNET**: Fast, most versatile (default, resolves to ``aimnet2``)
+
+Auto3D always uses a single AIMNet2 model (there is no ensemble). For
+specialized chemistry, select a different registry model instead of the
+default ``aimnet2`` (auto-downloaded on first use):
 
 .. code:: console
 
    # Fastest for screening
    auto3d run input.smi --k=1 --gpu --engine=ANI2xt
 
-   # Best accuracy
-   export AUTO3D_USE_ENSEMBLE=1
+   # Default AIMNet2
    auto3d run input.smi --k=1 --gpu --engine=AIMNET
+
+   # Specialized registry models (radicals / Pd, etc.)
+   auto3d run input.smi --k=1 --gpu --engine=aimnet2-nse
+   auto3d run input.smi --k=1 --gpu --engine=aimnet2-pd
 
 Optimal Batch Sizes
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/source/howto/quickstart.rst
+++ b/docs/source/howto/quickstart.rst
@@ -172,6 +172,14 @@ Specify with ``--engine``:
 
    auto3d run molecules.smi --k=1 --engine=ANI2x
 
+.. note::
+   The ANI engines (``ANI2x``, ``ANI2xt``) require the ``ani`` extra:
+   ``pip install "Auto3D[ani]"``.
+
+   Beyond the default ``aimnet2``, additional AIMNet2 registry models exist
+   (e.g. ``aimnet2-2025``, ``aimnet2-nse``, ``aimnet2-pd``) for specialized
+   chemistry. Run ``auto3d models list`` to see what's available.
+
 Configuration Files
 -------------------
 

--- a/docs/source/howto/troubleshooting.rst
+++ b/docs/source/howto/troubleshooting.rst
@@ -50,7 +50,7 @@ Installation Issues
       # With CUDA
       pip install torch --index-url https://download.pytorch.org/whl/cu118
 
-2. Check version compatibility (requires PyTorch >= 2.1.0):
+2. Check version compatibility (requires PyTorch >= 2.8):
 
    .. code:: python
 
@@ -96,12 +96,16 @@ CUDA Out of Memory
           batchsize_atoms=512,  # Reduce from default 1024
       )
 
-2. Use single model instead of ensemble:
+2. Reduce ``batchsize_atoms`` and ``capacity``:
 
-   .. code:: console
+   .. code:: python
 
-      export AUTO3D_USE_ENSEMBLE=0
-      auto3d run input.smi --k=1 --gpu
+      config = Auto3DOptions(
+          path="input.smi",
+          k=1,
+          batchsize_atoms=512,  # Smaller optimization batches
+          capacity=20,          # Fewer molecules per GB
+      )
 
 3. Process smaller chunks:
 
@@ -638,7 +642,7 @@ Common Error Messages
    * - ``RuntimeError: CUDA out of memory``
      - Reduce ``batchsize_atoms`` or use CPU
    * - ``ModuleNotFoundError: No module named 'torchani'``
-     - Install TorchANI: ``conda install -c conda-forge torchani``
+     - Install the ANI extra: ``pip install "Auto3D[ani]"`` (or ``conda install -c conda-forge torchani``)
    * - ``FileNotFoundError: input.smi``
      - Check file path exists
    * - ``KeyError: 'E_tot'``

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,12 @@ Welcome to Auto3D's documentation!
 ==================================
 
 .. note::
-   **AIMNet2 clarification**: The default model in Auto3D is AIMNet2 since version 2.2.1. If you specify ``optimizing_engine="AIMNET"``, it uses AIMNet2. The old AIMNet model has been deprecated since Auto3D 2.2.1.
+   **AIMNet2 default**: The default optimization engine is AIMNet2, served by
+   the ``aimnet`` package (a core dependency installed automatically with
+   Auto3D). Specifying ``optimizing_engine="AIMNET"`` resolves to the
+   ``aimnet2`` registry model; other registry models (``aimnet2-2025``,
+   ``aimnet2-nse``, ``aimnet2-pd``, ...) are available for specialized
+   chemistry and download automatically on first use.
 
 **Auto3D**
 ==========

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,11 +4,15 @@ Installation
 Minimum Dependencies Installation
 ---------------------------------
 
-1. Python >= 3.10
+1. Python >= 3.11
 2. `RDKit <https://www.rdkit.org/docs/Install.html>`__ >= 2022.03.1 (for
    the isomer engine)
-3. `PyTorch <https://pytorch.org/get-started/locally/>`__ >= 2.1.0 (for
+3. `PyTorch <https://pytorch.org/get-started/locally/>`__ >= 2.8 (for
    the optimization engine)
+
+The `aimnet <https://github.com/isayevlab/aimnet2>`__ package is a **core
+dependency** and is installed automatically with Auto3D. It serves the AIMNet2
+neural network potential (the default optimization engine).
 
 If you have an environment with the above dependencies, Auto3D can be
 installed by
@@ -37,15 +41,39 @@ Optional Dependencies Installation
 ----------------------------------
 
 By installing Auto3D with the above minimum dependencies, you can use
-Auto3D with RDKit and `AIMNet2 <https://github.com/isayevlab/AIMNet2>`__ as the
-isomer engine and optimization engine, respectively. Two additional
-optimization engines are available: ANI-2x and ANI-2xt, which can be
-installed by:
+Auto3D with RDKit and `AIMNet2 <https://github.com/isayevlab/aimnet2>`__ as the
+isomer engine and optimization engine, respectively. Auto3D ships several
+optional extras that can be installed alongside the base package.
+
+Two additional optimization engines are available: ANI-2x and ANI-2xt. They
+require `TorchANI <https://github.com/aiqm/torchani>`__, which is installed via
+the ``ani`` extra:
 
 .. code:: console
 
+   # Install the ANI engines (TorchANI)
+   pip install "Auto3D[ani]"
+
+   # Or via conda
    conda activate auto3D
    conda install -c conda-forge torchani
+
+To calculate thermodynamic properties (such as Gibbs free energy,
+enthalpy, entropy, geometry optimization) with Auto3D,
+`ASE <https://wiki.fysik.dtu.dk/ase/>`__ is needed. Install it via the
+``ase`` extra:
+
+.. code:: console
+
+   # Install ASE support
+   pip install "Auto3D[ase]"
+
+   # Or via conda
+   conda activate auto3D
+   conda install -c conda-forge ase
+
+Extras can be combined, e.g. ``pip install "Auto3D[ani,ase]"``. The ``all``
+extra installs every optional dependency.
 
 One additional isomer engine is available: OpenEye toolkit. It's a
 commercial software from `OpenEye
@@ -56,11 +84,11 @@ Software <https://www.eyesopen.com/omega>`__. It can be installed by
    conda activate auto3D
    conda install -c openeye openeye-toolkits
 
-To calculate thermodynamic properties (such as Gibbs free energy,
-enthalpy, entropy, geometry optimization) with Auto3D,
-`ASE <https://wiki.fysik.dtu.dk/ase/>`__ needs to be installed:
+AIMNet2 Model Downloads
+-----------------------
 
-.. code:: console
-
-   conda activate auto3D
-   conda install -c conda-forge ase
+AIMNet2 registry models (``aimnet2``, ``aimnet2-2025``, ``aimnet2-nse``,
+``aimnet2-pd``, ...) are **downloaded automatically on first use** and cached
+under ``~/.cache/aimnet``. Set the ``AIMNET_CACHE_DIR`` environment variable to
+override the cache location. An internet connection is required the first time
+each model is used.

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -9,7 +9,9 @@ Breaking Changes
 Python Version
 ~~~~~~~~~~~~~~
 
-Auto3D v3.0 requires **Python 3.10 or later**. If you're using an older Python version, you'll need to upgrade your environment.
+Auto3D v3.0 requires **Python 3.10 or later**. As of Auto3D 3.5, the minimum
+supported Python is **3.11** (and PyTorch **>= 2.8**); upgrade your environment
+accordingly.
 
 API Changes
 ~~~~~~~~~~~
@@ -172,8 +174,14 @@ New API for creating models directly:
    # Create a model for custom workflows
    model = create_model("AIMNET", device="cuda:0")
 
-   # Use ensemble for higher accuracy (slower)
-   model = create_model("AIMNET", device="cuda:0", use_ensemble=True)
+   # Select a specialized AIMNet2 registry model (auto-downloaded on first use)
+   model = create_model("aimnet2-nse", device="cuda:0")
+
+.. note::
+   The 8-model AIMNet2 ensemble was **removed**. ``use_ensemble=True`` (and the
+   ``AUTO3D_USE_ENSEMBLE=1`` environment variable) is now a **no-op** that emits
+   a ``UserWarning`` and falls back to a single registry model. (This is
+   unrelated to ANI-2x, which is itself internally an 8-model ensemble.)
 
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
@@ -181,12 +189,16 @@ Environment variables
 New environment variables for runtime configuration:
 
 - ``AUTO3D_COMPILE_MODEL=1`` - Enable torch.compile for ANI models (~1.25x speedup)
-- ``AUTO3D_USE_ENSEMBLE=1`` - Use ensemble model for AIMNet (higher accuracy)
+- ``AIMNET_CACHE_DIR`` - Override the cache directory for auto-downloaded AIMNet2 models (default ``~/.cache/aimnet``)
+
+.. note::
+   ``AUTO3D_USE_ENSEMBLE=1`` was removed in Auto3D 3.5. It is now a no-op that
+   emits a ``UserWarning``; a single AIMNet2 registry model is always used.
 
 Migration Checklist
 -------------------
 
-1. ☐ Update Python to 3.10+
+1. ☐ Update Python to 3.10+ (3.11+ for Auto3D 3.5) and PyTorch to 2.8+
 2. ☐ Replace ``from Auto3D.auto3D import options`` with ``from Auto3D import Auto3DOptions``
 3. ☐ Replace ``options(path, ...)`` calls with ``Auto3DOptions(path=path, ...)``
 4. ☐ Update CLI scripts to use ``auto3d run`` syntax

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -66,10 +66,14 @@ Auto3D supports three neural network potentials:
      - Use Case
      - Speed
      - Supported Elements
-   * - ``AIMNET``
+   * - ``AIMNET`` (= ``aimnet2``)
      - General use, charged molecules (default)
      - Fast
      - H, B, C, N, O, F, Si, P, S, Cl, As, Se, Br, I
+   * - ``aimnet2-nse`` / ``aimnet2-pd`` / ``aimnet2-2025``
+     - Specialized chemistry (radicals, Pd, updated release)
+     - Fast
+     - AIMNet2 elements (plus Pd for ``aimnet2-pd``)
    * - ``ANI2x``
      - Organic molecules
      - Very fast
@@ -78,6 +82,14 @@ Auto3D supports three neural network potentials:
      - Ultra-fast screening, tautomers
      - Ultra fast
      - H, C, N, O, F, S, Cl
+
+In addition to the default ``aimnet2``, the ``--engine`` flag accepts any
+aimnet registry model name (``aimnet2-2025``, ``aimnet2-nse``, ``aimnet2-pd``,
+...) or a path to a custom NNP model file.
+
+.. note::
+   AIMNet2 registry models are downloaded automatically on first use and
+   cached under ``~/.cache/aimnet`` (override with ``AIMNET_CACHE_DIR``).
 
 Select a model with ``--engine``:
 
@@ -145,7 +157,7 @@ Example ``config.yaml``:
    # window: 3.0               # Alternative: energy window in kcal/mol
 
    # Neural network model
-   optimizing_engine: AIMNET   # AIMNET, ANI2x, or ANI2xt
+   optimizing_engine: AIMNET   # AIMNET / aimnet registry name / ANI2x / ANI2xt / path to custom model
 
    # GPU settings
    use_gpu: true
@@ -336,7 +348,7 @@ Configuration Options
            # window=3.0,                 # Or energy window (kcal/mol)
 
            # Neural network model
-           optimizing_engine="AIMNET",   # AIMNET, ANI2x, ANI2xt
+           optimizing_engine="AIMNET",   # AIMNET / aimnet registry name / ANI2x / ANI2xt / custom model path
 
            # GPU settings
            use_gpu=True,
@@ -404,7 +416,7 @@ syntax, Python uses ``param_name`` in ``Auto3DOptions``.
      - Energy window in kcal/mol (*use ``k`` OR ``window``)
    * - ``optimizing_engine``
      - AIMNET
-     - Neural network: ``AIMNET``, ``ANI2x``, ``ANI2xt``, or path to custom model
+     - Neural network: ``AIMNET`` (= ``aimnet2``), any aimnet registry name (``aimnet2-2025``, ``aimnet2-nse``, ``aimnet2-pd``, ...), ``ANI2x``, ``ANI2xt``, or path to custom model
    * - ``use_gpu``
      - True
      - Enable GPU acceleration

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -23,6 +23,9 @@ mode_oe: 'classic'
 mpi_np: 4
 
 # Optimization settings
+# optimizing_engine accepts: AIMNET (= aimnet2), any aimnet registry name
+#   (aimnet2-2025, aimnet2-nse, aimnet2-pd, ...), ANI2x, ANI2xt,
+#   or a path to a custom NNP model file.
 optimizing_engine: 'AIMNET'
 use_gpu: True
 gpu_idx: [0]


### PR DESCRIPTION
Workstream W7 of the tech-debt roadmap. **Docs-only — no code change.**

The 8-model AIMNET ensemble was removed in 3.5 (`use_ensemble` / `AUTO3D_USE_ENSEMBLE` are now no-ops; there is no `--use-ensemble` flag), but the docs still presented it as a working "high accuracy" mode across five pages. This refresh:

- **Removes the deleted ensemble** from `advanced_usage`, `hpc`, `troubleshooting`, `cli`, `migration` (kept only as clearly-labeled "removed/no-op" notes in `migration.rst`). Replaces ensemble guidance with "a single registry model is used; pick `aimnet2-2025`/`-nse`/`-pd` for different chemistry".
- **Fixes version floors:** Python 3.10 → **3.11**, PyTorch 2.1.0 → **2.8**.
- **Documents** that `aimnet` is a core dependency serving AIMNet2, the `[ani]`/`[ase]` extras (`pip install "Auto3D[ani]"`), and first-use model auto-download to `~/.cache/aimnet` (`AIMNET_CACHE_DIR`).
- **Adds registry model names + custom-model-path** to the engine tables (`usage`, `cli`, `advanced_usage`, `quickstart`, `drug_discovery`) and `parameters.yaml`.

Left unchanged (already accurate): README, `api.rst`, `custom_nnp.rst`, `integrations.rst`, `citation.rst`, `docs/legacy-v2/**`.

## Test Plan
- [ ] `grep -rn "AUTO3D_USE_ENSEMBLE\|--use-ensemble" docs/source/` → only the two intentional "removed/no-op" notes in `migration.rst`.
- [ ] Read the Docs build (the existing docs workflow runs on this PR).

Independent of #93/#94 (docs vs code); merges cleanly alongside them.