### PR TITLE
tech-debt: v3.5 docs refresh, ANI2xt fp64 energies, optimizer benchmark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ We welcome:
 
 ### Prerequisites
 
-- Python 3.10 or later
+- Python 3.11 or later
 - Git
 - conda (recommended) or pip
 
@@ -198,6 +198,24 @@ def test_auto3d_options_validation():
 - Use small test molecules in `tests/files/`
 - Don't commit large data files
 - Use fixtures for common test data
+
+### Benchmarking
+
+`scripts/bench_optimizer.py` is an opt-in micro-benchmark for the geometry
+optimization hot loop (FIRE optimizer, batched model wrapper, bucketing). It
+lives outside `tests/`, so it never runs in the suite or gates CI. Use it to
+get a wall-clock and throughput signal before and after changes to
+`Auto3D.batch_opt`:
+
+```bash
+python scripts/bench_optimizer.py --engine AIMNET --n 200 --steps 200
+python scripts/bench_optimizer.py --engine ANI2xt --n 50 --device cuda:0
+```
+
+It builds a fixed set of drug-like conformers (RDKit ETKDG, fixed seed, so the
+geometries are identical run-to-run) and reports wall time, conformers/s, and
+peak memory. Compare the numbers from two runs of the same command on the same
+machine — it is a relative regression signal, not an absolute baseline.
 
 ## Documentation
 

--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -54,8 +54,8 @@ Quick Settings Reference
    # Balanced (default)
    auto3d run input.smi --k=1 --engine=AIMNET --gpu
 
-   # High accuracy (for final production runs)
-   AUTO3D_USE_ENSEMBLE=1 auto3d run input.smi --k=1 --engine=AIMNET --gpu
+   # A specific registry model (e.g. the 2025 refresh; see: auto3d models list)
+   auto3d run input.smi --k=1 --engine=aimnet2-2025 --gpu
 
 Configuration Presets
 ~~~~~~~~~~~~~~~~~~~~~
@@ -219,8 +219,8 @@ Control Auto3D behavior via environment variables:
    # Enable torch.compile for ANI models
    export AUTO3D_COMPILE_MODEL=1
 
-   # Use AIMNET ensemble (slower, highest accuracy)
-   export AUTO3D_USE_ENSEMBLE=1
+   # Override the AIMNet2 model download cache (default: ~/.cache/aimnet)
+   export AIMNET_CACHE_DIR=/path/to/aimnet/cache
 
    # Set OpenEye license path
    export OE_LICENSE=/path/to/oe_license.txt
@@ -238,9 +238,9 @@ Control Auto3D behavior via environment variables:
    * - ``AUTO3D_COMPILE_MODEL``
      - ``0``
      - Enable torch.compile() for ANI models
-   * - ``AUTO3D_USE_ENSEMBLE``
-     - ``0``
-     - Use AIMNET 8-model ensemble
+   * - ``AIMNET_CACHE_DIR``
+     - ``~/.cache/aimnet``
+     - Override the AIMNet2 model download cache location
    * - ``OE_LICENSE``
      - (none)
      - OpenEye license for Omega isomer engine
@@ -507,21 +507,24 @@ Available Models
      - Neutral only
      - Ultra-fast
 
-Single Model vs Ensemble (AIMNET)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Choosing an AIMNet2 Registry Model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, Auto3D uses a single AIMNet2 model for ~35x faster optimization:
+Auto3D always uses a single AIMNet2 model for ~35x faster optimization; the
+single model is accurate enough for conformer generation and ranking. Instead
+of an ensemble, choose a specific registry model when you need different
+chemistry coverage:
 
 .. code:: console
 
-   # Default: single model (fast)
+   # Default AIMNet2 model
    auto3d run input.smi --k=1 --gpu
 
-   # Ensemble: highest accuracy (slower)
-   AUTO3D_USE_ENSEMBLE=1 auto3d run input.smi --k=1 --gpu
+   # A specific registry model (auto-downloaded on first use)
+   auto3d run input.smi --k=1 --engine=aimnet2-2025 --gpu
 
-The single model is accurate enough for conformer generation and ranking.
-Use ensemble only when you need the most accurate absolute energies.
+Run ``auto3d models list`` to see the available registry models
+(``aimnet2``, ``aimnet2-2025``, ``aimnet2-nse``, ``aimnet2-pd``, ...).
 
 Model Factory API (Python)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -564,8 +567,8 @@ If you encounter CUDA out-of-memory errors:
    EOF
    auto3d run input.smi --k=1 -c low_memory.yaml --gpu
 
-   # 2. Disable ensemble
-   AUTO3D_USE_ENSEMBLE=0 auto3d run input.smi --k=1 --gpu
+   # 2. Use a lighter model (ANI2xt is the fastest, lowest memory)
+   auto3d run input.smi --k=1 --engine=ANI2xt --gpu
 
    # 3. Use CPU as fallback
    auto3d run input.smi --k=1 --no-gpu

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -85,7 +85,9 @@ Run conformer generation on input molecules.
      - Energy window in kcal/mol (alternative to ``--k``)
    * - ``--engine``
      - AIMNET
-     - Optimization engine: ``AIMNET``, ``ANI2x``, ``ANI2xt``
+     - Optimization engine: ``AIMNET`` (alias for ``aimnet2``), any aimnet
+       registry name (``aimnet2``, ``aimnet2-2025``, ``aimnet2-nse``,
+       ``aimnet2-pd``, ...), ``ANI2x``, ``ANI2xt``, or a path to a custom model
    * - ``--gpu`` / ``--no-gpu``
      - --no-gpu
      - Enable/disable GPU acceleration
@@ -409,8 +411,8 @@ Environment Variables
      - Description
    * - ``AUTO3D_COMPILE_MODEL``
      - Set to ``1`` to enable torch.compile() for ANI models
-   * - ``AUTO3D_USE_ENSEMBLE``
-     - Set to ``1`` to use AIMNET 8-model ensemble (slower, more accurate)
+   * - ``AIMNET_CACHE_DIR``
+     - Override the AIMNet2 model download cache (default: ``~/.cache/aimnet``)
    * - ``OE_LICENSE``
      - Path to OpenEye license file (for Omega isomer engine)
    * - ``CUDA_VISIBLE_DEVICES``

--- a/docs/source/howto/hpc.rst
+++ b/docs/source/howto/hpc.rst
@@ -95,12 +95,11 @@ For limited GPU memory:
        use_gpu=True,
    )
 
-Or use single model instead of ensemble:
+Or use a lighter model (ANI2xt uses the least memory):
 
 .. code:: console
 
-   export AUTO3D_USE_ENSEMBLE=0
-   auto3d run input.smi --k=1 --gpu
+   auto3d run input.smi --k=1 --gpu --engine=ANI2xt
 
 Chunked Processing
 ~~~~~~~~~~~~~~~~~~
@@ -244,16 +243,15 @@ From fastest to slowest:
 
 1. **ANI2xt**: Ultra-fast, good for screening
 2. **ANI2x**: Very fast, well-validated
-3. **AIMNET single**: Fast, most versatile (default)
-4. **AIMNET ensemble**: Slower, highest accuracy
+3. **AIMNet2**: Fast, most versatile (default); pick a specific registry model
+   (``aimnet2-2025``, ``aimnet2-nse``, ``aimnet2-pd``) for specialized chemistry
 
 .. code:: console
 
    # Fastest for screening
    auto3d run input.smi --k=1 --gpu --engine=ANI2xt
 
-   # Best accuracy
-   export AUTO3D_USE_ENSEMBLE=1
+   # Most versatile (default)
    auto3d run input.smi --k=1 --gpu --engine=AIMNET
 
 Optimal Batch Sizes

--- a/docs/source/howto/quickstart.rst
+++ b/docs/source/howto/quickstart.rst
@@ -172,6 +172,14 @@ Specify with ``--engine``:
 
    auto3d run molecules.smi --k=1 --engine=ANI2x
 
+.. note::
+
+   ``ANI2x`` / ``ANI2xt`` require the optional ani extra
+   (``pip install "Auto3D[ani]"``). The ``AIMNET`` engine also accepts specific
+   registry models (``aimnet2-2025``, ``aimnet2-nse``, ``aimnet2-pd``, ...) that
+   download on first use to ``~/.cache/aimnet``; run ``auto3d models list`` to
+   see them.
+
 Configuration Files
 -------------------
 

--- a/docs/source/howto/troubleshooting.rst
+++ b/docs/source/howto/troubleshooting.rst
@@ -50,7 +50,7 @@ Installation Issues
       # With CUDA
       pip install torch --index-url https://download.pytorch.org/whl/cu118
 
-2. Check version compatibility (requires PyTorch >= 2.1.0):
+2. Check version compatibility (requires PyTorch >= 2.8):
 
    .. code:: python
 
@@ -96,12 +96,11 @@ CUDA Out of Memory
           batchsize_atoms=512,  # Reduce from default 1024
       )
 
-2. Use single model instead of ensemble:
+2. Use a lighter model (ANI2xt uses the least memory):
 
    .. code:: console
 
-      export AUTO3D_USE_ENSEMBLE=0
-      auto3d run input.smi --k=1 --gpu
+      auto3d run input.smi --k=1 --gpu --engine=ANI2xt
 
 3. Process smaller chunks:
 
@@ -638,7 +637,7 @@ Common Error Messages
    * - ``RuntimeError: CUDA out of memory``
      - Reduce ``batchsize_atoms`` or use CPU
    * - ``ModuleNotFoundError: No module named 'torchani'``
-     - Install TorchANI: ``conda install -c conda-forge torchani``
+     - Install the optional ani extra: ``pip install "Auto3D[ani]"`` (or ``conda install -c conda-forge torchani``)
    * - ``FileNotFoundError: input.smi``
      - Check file path exists
    * - ``KeyError: 'E_tot'``

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ Welcome to Auto3D's documentation!
 ==================================
 
 .. note::
-   **AIMNet2 clarification**: The default model in Auto3D is AIMNet2 since version 2.2.1. If you specify ``optimizing_engine="AIMNET"``, it uses AIMNet2. The old AIMNet model has been deprecated since Auto3D 2.2.1.
+   **AIMNet2 clarification**: The default model in Auto3D is AIMNet2 since version 2.2.1. If you specify ``optimizing_engine="AIMNET"``, it uses AIMNet2. The old AIMNet model has been deprecated since Auto3D 2.2.1. Specialized AIMNet2 registry models (``aimnet2-2025``, ``aimnet2-nse``, ``aimnet2-pd``) are also available -- run ``auto3d models list``.
 
 **Auto3D**
 ==========

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,11 +4,14 @@ Installation
 Minimum Dependencies Installation
 ---------------------------------
 
-1. Python >= 3.10
+1. Python >= 3.11
 2. `RDKit <https://www.rdkit.org/docs/Install.html>`__ >= 2022.03.1 (for
    the isomer engine)
-3. `PyTorch <https://pytorch.org/get-started/locally/>`__ >= 2.1.0 (for
+3. `PyTorch <https://pytorch.org/get-started/locally/>`__ >= 2.8 (for
    the optimization engine)
+4. ``aimnet`` (a core dependency, installed automatically) serves the AIMNet2
+   models; the weights download on first use to ``~/.cache/aimnet`` (override
+   with ``AIMNET_CACHE_DIR``)
 
 If you have an environment with the above dependencies, Auto3D can be
 installed by
@@ -47,6 +50,9 @@ installed by:
    conda activate auto3D
    conda install -c conda-forge torchani
 
+   # or, equivalently, the pip extra
+   pip install "Auto3D[ani]"
+
 One additional isomer engine is available: OpenEye toolkit. It's a
 commercial software from `OpenEye
 Software <https://www.eyesopen.com/omega>`__. It can be installed by
@@ -64,3 +70,6 @@ enthalpy, entropy, geometry optimization) with Auto3D,
 
    conda activate auto3D
    conda install -c conda-forge ase
+
+   # or, equivalently, the pip extra
+   pip install "Auto3D[ase]"

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -9,7 +9,7 @@ Breaking Changes
 Python Version
 ~~~~~~~~~~~~~~
 
-Auto3D v3.0 requires **Python 3.10 or later**. If you're using an older Python version, you'll need to upgrade your environment.
+Auto3D v3.x requires **Python 3.11 or later**. If you're using an older Python version, you'll need to upgrade your environment.
 
 API Changes
 ~~~~~~~~~~~
@@ -172,8 +172,9 @@ New API for creating models directly:
    # Create a model for custom workflows
    model = create_model("AIMNET", device="cuda:0")
 
-   # Use ensemble for higher accuracy (slower)
-   model = create_model("AIMNET", device="cuda:0", use_ensemble=True)
+   # NOTE: the old ``use_ensemble=True`` argument is removed in v3.5 -- a single
+   # registry model is always used. Pick a specific registry model instead:
+   model = create_model("aimnet2-2025", device="cuda:0")
 
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
@@ -181,12 +182,17 @@ Environment variables
 New environment variables for runtime configuration:
 
 - ``AUTO3D_COMPILE_MODEL=1`` - Enable torch.compile for ANI models (~1.25x speedup)
-- ``AUTO3D_USE_ENSEMBLE=1`` - Use ensemble model for AIMNet (higher accuracy)
+- ``AIMNET_CACHE_DIR`` - Override the AIMNet2 model download cache (default: ``~/.cache/aimnet``)
+
+.. note::
+
+   ``AUTO3D_USE_ENSEMBLE`` and the ``use_ensemble=True`` argument are removed in
+   v3.5 and have no effect; a single AIMNet2 registry model is always used.
 
 Migration Checklist
 -------------------
 
-1. ☐ Update Python to 3.10+
+1. ☐ Update Python to 3.11+
 2. ☐ Replace ``from Auto3D.auto3D import options`` with ``from Auto3D import Auto3DOptions``
 3. ☐ Replace ``options(path, ...)`` calls with ``Auto3DOptions(path=path, ...)``
 4. ☐ Update CLI scripts to use ``auto3d run`` syntax

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -94,7 +94,12 @@ Select a model with ``--engine``:
 
 .. note::
    **AIMNet2 clarification**: The default model is AIMNet2 since version 2.2.1.
-   Specifying ``--engine=AIMNET`` uses AIMNet2.
+   Specifying ``--engine=AIMNET`` uses AIMNet2. ``--engine`` also accepts any
+   aimnet registry name (``aimnet2``, ``aimnet2-2025``, ``aimnet2-nse``,
+   ``aimnet2-pd``, ...); the weights download on first use to ``~/.cache/aimnet``
+   (override with ``AIMNET_CACHE_DIR``). Run ``auto3d models list`` to see them.
+   ``ANI2x`` / ``ANI2xt`` require the optional ani extra
+   (``pip install "Auto3D[ani]"``).
 
 Isomer and Tautomer Enumeration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/superpowers/plans/2026-06-11-hardening-gaps-remediation.md
+++ b/docs/superpowers/plans/2026-06-11-hardening-gaps-remediation.md
@@ -1,0 +1,712 @@
+# Hardening Gaps Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining deferred items from the round-2 module audit: make the test suite robust when the optional `torchani` extra is absent, pin TF32 precision correctly on torch ≥ 2.9, and turn two O(n²) RMSD-dedup loops into O(n).
+
+**Architecture:** Three independent, low-risk changes plus two optional follow-ups. The keystone is decoupling the product import chain from `torchani` (one eager `import torchani` in `ANI2xt_no_rep.py` currently drags the optional dependency into `Auto3D.ASE.thermo`, `Auto3D.SPE`, and the pure-Python thermo helpers). Making that import lazy fixes a collection-abort and 6 test failures at the source; the genuinely-ANI2xt tests then get explicit `pytest.importorskip`.
+
+**Tech Stack:** Python ≥3.11, PyTorch 2.9.1, RDKit, pytest. Verified facts: `torch.__version__ == "2.9.1+cu128"`; `torch.backends.cuda.matmul.fp32_precision` and `torch.backends.cudnn.fp32_precision` both exist; `torchani` is NOT installed in the dev env (so Tasks 1–2 are directly verifiable here).
+
+**Conventions:** ruff lint set is `E,F,I,N,UP,B,C4,SIM` (line-length 100). Commit one task at a time. Repo authorship rules: single author, no AI attribution/co-author trailers.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `src/Auto3D/batch_opt/ANI2xt_no_rep.py` | Modify | Move `import torchani` from module top into `ANI2xt.__init__` (lazy) |
+| `tests/test_lazy_torchani_import.py` | Create | Assert `Auto3D.ASE.thermo` imports with torchani blocked |
+| `tests/test_thermo_helpers.py` | (no change) | Already-present pure-Python tests; flip FAIL→PASS after Task 1 |
+| `tests/test_model_caching.py` | Modify | `pytest.importorskip("torchani")` on the 3 ANI2xt tests |
+| `tests/test_validation.py` | Modify | `pytest.importorskip("torchani")` on the ANI2x ordering test |
+| `tests/test_thermo.py` | Modify | Module-level `pytest.importorskip("torchani")` guard (belt-and-braces) |
+| `src/Auto3D/torch_config.py` | Modify | Set modern `fp32_precision` knob alongside legacy `allow_tf32` |
+| `tests/test_torch_config.py` | Modify | Assert `fp32_precision` is pinned when the attr exists |
+| `src/Auto3D/filtering.py` | Modify | Precompute no-H forms once → O(n) `RemoveHs` |
+| `src/Auto3D/utils/chemistry.py` | Modify | Same O(n) fix in legacy `filter_unique` |
+| `tests/test_filtering.py` | Modify | Count `RemoveHs` calls to prove O(n) |
+| `src/Auto3D/utils/file_ops.py` | Modify (Part B) | Per-file guard on the omega temp-file sweep |
+
+---
+
+# Part A — Recommended (do now)
+
+## Task 1: Make the `torchani` import in `ANI2xt_no_rep` lazy
+
+**Why:** `import torchani` at `ANI2xt_no_rep.py:5` is the ONLY unguarded eager torchani import in the product. It is used solely inside `ANI2xt.__init__` (the AEV computer, lines 36–38). Because `Auto3D.ASE.thermo:22` does `from Auto3D.batch_opt.ANI2xt_no_rep import ANI2xt`, importing the thermo module (or the pure-Python helpers `_detect_geometry`/`_symmetry_number`, or `_load_hessian_model("AIMNET")`) currently raises `ModuleNotFoundError` when torchani is absent — even though none of those need torchani. Moving the import into `__init__` defers the error to actual ANI2xt construction.
+
+**Files:**
+- Modify: `src/Auto3D/batch_opt/ANI2xt_no_rep.py:1-6` and `:22-23`
+- Test: `tests/test_lazy_torchani_import.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_lazy_torchani_import.py`:
+
+```python
+"""The optional torchani extra must not be required just to import thermo."""
+from __future__ import annotations
+
+import builtins
+import sys
+
+import pytest
+
+
+def test_thermo_imports_with_torchani_blocked(monkeypatch):
+    """Importing Auto3D.ASE.thermo (and using its pure-Python helpers) must work
+    even when torchani cannot be imported. torchani is only needed to *construct*
+    an ANI2xt model, not to import the module that references the class.
+    """
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "torchani" or name.startswith("torchani."):
+            raise ImportError("torchani blocked for this test")
+        return real_import(name, *args, **kwargs)
+
+    # Drop cached copies so the re-import re-runs module-level code under the block.
+    for mod in list(sys.modules):
+        if mod.startswith("Auto3D.ASE.thermo") or mod.startswith(
+            "Auto3D.batch_opt.ANI2xt_no_rep"
+        ):
+            sys.modules.pop(mod, None)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+    import Auto3D.ASE.thermo as thermo  # must NOT raise ModuleNotFoundError
+
+    from rdkit import Chem
+
+    # A pure-Python helper that does not touch torchani must work.
+    assert thermo._symmetry_number(Chem.MolFromSmiles("CCO")) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_lazy_torchani_import.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'torchani'` raised during `import Auto3D.ASE.thermo` (the blocked import propagates through `ANI2xt_no_rep.py:5`).
+
+- [ ] **Step 3: Make the import lazy**
+
+In `src/Auto3D/batch_opt/ANI2xt_no_rep.py`, change the top of the file from:
+
+```python
+import os
+
+import torch
+import torch.nn as nn
+import torchani
+
+from Auto3D.utils import ANI2XT_INDEX, hartree2ev
+```
+
+to (drop the module-level `import torchani`):
+
+```python
+import os
+
+import torch
+import torch.nn as nn
+
+from Auto3D.utils import ANI2XT_INDEX, hartree2ev
+```
+
+Then, inside `ANI2xt.__init__`, add the import as the first statement of the body (right after the docstring/`super().__init__()`), before the AEV constants. Change:
+
+```python
+    def __init__(self, device, state_dict=ani_2xt_dict, periodic_table_index=False):
+        super().__init__()
+        # setup constants and construct an AEV computer
+        Rcr = 5.2000e+00
+```
+
+to:
+
+```python
+    def __init__(self, device, state_dict=ani_2xt_dict, periodic_table_index=False):
+        super().__init__()
+        # torchani is an optional dependency, imported lazily so that merely
+        # importing this module (e.g. via Auto3D.ASE.thermo, which only
+        # references the ANI2xt class) never requires torchani. It is only
+        # needed to build the AEV computer below.
+        import torchani
+
+        # setup constants and construct an AEV computer
+        Rcr = 5.2000e+00
+```
+
+- [ ] **Step 4: Run the new test and the previously-broken pure-Python tests**
+
+Run: `python -m pytest tests/test_lazy_torchani_import.py tests/test_thermo_helpers.py -q`
+Expected: PASS for the new test AND all of `tests/test_thermo_helpers.py` (its 5 tests previously errored at import; they exercise `_detect_geometry`, `_symmetry_number`, and `_load_hessian_model("AIMNET")`, none of which need torchani).
+
+- [ ] **Step 5: Confirm thermo collection no longer aborts**
+
+Run: `python -m pytest tests/test_thermo.py --collect-only -q 2>&1 | tail -5`
+Expected: collection succeeds (no `ERROR tests/test_thermo.py`). Individual slow NNP tests may still be deselected/skipped, but collection must not error.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Auto3D/batch_opt/ANI2xt_no_rep.py tests/test_lazy_torchani_import.py
+git commit -m "fix: import torchani lazily in ANI2xt so thermo imports without the ani extra"
+```
+
+---
+
+## Task 2: Add `importorskip` to the genuinely-ANI/torchani tests
+
+**Why:** After Task 1, three model-caching tests (`create_model("ANI2xt", ...)`) and one validation test (`check_input` with `optimizing_engine="ANI2x"`, which imports torchani directly at `validation.py:85`) still require torchani because they actually construct/exercise the ANI path. They must skip — not fail — when the extra is absent. This matches the existing convention in `tests/test_model_factory.py` and `tests/test_model_adapter.py`. The validation test's failure is a *test-ordering artifact* (the dependency check fires before the element-compatibility check it asserts); do NOT reorder the product checks — fail-fast on a missing dependency is correct.
+
+**Files:**
+- Modify: `tests/test_model_caching.py` (3 tests)
+- Modify: `tests/test_validation.py` (1 test)
+- Modify: `tests/test_thermo.py` (module guard)
+
+- [ ] **Step 1: Guard the 3 ANI2xt caching tests**
+
+In `tests/test_model_caching.py`, add `import pytest` if not present, then insert `pytest.importorskip("torchani")` as the FIRST line inside each of these test bodies:
+- `TestModelCaching::test_different_models_create_different_instances`
+- `TestModelCaching::test_clear_cache_removes_models`
+- `TestModelCaching::test_get_cache_info_returns_size`
+
+Example shape (apply to each):
+
+```python
+    def test_clear_cache_removes_models(self):
+        pytest.importorskip("torchani")  # ANI2xt requires the optional ani extra
+        ...  # existing body unchanged
+```
+
+- [ ] **Step 2: Guard the ANI2x validation test**
+
+In `tests/test_validation.py`, add `pytest.importorskip("torchani")` as the first line of
+`TestCheckInputExceptions::test_only_aimnet_molecules_with_ani2x_raises_configuration_error`:
+
+```python
+    def test_only_aimnet_molecules_with_ani2x_raises_configuration_error(self, tmp_path):
+        pytest.importorskip("torchani")  # check_input imports torchani for the ANI2x path
+        ...  # existing body unchanged
+```
+
+(Confirm `import pytest` is already at the top of the file; it is.)
+
+- [ ] **Step 3: Add a belt-and-braces module guard to test_thermo.py**
+
+Task 1 fixes collection, but `test_thermo.py`'s slow tests genuinely run NNPs. Add a module-level guard right after its imports so the whole module skips cleanly if torchani is ever required by a test body and absent. At the top of `tests/test_thermo.py`, after the existing imports, add:
+
+```python
+import pytest
+
+pytestmark = pytest.mark.filterwarnings("default")  # keep existing marks if any
+```
+
+NOTE: if `test_thermo.py` already defines `pytestmark` (e.g. `pytest.mark.slow`), do NOT overwrite it — instead leave the slow mark and rely on Task 1 for collection. Only add `pytest.importorskip("torchani")` at module level if a non-slow test in that file constructs an ANI model. Inspect the file first; if every NNP-touching test is already `@pytest.mark.slow`, skip this step entirely and note it.
+
+- [ ] **Step 4: Run the guarded tests**
+
+Run: `python -m pytest tests/test_model_caching.py tests/test_validation.py -q`
+Expected: the 3 caching tests and the 1 validation test now report `s` (skipped), not `F` (failed); all other tests pass.
+
+- [ ] **Step 5: Confirm a clean full run (no errors, only skips)**
+
+Run: `python -m pytest tests/ -q --continue-on-collection-errors 2>&1 | tail -3`
+Expected: `0 failed`, some `skipped`, no `error`. (If any non-torchani failures remain they are out of scope for this task — report them.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_model_caching.py tests/test_validation.py tests/test_thermo.py
+git commit -m "test: skip ANI2xt/ANI2x tests when the optional torchani extra is absent"
+```
+
+---
+
+## Task 3: Pin TF32 precision via the modern `fp32_precision` API
+
+**Why:** On the installed torch 2.9.1 the legacy `torch.backends.cuda.matmul.allow_tf32` booleans are deprecated; the canonical control is `*.fp32_precision` (`"ieee"` for full FP32, `"tf32"` for TF32). `configure_torch` sets only the legacy flags, so the docstring's "maximum precision when `allow_tf32=False`" promise is on a deprecation path. Set both, guarded by `hasattr` for older torch.
+
+**Files:**
+- Modify: `src/Auto3D/torch_config.py:86-89`
+- Test: `tests/test_torch_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_torch_config.py`, inside `class TestConfigureTorch`:
+
+```python
+    def test_configure_torch_sets_fp32_precision_when_available(self):
+        """On torch with the modern fp32_precision API, allow_tf32 must map to
+        the precision mode ('ieee' for False, 'tf32' for True)."""
+        from Auto3D.torch_config import TorchConfig, configure_torch
+
+        matmul = torch.backends.cuda.matmul
+        if not hasattr(matmul, "fp32_precision"):
+            pytest.skip("torch too old for fp32_precision API")
+
+        configure_torch(TorchConfig(allow_tf32=False))
+        assert matmul.fp32_precision == "ieee"
+
+        configure_torch(TorchConfig(allow_tf32=True))
+        assert matmul.fp32_precision == "tf32"
+
+        configure_torch(TorchConfig(allow_tf32=False))  # restore default
+```
+
+Add `import pytest` to the top of `tests/test_torch_config.py` if it is not already imported (it currently is not — the autofixer removed it; re-add it).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_torch_config.py::TestConfigureTorch::test_configure_torch_sets_fp32_precision_when_available -q`
+Expected: FAIL — `assert <current value> == 'ieee'` (the value is not pinned because configure_torch never sets `fp32_precision`).
+
+- [ ] **Step 3: Set the modern knob**
+
+In `src/Auto3D/torch_config.py`, change:
+
+```python
+    # Precision settings
+    torch.backends.cuda.matmul.allow_tf32 = config.allow_tf32
+    torch.backends.cudnn.allow_tf32 = config.allow_tf32
+    torch.backends.cudnn.benchmark = config.cudnn_benchmark
+```
+
+to:
+
+```python
+    # Precision settings. Set both the legacy allow_tf32 booleans (back-compat
+    # for torch < 2.9) and the modern fp32_precision knob (canonical on torch
+    # >= 2.9, where allow_tf32 is deprecated). "ieee" = full FP32, "tf32" = TF32.
+    fp32_mode = "tf32" if config.allow_tf32 else "ieee"
+    torch.backends.cuda.matmul.allow_tf32 = config.allow_tf32
+    torch.backends.cudnn.allow_tf32 = config.allow_tf32
+    if hasattr(torch.backends.cuda.matmul, "fp32_precision"):
+        torch.backends.cuda.matmul.fp32_precision = fp32_mode
+    if hasattr(torch.backends.cudnn, "fp32_precision"):
+        torch.backends.cudnn.fp32_precision = fp32_mode
+    torch.backends.cudnn.benchmark = config.cudnn_benchmark
+```
+
+- [ ] **Step 4: Run the test plus the existing tf32 tests**
+
+Run: `python -m pytest tests/test_torch_config.py -q`
+Expected: PASS (new test + all existing). Note: setting `fp32_precision` may make `cuda.matmul.allow_tf32` read back as the synced value; the existing `test_configure_torch_tf32_enabled/disabled` assert `allow_tf32` which stays consistent — confirm they still pass and, if torch syncs the legacy flag from the modern one, adjust only if a real failure appears.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+ruff check src/Auto3D/torch_config.py tests/test_torch_config.py
+git add src/Auto3D/torch_config.py tests/test_torch_config.py
+git commit -m "fix: pin TF32 precision via the modern fp32_precision API on torch>=2.9"
+```
+
+---
+
+## Task 4: Make `filtering._filter_within_cluster` `RemoveHs` O(n)
+
+**Why:** `Chem.RemoveHs(mol_j)` (`filtering.py:100`) is recomputed for every `mol_i`, so each accepted unique conformer is stripped O(cluster_size) times → O(m²) `RemoveHs` calls where O(m) suffices. `RemoveHs` builds a new Mol; for large iso-energetic clusters it dominates. Precompute each member's no-H form once. `GetBestRMS` is symmetric on no-H forms, so results are identical.
+
+**Files:**
+- Modify: `src/Auto3D/filtering.py:91-115`
+- Test: `tests/test_filtering.py`
+
+- [ ] **Step 1: Write the failing test (counts RemoveHs calls)**
+
+Add to `tests/test_filtering.py`:
+
+```python
+def test_filter_within_cluster_removehs_is_linear_and_nondestructive(monkeypatch):
+    """RemoveHs runs once per molecule (O(n)) AND is non-destructive: returned
+    conformers keep their explicit hydrogens and exact H positions. This is a
+    correctness invariant, not just perf -- the MLIP requires explicit H and the
+    final geometries written to SDF must retain the optimized H coordinates. The
+    no-H form is a throwaway copy used only for the RMSD comparison.
+    """
+    import numpy as np
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    from Auto3D import filtering
+
+    # Five DISTINCT conformers of one molecule so all survive as unique,
+    # maximizing inner-loop comparisons (the O(n^2) path strips Hs each pair).
+    mols = []
+    base = Chem.AddHs(Chem.MolFromSmiles("CCCCO"))
+    cids = AllChem.EmbedMultipleConfs(base, numConfs=5, randomSeed=1)
+    for cid in cids:
+        m = Chem.Mol(base, confId=int(cid))
+        m.SetProp("E_tot", "0.0")
+        m.SetProp("Converged", "true")
+        mols.append(m)
+    n_atoms = base.GetNumAtoms()  # heavy + explicit H (15 for CCCCO)
+    orig_pos = {id(m): m.GetConformer().GetPositions().copy() for m in mols}
+
+    calls = {"n": 0}
+    real_removehs = filtering.Chem.RemoveHs
+
+    def counting(mol, *a, **k):
+        calls["n"] += 1
+        return real_removehs(mol, *a, **k)
+
+    monkeypatch.setattr(filtering.Chem, "RemoveHs", counting)
+
+    result = filtering._filter_within_cluster(mols, rmsd_threshold=0.01)
+
+    # O(n): RemoveHs called once per input, never per pair.
+    assert calls["n"] == len(mols)
+    assert len(result) == len(mols)
+    # Non-destructive: returned mols keep explicit H and byte-identical positions.
+    for m in result:
+        assert m.GetNumAtoms() == n_atoms
+        assert any(a.GetAtomicNum() == 1 for a in m.GetAtoms())
+        assert np.array_equal(m.GetConformer().GetPositions(), orig_pos[id(m)])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_filtering.py::test_filter_within_cluster_removehs_is_linear_and_nondestructive -q`
+Expected: FAIL — `calls["n"]` exceeds `len(mols)` (the inner loop strips Hs per comparison: 5 outer + 0+1+2+3+4 inner = 15 ≠ 5). The non-destructive assertions would already pass (the original code also returns originals), but the call-count assertion fails until the loop is rewritten.
+
+- [ ] **Step 3: Rewrite the loop to precompute no-H forms once**
+
+In `src/Auto3D/filtering.py`, replace the body of `_filter_within_cluster` after the `if len(mols) <= 1` guard:
+
+```python
+    unique: list[Chem.Mol] = []
+    for mol_i in mols:
+        is_unique = True
+        mol_i_noH = Chem.RemoveHs(mol_i)
+
+        for mol_j in unique:
+            mol_j_noH = Chem.RemoveHs(mol_j)
+            try:
+                # Temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
+                # Removing Hs speeds up the calculation
+                rmsd = rdMolAlign.GetBestRMS(mol_i_noH, mol_j_noH)
+            except RuntimeError:
+                rmsd = float("inf")  # incomparable pair -> treat as distinct
+
+            if rmsd < rmsd_threshold:
+                is_unique = False
+                break
+
+        if is_unique:
+            unique.append(mol_i)
+
+    return unique
+```
+
+with:
+
+```python
+    # Strip Hs once per molecule (O(n)), not once per comparison (O(n^2)).
+    # GetBestRMS on the no-H forms is symmetric, so results are unchanged.
+    unique: list[Chem.Mol] = []
+    unique_noH: list[Chem.Mol] = []
+    for mol_i in mols:
+        mol_i_noH = Chem.RemoveHs(mol_i)
+        is_unique = True
+
+        for mol_j_noH in unique_noH:
+            try:
+                # Temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
+                # Removing Hs speeds up the calculation
+                rmsd = rdMolAlign.GetBestRMS(mol_i_noH, mol_j_noH)
+            except RuntimeError:
+                rmsd = float("inf")  # incomparable pair -> treat as distinct
+
+            if rmsd < rmsd_threshold:
+                is_unique = False
+                break
+
+        if is_unique:
+            unique.append(mol_i)
+            unique_noH.append(mol_i_noH)
+
+    return unique
+```
+
+- [ ] **Step 4: Run the new test plus the existing filtering tests**
+
+Run: `python -m pytest tests/test_filtering.py -q`
+Expected: PASS (new test asserts `calls["n"] == 5`; existing correctness tests unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Auto3D/filtering.py tests/test_filtering.py
+git commit -m "perf: strip Hs once per conformer in cluster dedup (O(n^2) -> O(n))"
+```
+
+---
+
+## Task 5: Apply the same O(n) `RemoveHs` fix to legacy `filter_unique`
+
+**Why:** `utils/chemistry.py:519` is the same pattern, and worse — it strips Hs from BOTH `mol_i` and `mol_j` inside the inner loop (`GetBestRMS(Chem.RemoveHs(mol_i), Chem.RemoveHs(mol_j))`), so `mol_i` is re-stripped on every comparison too. Keep the two filters consistent.
+
+**Files:**
+- Modify: `src/Auto3D/utils/chemistry.py:511-530`
+- Test: `tests/test_utils_chemistry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_utils_chemistry.py`:
+
+```python
+def test_filter_unique_removehs_is_linear_and_nondestructive(monkeypatch):
+    """Legacy filter_unique strips Hs once per molecule (not per comparison) and
+    returns the originals with explicit H + exact positions intact."""
+    import numpy as np
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    from Auto3D.utils import chemistry
+
+    base = Chem.AddHs(Chem.MolFromSmiles("CCCCO"))
+    cids = AllChem.EmbedMultipleConfs(base, numConfs=5, randomSeed=1)
+    mols = []
+    for cid in cids:
+        m = Chem.Mol(base, confId=int(cid))
+        m.SetProp("Converged", "true")
+        mols.append(m)
+    n_atoms = base.GetNumAtoms()
+    orig_pos = {id(m): m.GetConformer().GetPositions().copy() for m in mols}
+
+    calls = {"n": 0}
+    real_removehs = chemistry.Chem.RemoveHs
+
+    def counting(mol, *a, **k):
+        calls["n"] += 1
+        return real_removehs(mol, *a, **k)
+
+    monkeypatch.setattr(chemistry.Chem, "RemoveHs", counting)
+
+    result = chemistry.filter_unique(mols, crit=0.01)
+    assert calls["n"] == len(mols)  # once per input, never per pair
+    assert len(result) == len(mols)
+    for m in result:
+        assert m.GetNumAtoms() == n_atoms
+        assert any(a.GetAtomicNum() == 1 for a in m.GetAtoms())
+        assert np.array_equal(m.GetConformer().GetPositions(), orig_pos[id(m)])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_utils_chemistry.py::test_filter_unique_removehs_is_linear_and_nondestructive -q`
+Expected: FAIL — `calls["n"]` far exceeds 5 (both sides stripped each comparison). Non-destructive assertions already pass; the call-count one drives the fix.
+
+- [ ] **Step 3: Rewrite the loop**
+
+In `src/Auto3D/utils/chemistry.py`, replace:
+
+```python
+    # Remove similar structures
+    unique_mols: list[Chem.Mol] = []
+    for mol_i in mols:
+        unique = True
+        for mol_j in unique_mols:
+            try:
+                # temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
+                # removing Hs speeds up the calculation
+                rmsd = rdMolAlign.GetBestRMS(Chem.RemoveHs(mol_i), Chem.RemoveHs(mol_j))
+            except RuntimeError:
+                # Incomparable pair: treat as distinct (not a duplicate) so the
+                # conformer is kept. Using 0 would make it look like a perfect
+                # duplicate and drop a genuinely distinct structure.
+                rmsd = float("inf")
+            if rmsd < crit:
+                unique = False
+                break
+        if unique:
+            unique_mols.append(mol_i)
+    return unique_mols
+```
+
+with:
+
+```python
+    # Remove similar structures. Strip Hs once per molecule (O(n)) instead of on
+    # both sides of every comparison (O(n^2)); GetBestRMS on no-H forms is
+    # symmetric so results are unchanged.
+    unique_mols: list[Chem.Mol] = []
+    unique_noH: list[Chem.Mol] = []
+    for mol_i in mols:
+        mol_i_noH = Chem.RemoveHs(mol_i)
+        unique = True
+        for mol_j_noH in unique_noH:
+            try:
+                # temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
+                # removing Hs speeds up the calculation
+                rmsd = rdMolAlign.GetBestRMS(mol_i_noH, mol_j_noH)
+            except RuntimeError:
+                # Incomparable pair: treat as distinct (not a duplicate) so the
+                # conformer is kept. Using 0 would make it look like a perfect
+                # duplicate and drop a genuinely distinct structure.
+                rmsd = float("inf")
+            if rmsd < crit:
+                unique = False
+                break
+        if unique:
+            unique_mols.append(mol_i)
+            unique_noH.append(mol_i_noH)
+    return unique_mols
+```
+
+- [ ] **Step 4: Run the new test plus existing chemistry/filtering tests**
+
+Run: `python -m pytest tests/test_utils_chemistry.py tests/test_filtering.py tests/test_utils_validation.py -q`
+Expected: PASS (new test asserts 5 calls; existing `filter_unique` correctness tests unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Auto3D/utils/chemistry.py tests/test_utils_chemistry.py
+git commit -m "perf: strip Hs once per conformer in legacy filter_unique (O(n^2) -> O(n))"
+```
+
+---
+
+# Part B — Optional / lower priority
+
+## Task 6: Harden the omega temp-file sweep in `housekeeping`
+
+**Why:** `housekeeping` (`file_ops.py:373-380`) globs the process CWD for `oeomega_*`/`flipper_*` and moves them under one bare `try/except OSError`. The "two omega workers race" framing is architecturally impossible (a single isomer worker runs omega serially), but a real, narrow cross-process race remains: an optimizer worker finishing chunk N can sweep the isomer worker's *in-flight* `oeomega_*` logfiles for chunk N+1 into the wrong verbose folder; with multiple optimizers, a peer may move a file first and the bare `except` then abandons the rest of the sweep. Impact is confined to misplaced/lost **verbose-mode diagnostic logs** (never results) and only with `OE_LICENSE` + `omega` + multi-GPU. This is a cheap robustness guard, not a correctness fix.
+
+**Files:**
+- Modify: `src/Auto3D/utils/file_ops.py:373-380`
+- Test: `tests/test_utils_file_ops.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_utils_file_ops.py`:
+
+```python
+def test_housekeeping_omega_sweep_is_per_file_robust(tmp_path, monkeypatch):
+    """A vanished/peer-moved oeomega_* file must not abort moving the rest."""
+    import os
+
+    from Auto3D.utils.file_ops import housekeeping
+
+    job = tmp_path / "job"
+    job.mkdir()
+    dest = tmp_path / "verbose"
+    dest.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    # Two omega logfiles; the first will "disappear" before it is moved.
+    (cwd / "oeomega_a.log").write_text("a")
+    (cwd / "oeomega_b.log").write_text("b")
+
+    real_move = __import__("shutil").move
+
+    def flaky_move(src, dst):
+        if src.endswith("oeomega_a.log"):
+            os.remove(src)  # simulate a peer worker having moved it already
+            raise OSError("already gone")
+        return real_move(src, dst)
+
+    monkeypatch.setattr("Auto3D.utils.file_ops.shutil.move", flaky_move)
+
+    housekeeping(str(job), str(dest), str(job / "out.sdf"))  # must not raise
+
+    # The surviving file must still have been moved despite the first failing.
+    assert (dest / "oeomega_b.log").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_utils_file_ops.py::test_housekeeping_omega_sweep_is_per_file_robust -q`
+Expected: FAIL — the single bare `try/except` around the whole loop means the `OSError` on `oeomega_a.log` aborts the loop before `oeomega_b.log` is moved, so `dest/oeomega_b.log` does not exist.
+
+- [ ] **Step 3: Guard each move individually**
+
+In `src/Auto3D/utils/file_ops.py`, replace:
+
+```python
+    try:
+        files1 = list(Path(".").glob("oeomega_*"))
+        files2 = list(Path(".").glob("flipper_*"))
+        files = files1 + files2
+        for file in files:
+            shutil.move(str(file), folder)
+    except OSError:
+        pass
+```
+
+with:
+
+```python
+    # Sweep OpenEye omega/flipper logfiles the binaries drop in the CWD. Guard
+    # each move individually: with multi-GPU optimizers running concurrently a
+    # peer may move/remove a file first, and a single bare try used to abandon
+    # the rest of the sweep on the first such error. (Diagnostic logs only.)
+    for file in list(Path(".").glob("oeomega_*")) + list(Path(".").glob("flipper_*")):
+        try:
+            if file.exists():
+                shutil.move(str(file), folder)
+        except OSError:
+            pass
+```
+
+- [ ] **Step 4: Run the new test plus existing file_ops tests**
+
+Run: `python -m pytest tests/test_utils_file_ops.py -q`
+Expected: PASS (the surviving file is moved; existing tests unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Auto3D/utils/file_ops.py tests/test_utils_file_ops.py
+git commit -m "fix: guard each omega/flipper temp-file move in housekeeping individually"
+```
+
+---
+
+## Task 7: (Documentation only) ANI2xt `energy_shifts` precision note
+
+**Why / decision:** Analysis showed the float64 `energy_shifts` buffer is downcast to float32 in `forward` (accumulated into a float32 `self_energies`), BUT this is **irrelevant to conformer ranking**: self-energies depend only on atom counts, which are identical across conformers of one molecule, so the term cancels exactly in any energy difference. The only real precision limit is the float32 forward itself (ULP ≈ 0.0039 eV at ~43000 eV absolute energy), which a buffer-dtype change does NOT fix. Therefore do NOT attempt a "precision fix" here — it would be misleading. The only honest change is a one-line docstring note. This task is optional and has no test (no behavior change; torchani is required to exercise the path and is absent in the dev env).
+
+**Files:**
+- Modify: `src/Auto3D/batch_opt/ANI2xt_no_rep.py` (docstring of `forward`)
+
+- [ ] **Step 1: Add the clarifying note**
+
+In `ANI2xt.forward`'s docstring, after the `Returns:` line, add:
+
+```python
+        Note:
+            Energies are computed in float32 (coords dtype). Self-atomic energy
+            shifts cancel in conformer energy differences (same atom counts), so
+            the float32 path does not affect ranking; absolute energies carry a
+            float32 ULP (~4e-3 eV) at typical total-energy magnitudes.
+```
+
+- [ ] **Step 2: Lint and commit**
+
+```bash
+ruff check src/Auto3D/batch_opt/ANI2xt_no_rep.py
+git add src/Auto3D/batch_opt/ANI2xt_no_rep.py
+git commit -m "docs: clarify ANI2xt float32 energy precision and self-energy cancellation"
+```
+
+---
+
+# Explicitly dropped (analyzed, not worth doing)
+
+- **`padding.py` per-molecule host→device transfers** — real but amortized to ~1/2000th of bucket wall time (the hot loop runs on already-resident GPU tensors); end-to-end gain not measurable. Revisit only if profiling flags it.
+- **`batchopt.py` `.tolist()` round-trips** — non-issue. RDKit `SetAtomPosition` rejects torch tensors, and results are scattered into pure-Python RDKit Mols, so the single bulk D2H per bucket is already optimal; keeping tensors would push N small per-molecule syncs into `run()` (strictly worse).
+- **Thin-module dead code** — `cli/progress.py` builds an unused `bar` local; `utils/stereo_check.py` is correct-but-unwired (documented gate). No bugs. Fold into a future cleanup pass only if touching those files anyway.
+
+---
+
+# Self-Review
+
+- **Spec coverage:** every "fix now"/"fix later" item from the two analysis agents maps to a task (1–2: torchani decoupling + skips; 3: fp32_precision; 4–5: O(n) RemoveHs ×2; 6: omega guard; 7: ANI2xt doc). Dropped items are listed with rationale.
+- **Placeholders:** none — every code step shows the exact before/after.
+- **Type/name consistency:** `unique_noH` introduced in Tasks 4 and 5 is local to each function; `fp32_mode` local to `configure_torch`; no cross-task signature drift.
+- **Risk ordering:** Part A is low-risk and directly verifiable in this env (torchani absent makes Tasks 1–2 testable now). Part B is optional.

--- a/docs/superpowers/plans/2026-06-11-tech-debt-backlog-roadmap.md
+++ b/docs/superpowers/plans/2026-06-11-tech-debt-backlog-roadmap.md
@@ -1,0 +1,518 @@
+# Auto3D Technical-Debt Roadmap (post-hardening)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:subagent-driven-development or superpowers:executing-plans. Each **workstream (W#)** below is INDEPENDENT and produces working, testable software on its own — execute them in priority order, one PR per workstream. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Close the infrastructure / feature / cleanup debt that remains after the module-correctness audit (PRs #92/#93). The pipeline logic is verified; what's left is a CI gate, one genuinely-broken feature (custom NNP), graceful OOM handling, lint/docs debt, and small polish.
+
+**Scope:** 8 workstreams (release deliberately excluded). Independent — pick any order, though the recommended sequence is W1→W2 first (highest leverage), W3 before/with W1 (so the CI lint gate passes).
+
+**Tech stack:** Python ≥3.11, torch 2.9.x, RDKit, pytest, ruff (`E,F,I,N,UP,B,C4,SIM`, line 100), mypy (already configured in `.pre-commit-config.yaml`), GitHub Actions. `aimnet` is a core dep; `torchani` is the optional `[ani]` extra (NOT installed in dev/CI by default).
+
+**Ground-truth facts established during investigation:**
+- There is **no test-running CI workflow** — only `.github/workflows/docs.yml` and `publish.yml`. A `.pre-commit-config.yaml` exists (ruff + ruff-format + mypy) but is local-only.
+- The "userNNP2" failure is **`torch.jit.script` on an embedded AIMNet2 module** (aimnet dropped scripting support — `aimnetcentral/CHANGELOG.md:45`), NOT torchani. The AIMNet2 custom-NNP path needs only `aimnet` (core), so it is testable without torchani.
+- `forward_batched` (`model_wrapper.py:203`) computes `batch_size = max(1, batchsize_atoms // N)`; a single molecule with `N > batchsize_atoms` runs as a batch of 1 and OOMs the whole run with no recovery.
+- Lint debt (ruff) lives in untouched files: `ASE/thermo.py` (I001 ×2), `batch_opt/batchopt.py` (I001), `batch_opt/padding.py` (I001 + **B905** zip-without-strict at line 65), `models/__init__.py` (I001), `utils/__init__.py` (I001).
+
+---
+
+# W1 — Test CI gate (P1, High) — `tests.yml`
+
+**Goal:** Run the suite on every push/PR so the 624 tests actually gate merges, and exercise the `[ani]` path CI has never run.
+
+**Files:** Create `.github/workflows/tests.yml`. Depends on W3 (lint clean) for the ruff job to pass.
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/tests.yml`:
+
+```yaml
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (py${{ matrix.python }}, ani=${{ matrix.ani }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.11", "3.12"]
+        ani: [false]
+        include:
+          - python: "3.12"
+            ani: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[ase]"
+      - name: Install ani extra
+        if: matrix.ani
+        run: pip install -e ".[ani]"
+      - name: Run fast tests
+        run: pytest tests/ -q -m "not slow" --continue-on-collection-errors
+
+  lint:
+    name: ruff + mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install tooling
+        run: pip install ruff mypy
+      - name: ruff
+        run: ruff check src/Auto3D/
+      - name: mypy
+        run: mypy src/Auto3D/ --ignore-missing-imports || true   # non-blocking until W3+ cleans mypy debt
+```
+
+- [ ] **Step 2: Validate the workflow YAML locally**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/tests.yml')); print('yaml ok')"`
+Expected: `yaml ok`.
+
+- [ ] **Step 3: Confirm the test invocation it runs is green locally**
+
+Run: `pytest tests/ -q -m "not slow" --continue-on-collection-errors 2>&1 | tail -3`
+Expected: `0 failed`, `0 error` (skips allowed). If the `lint` job's `ruff check src/Auto3D/` is not clean, do W3 first or it will fail — note this in the PR.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/tests.yml
+git commit -m "ci: run pytest (with/without the ani extra) and ruff/mypy on push and PRs"
+```
+
+- [ ] **Step 5 (after merge, manual):** In GitHub repo settings → branch protection for `main`, add the `test` + `lint` checks as required status checks. (Cannot be scripted here; note it in the PR description as a follow-up for the maintainer.)
+
+**Notes:** mypy is non-blocking (`|| true`) on purpose — the repo has latent type debt; tighten in a later pass. The `slow` NNP/thermo tests are excluded from PR CI; add a separate scheduled (`on: schedule`) job for them once `[ani]`+model-download caching is set up (out of scope here).
+
+---
+
+# W2 — Custom-NNP path repair (P1, High)
+
+**Goal:** Fix the broken custom-NNP feature: load **eager OR scripted** user models (modern AIMNet2-based models are not `torch.jit.script`-able), and stop the tests from scripting AIMNet2. Add ungated coverage. Document the contract and the `species_pad=0` NaN hazard.
+
+**Files:** `src/Auto3D/models/adapter.py` (`CustomModelAdapter`), `src/Auto3D/utils/validation.py`, `tests/test_SPE.py` / `tests/test_auto3D.py` / `tests/test_thermo.py` (the `userNNP2`/`userNNP3` AIMNet2 cases), new `tests/test_custom_nnp_eager.py`.
+
+- [ ] **Step 1: Write a failing, torchani-free unit test for the eager-load path**
+
+Create `tests/test_custom_nnp_eager.py`:
+
+```python
+"""A custom NNP saved as an eager nn.Module (torch.save) must load and run.
+
+Modern AIMNet2-based models are no longer torch.jit.script-able, so the
+custom-NNP adapter must accept eager modules, not only TorchScript archives.
+This needs no torchani and no aimnet -- a trivial analytic energy module suffices.
+"""
+from __future__ import annotations
+
+import torch
+
+
+class _TinyNNP(torch.nn.Module):
+    """E = sum(coord^2) over real atoms; ignores charges. coord_pad/species_pad
+    follow the custom-NNP contract."""
+
+    coord_pad = 0.0
+    species_pad = -1
+
+    def forward(self, species, coords, charges):
+        mask = (species != self.species_pad).unsqueeze(-1)
+        return (coords * mask).pow(2).sum(dim=(1, 2))
+
+
+def test_custom_eager_module_loads_and_runs(tmp_path):
+    from Auto3D.models.adapter import CustomModelAdapter
+
+    path = tmp_path / "tiny_eager.pt"
+    torch.save(_TinyNNP(), path)  # eager module, NOT torch.jit.script
+
+    adapter = CustomModelAdapter(str(path), torch.device("cpu"))
+    species = torch.tensor([[1, 6, -1]])           # last atom is padding
+    coords = torch.randn(1, 3, 3, requires_grad=False)
+    charges = torch.zeros(1)
+    e, f = adapter(species, coords, charges)
+    assert torch.isfinite(e).all()
+    assert f.shape == coords.shape and torch.isfinite(f).all()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/test_custom_nnp_eager.py -q`
+Expected: FAIL — `CustomModelAdapter.__init__` calls `torch.jit.load`, which raises `RuntimeError` on a `torch.save`-d eager module (it is not a TorchScript archive).
+
+- [ ] **Step 3: Make `CustomModelAdapter` load eager-or-scripted**
+
+In `src/Auto3D/models/adapter.py`, in `CustomModelAdapter.__init__`, replace the `model = torch.jit.load(model_path, map_location=device)` line with:
+
+```python
+        # Prefer torch.jit.load for legacy TorchScript archives; fall back to a
+        # plain torch.load for eager nn.Module checkpoints. Modern AIMNet2-based
+        # models are no longer torch.jit.script-able (aimnet dropped scripting
+        # support), so the custom-NNP contract must accept eager modules too.
+        try:
+            model = torch.jit.load(model_path, map_location=device)
+        except RuntimeError:
+            model = torch.load(model_path, map_location=device, weights_only=False)
+            if not isinstance(model, torch.nn.Module):
+                raise ModelLoadError(
+                    f"Custom NNP at {model_path} did not deserialize to an nn.Module."
+                )
+            model = model.to(device).eval()
+```
+
+Ensure `ModelLoadError` is imported in `adapter.py` (it is defined in `Auto3D.exceptions`; add the import if missing).
+
+- [ ] **Step 4: Run the eager test to green + existing adapter tests**
+
+Run: `python -m pytest tests/test_custom_nnp_eager.py tests/test_model_adapter.py -q 2>&1 | tail -5`
+Expected: PASS (eager test green; existing scripted-path tests unchanged — the try still uses `jit.load` first).
+
+- [ ] **Step 5: Mirror the load logic in input validation**
+
+In `src/Auto3D/utils/validation.py` (`check_input`, the `if Path(args.optimizing_engine).exists():` block that currently only does `torch.jit.load`), apply the same try/except so a valid eager `.pt` is not rejected at validation time:
+
+```python
+    if Path(args.optimizing_engine).exists():
+        try:
+            try:
+                model_ = torch.jit.load(args.optimizing_engine)  # noqa: F841
+            except RuntimeError:
+                model_ = torch.load(args.optimizing_engine, weights_only=False)  # noqa: F841
+                if not isinstance(model_, torch.nn.Module):
+                    raise ModelLoadError(
+                        "A path to a user NNP is used as optimizing engine, but it did "
+                        "not deserialize to an nn.Module."
+                    )
+        except (RuntimeError, pickle.UnpicklingError, OSError) as e:
+            raise ModelLoadError(
+                "A path to a user NNP is used as optimizing engine, but it cannot be loaded. "
+                f"Error: {type(e).__name__}: {e}. See ..."
+            ) from e
+```
+(Add `ModelLoadError` to the imports if not present — it already is.)
+
+- [ ] **Step 6: Fix the slow AIMNet2-based custom-NNP tests to use `torch.save`**
+
+In `tests/test_SPE.py`, `tests/test_auto3D.py`, and `tests/test_thermo.py`, for the `userNNP2`/`userNNP3` cases that embed an AIMNet2 module, replace:
+```python
+myNNP_jit = torch.jit.script(myNNP)
+myNNP_jit.save(model_path)
+```
+with:
+```python
+torch.save(myNNP, model_path)
+```
+Leave the **torchani** `userNNP1` cases on `torch.jit.script` (they exercise the legacy ScriptModule path and are torchani-gated). Add `pytest.importorskip("torchani")` only where a case actually needs torchani.
+
+ALSO — these AIMNet2-based examples set `species_pad = 0`, which AIMNet2 turns into NaN on padded atoms (per `adapter.py` AIMNet2 docstring). Run the affected `@pytest.mark.slow` test on a **2-molecule** SDF (not just single-molecule) to surface any batch-padding NaN. If NaN appears, set a non-zero pad sentinel in the example (e.g. `species_pad = -1`) and document it (Step 7).
+
+- [ ] **Step 7: Document the contract**
+
+In `CustomModelAdapter`'s class docstring (`adapter.py`), add: custom models may be a TorchScript archive (`torch.jit.script(m).save(path)`) OR an eager module (`torch.save(m, path)`); the adapter auto-detects. Note that AIMNet2-based custom models must use a non-zero `species_pad` (0 yields NaN on padded atoms). Mirror this in `docs/source/howto/custom_nnp.rst`.
+
+- [ ] **Step 8: Run slow custom-NNP tests (this env has aimnet, no torchani) + commit**
+
+Run: `python -m pytest tests/test_SPE.py -q -m slow -k "userNNP2" 2>&1 | tail -6` — expected PASS (no longer scripts AIMNet2). Then:
+```bash
+git add src/Auto3D/models/adapter.py src/Auto3D/utils/validation.py tests/test_custom_nnp_eager.py tests/test_SPE.py tests/test_auto3D.py tests/test_thermo.py docs/source/howto/custom_nnp.rst
+git commit -m "fix: load eager custom NNPs (not only TorchScript); repair AIMNet2 custom-NNP tests"
+```
+
+**Effort S–M, risk Low** (load-path try/except preserves the scripted path exactly).
+
+---
+
+# W3 — Lint debt cleanup (P2, Med)
+
+**Goal:** Clear the ruff errors in untouched files so the W1 lint gate is green. Pure hygiene, no behavior change.
+
+**Files:** `ASE/thermo.py`, `batch_opt/batchopt.py`, `batch_opt/padding.py`, `models/__init__.py`, `utils/__init__.py`.
+
+- [ ] **Step 1: Auto-fix the import-sort (I001) issues**
+
+Run: `ruff check --fix src/Auto3D/ASE/thermo.py src/Auto3D/batch_opt/batchopt.py src/Auto3D/batch_opt/padding.py src/Auto3D/models/__init__.py src/Auto3D/utils/__init__.py`
+Then confirm only the manual `B905` remains: `ruff check src/Auto3D/ 2>&1 | grep -E "^[A-Z][0-9]+"`
+
+- [ ] **Step 2: Fix B905 (zip-without-strict) manually in `padding.py:65`**
+
+Read the line; it is a `zip(...)` over two sequences that are the same length by construction (coords/species per atom). Add `strict=True`:
+```python
+for a, b in zip(seq_a, seq_b, strict=True):
+```
+(Use the actual variable names at `padding.py:65`. `strict=True` is correct since the two iterables are per-atom parallel arrays of equal length; if they could legitimately differ, use `strict=False` with a comment — but verify they cannot.)
+
+- [ ] **Step 3: Confirm clean + tests unaffected**
+
+Run: `ruff check src/Auto3D/ 2>&1 | tail -1` → `All checks passed!`
+Run: `python -m pytest tests/test_batchopt.py tests/test_padding.py tests/test_thermo_helpers.py -q 2>&1 | tail -3` → PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Auto3D/ASE/thermo.py src/Auto3D/batch_opt/batchopt.py src/Auto3D/batch_opt/padding.py src/Auto3D/models/__init__.py src/Auto3D/utils/__init__.py
+git commit -m "style: clear ruff import-sort and zip-strict debt in untouched modules"
+```
+
+---
+
+# W4 — `models info` registry alias + remove stale ensemble strings (P2, Med)
+
+**Goal:** `auto3d models info aimnet2-2025` (and other `aimnet2-*` names) should resolve, not print "Unknown engine"; remove the `--use-ensemble` / "8-model ensemble" strings that document removed behavior.
+
+**Files:** `src/Auto3D/cli/commands/models.py`, `tests/test_cli_app.py`.
+
+- [ ] **Step 1: Failing test for the registry alias**
+
+Add to `tests/test_cli_app.py`:
+```python
+def test_models_info_aimnet2_registry_variants(runner):
+    """All aimnet2-* registry names should resolve to the AIMNet2 entry."""
+    from Auto3D.cli.app import app
+    for name in ("aimnet2-2025", "aimnet2-nse", "aimnet2-pd"):
+        result = runner.invoke(app, ["models", "info", name])
+        assert result.exit_code == 0, (name, result.stdout)
+        assert "AIMNet2" in result.stdout
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/test_cli_app.py::test_models_info_aimnet2_registry_variants -q` → FAIL (exit 1, "Unknown engine" for `aimnet2-2025` — only the exact key `AIMNET2-2025` exists, but e.g. an unknown future variant would still miss; current code only special-cases `AIMNET2`).
+
+- [ ] **Step 3: Generalize the alias in `execute_models_info`**
+
+In `src/Auto3D/cli/commands/models.py`, replace the `if engine_upper == "AIMNET2": engine_upper = "AIMNET"` special-case with: any `aimnet2`-prefixed name that is not an explicit `ENGINE_INFO` key falls back to the base AIMNET entry:
+```python
+    engine_upper = engine.upper()
+    if engine_upper not in ENGINE_INFO and engine_upper.startswith("AIMNET2"):
+        # aimnet2 / aimnet2-2025 / aimnet2-nse / ... all describe AIMNet2;
+        # show the base entry for any registry variant without its own block.
+        engine_upper = "AIMNET"
+```
+
+- [ ] **Step 4: Remove stale ensemble strings**
+
+In the same file's `ENGINE_INFO`, delete the AIMNET note line `"Use --use-ensemble for highest accuracy"` (no such flag exists; the ensemble was removed). Verify no other `--use-ensemble`/"8-model ensemble" string remains for AIMNET: `grep -n "use-ensemble\|8-model ensemble" src/Auto3D/cli/commands/models.py` (the ANI2x "8-model ensemble" note is factually about ANI2x itself and may stay).
+
+- [ ] **Step 5: Run + commit**
+
+Run: `python -m pytest tests/test_cli_app.py -q 2>&1 | tail -3` → PASS.
+```bash
+git add src/Auto3D/cli/commands/models.py tests/test_cli_app.py
+git commit -m "fix: resolve all aimnet2-* names in models info; drop stale --use-ensemble note"
+```
+
+---
+
+# W5 — OOM-resilient batching (P2, Med)
+
+**Goal:** A CUDA OOM in `forward_batched` should be recovered (empty cache, retry with a smaller batch) instead of crashing the whole run; a single molecule that still OOMs must raise a clear, actionable error.
+
+**Files:** `src/Auto3D/batch_opt/model_wrapper.py` (`forward_batched`), `tests/test_model_wrapper.py`.
+
+- [ ] **Step 1: Failing test (CPU-simulable via a fake OOM)**
+
+Add to `tests/test_model_wrapper.py`:
+```python
+def test_forward_batched_retries_on_oom(monkeypatch):
+    """A transient CUDA OOM on a multi-molecule batch must be retried with a
+    smaller batch, not crash the run."""
+    import torch
+    from Auto3D.batch_opt.model_wrapper import EnForce_ANI
+
+    calls = {"n": 0}
+
+    class _Adapter:
+        coord_pad = 0.0
+        species_pad = -1
+
+        def __call__(self, species, coords, charges):
+            # Fail once with a CUDA OOM when handed more than one molecule,
+            # then succeed (simulating recovery after batch shrink).
+            calls["n"] += 1
+            if coords.shape[0] > 1:
+                raise torch.cuda.OutOfMemoryError("CUDA out of memory (simulated)")
+            e = coords.pow(2).sum(dim=(1, 2))
+            return e, torch.zeros_like(coords)
+
+    wrapper = EnForce_ANI(_Adapter(), batchsize_atoms=10_000)
+    coords = torch.randn(2, 3, 3)
+    numbers = torch.tensor([[1, 6, -1], [1, 6, -1]])
+    charges = torch.zeros(2)
+    e, f = wrapper.forward_batched(coords, numbers, charges)
+    assert e.shape == (2,) and torch.isfinite(e).all()
+```
+(`torch.cuda.OutOfMemoryError` exists in torch ≥2.x and is raisable/catchable on CPU.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/test_model_wrapper.py::test_forward_batched_retries_on_oom -q` → FAIL (the OOM propagates; no retry).
+
+- [ ] **Step 3: Add OOM-retry to `forward_batched`**
+
+In `src/Auto3D/batch_opt/model_wrapper.py`, replace the batch loop:
+```python
+        for batch in idx.split(batch_size):
+            _e, _f = self(coord[batch], numbers[batch], charges[batch])
+            e_list.append(_e)
+            f_list.append(_f)
+```
+with a recursive halving on OOM:
+```python
+        def _run(batch_idx: torch.Tensor, bsize: int):
+            for sub in batch_idx.split(bsize):
+                try:
+                    _e, _f = self(coord[sub], numbers[sub], charges[sub])
+                except torch.cuda.OutOfMemoryError:
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                    if sub.numel() == 1:
+                        raise OptimizationError(
+                            f"A single molecule with {N} atoms exhausted GPU memory even "
+                            f"at batch size 1. Reduce batchsize_atoms or use a smaller model."
+                        )
+                    _run(sub, max(1, bsize // 2))  # retry this slice with a smaller batch
+                    continue
+                e_list.append(_e)
+                f_list.append(_f)
+
+        _run(idx, batch_size)
+```
+Add `from Auto3D.exceptions import OptimizationError` to the imports. (Order is preserved: `idx.split` and the recursive `sub.split` keep ascending index order, and `e_list`/`f_list` are concatenated in that order downstream.)
+
+- [ ] **Step 4: Run + verify ordering preserved across the existing tests**
+
+Run: `python -m pytest tests/test_model_wrapper.py tests/test_batchopt.py tests/test_optimization_engine.py -q 2>&1 | tail -4` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Auto3D/batch_opt/model_wrapper.py tests/test_model_wrapper.py
+git commit -m "fix: recover from CUDA OOM in forward_batched by retrying with a smaller batch"
+```
+
+**Note:** you cannot sub-split a *single* molecule across batches (an NNP needs the whole molecule), hence the clear error at batch size 1 rather than silent loss.
+
+---
+
+# W6 — `input_format` single source of truth (P3, Low)
+
+**Goal:** Remove the redundant `self.input_format` orchestrator attribute now that it is a real (pickled) config field; read `self.config.input_format` everywhere. Eliminates a desync footgun (#93 architect minor).
+
+**Files:** `src/Auto3D/workflow.py`. (`chunk_manager`/`isomer_engine`/`factory` take `input_format` as an explicit param and are unchanged; only the orchestrator's internal duplication is removed.)
+
+- [ ] **Step 1: Add a guard test**
+
+Add to `tests/test_workflow.py`:
+```python
+def test_orchestrator_reads_input_format_from_config(tmp_path):
+    """After validation, input_format lives on the config (single source)."""
+    from Auto3D.config import Auto3DOptions
+    from Auto3D.workflow import WorkflowOrchestrator
+
+    smi = tmp_path / "m.smi"
+    smi.write_text("CCO ethanol\n")
+    orch = WorkflowOrchestrator(Auto3DOptions(path=str(smi), k=1))
+    orch._validate_input()
+    assert orch.config.input_format == "smi"
+```
+
+- [ ] **Step 2: Run (passes today — characterization), then refactor**
+
+Run: `python -m pytest tests/test_workflow.py::test_orchestrator_reads_input_format_from_config -q` → PASS (config field already set). This test pins the contract before refactor.
+
+- [ ] **Step 3: Drop the redundant attribute**
+
+In `src/Auto3D/workflow.py`:
+- Delete the `self.input_format: str = ""` line (~line 57) from `__init__`.
+- In `_validate_input` (~line 125), remove the separate `self.input_format = ...` assignment; keep only `self.config["input_format"] = input_format` (compute `input_format` as a local, used for the suffix check).
+- In `_prepare_chunks` (~line 239), change `input_format=self.input_format` to `input_format=self.config.input_format`.
+- Verify no other `self.input_format` reference remains: `grep -n "self.input_format" src/Auto3D/workflow.py` → no hits.
+
+- [ ] **Step 4: Run workflow tests + commit**
+
+Run: `python -m pytest tests/test_workflow.py -q 2>&1 | tail -3` → PASS.
+```bash
+git add src/Auto3D/workflow.py tests/test_workflow.py
+git commit -m "refactor: single source of truth for input_format (config field, drop orchestrator attr)"
+```
+
+---
+
+# W7 — Docs refresh for v3.5 (P2, Med — mechanical but broad)
+
+**Goal:** Remove docs of removed behavior (`AUTO3D_USE_ENSEMBLE` / 8-model ensemble / `--use-ensemble`), fix version floors (Python 3.11, PyTorch 2.8), document the `aimnet` core dep + `[ani]`/`[ase]` extras + `~/.cache/aimnet`, and add registry model names. No code; verify with a docs build.
+
+**Files (each a checkbox; the survey gives exact targets):**
+
+- [ ] **`docs/source/advanced_usage.rst`** (P1 within W7): delete the "Single Model vs Ensemble" subsection and every `AUTO3D_USE_ENSEMBLE` mention (Quick Settings, Environment Variables table, Troubleshooting GPU step 2). Replace "high accuracy = ensemble" with "a single registry member is always used; choose a different registry model (`aimnet2-2025`, `aimnet2-nse`, `aimnet2-pd`) for different needs." Add registry names to the model table.
+- [ ] **`docs/source/howto/hpc.rst`**: remove `export AUTO3D_USE_ENSEMBLE=0/1`; drop the "AIMNET ensemble" speed/accuracy tier; replace with registry-model guidance.
+- [ ] **`docs/source/howto/troubleshooting.rst`**: replace the `AUTO3D_USE_ENSEMBLE=0` OOM remedy with "reduce `batchsize_atoms`/`capacity`"; fix "PyTorch >= 2.1.0" → ">= 2.8"; mention the `[ani]` extra for the torchani error.
+- [ ] **`docs/source/cli.rst`**: remove `AUTO3D_USE_ENSEMBLE` from the env-var table; add registry names + "or a path to a custom model" to `--engine`.
+- [ ] **`docs/source/migration.rst`**: mark `AUTO3D_USE_ENSEMBLE` / `use_ensemble=True` as removed/no-op; note Python floor is now 3.11 for 3.5.
+- [ ] **`docs/source/installation.rst`**: Python `>=3.10`→`>=3.11`, PyTorch `>=2.1.0`→`>=2.8`; document `aimnet` as a core dep, `pip install "Auto3D[ani]"` / `"Auto3D[ase]"` extras, and that AIMNet2 models download on first use to `~/.cache/aimnet` (`AIMNET_CACHE_DIR`).
+- [ ] **`docs/source/howto/quickstart.rst`**: add the `[ani]` extra note where `--engine=ANI2x` appears; add a "registry models exist — run `auto3d models list`" pointer.
+- [ ] **`docs/source/usage.rst`**: add registry names ("any aimnet registry name") to the model table; note the AIMNet2 download/cache.
+- [ ] **`docs/source/howto/drug_discovery.rst`** & **`docs/source/index.rst`**: minor — mention `aimnet2-nse`/`aimnet2-pd` for specialized chemistry; align the index `.. note::` with the README v3.5 framing.
+- [ ] **`parameters.yaml`**: add a comment listing accepted `optimizing_engine` values (AIMNET/registry names/ANI2x/ANI2xt/path).
+
+**Verification (one step at the end):**
+- [ ] Run a docs build if configured: `pip install -e ".[docs]" && sphinx-build -b html docs/source /tmp/auto3d-docs -q 2>&1 | tail -5` — expect no new warnings about the edited pages. Grep to confirm removal: `grep -rn "AUTO3D_USE_ENSEMBLE\|use-ensemble\|8-model ensemble" docs/source/` → only intentional "removed/deprecated" mentions remain.
+- [ ] Commit: `git add docs/source parameters.yaml && git commit -m "docs: update for v3.5 — drop removed ensemble, fix version floors, document aimnet/extras/registry models"`
+
+**Already accurate (leave):** `README.md`, `docs/source/api.rst`, `custom_nnp.rst` (touch only if W2 adds the contract note), `integrations.rst`, `citation.rst`, package docstrings, `docs/legacy-v2/**`.
+
+---
+
+# W8 — ANI2xt forward fp64 accumulators (P3, Low — optional cleanup)
+
+**Goal:** Make the float64 `energy_shifts` buffer meaningful by accumulating the ANI2xt forward in fp64. Cosmetic — does NOT change conformer ranking (self-energies cancel across conformers); only cleans up absolute energies. Round-3 already added the clarifying docstring; this is the optional follow-through.
+
+**Files:** `src/Auto3D/batch_opt/ANI2xt_no_rep.py`. Torchani-gated (cannot run in dev env); keep the change minimal and verify via the existing torchani-gated thermo/SPE tests in CI's `[ani]` job (W1).
+
+- [ ] **Step 1:** In `ANI2xt.forward`, build `atom_energies` and `self_energies` in `torch.float64` (instead of `coords.dtype`), keep `total_energy` in fp64, and let the adapter downcast as it already does for AIMNet2. Do NOT change shapes or the AEV path.
+- [ ] **Step 2:** Update the docstring note to say energies are now accumulated in fp64 (absolute energies cleaner; ranking still unaffected).
+- [ ] **Step 3:** `ruff check`; commit `perf: accumulate ANI2xt forward energies in fp64 (cleaner absolute energies)`. Mark the PR "verify in CI [ani] job" since it cannot run locally without torchani.
+
+**Recommendation:** lowest priority; do only if touching ANI2xt anyway. Skipping is fine.
+
+---
+
+# W9 — Optimizer benchmark harness (P3, Low — new capability)
+
+**Goal:** A small, opt-in benchmark so future changes to the FIRE/optimization hot loop have a regression signal. Not a correctness gate.
+
+**Files:** Create `scripts/bench_optimizer.py` (not under `tests/` so it never runs in the default suite).
+
+- [ ] **Step 1:** Write `scripts/bench_optimizer.py` that builds a fixed set of N conformers (e.g. 200 drug-like SMILES embedded with a fixed seed), times `optimizing(...).run()` on CPU for a fixed `opt_steps`, and prints wall-time + steps/sec + peak memory (`torch.cuda.max_memory_allocated` when CUDA). Accept `--n`, `--engine`, `--steps`, `--device` flags.
+- [ ] **Step 2:** Add a `## Benchmarking` section to `CONTRIBUTING`/README pointing at it: `python scripts/bench_optimizer.py --engine AIMNET --n 200 --steps 200`.
+- [ ] **Step 3:** Commit `chore: add opt-in optimizer benchmark script`. (No CI wiring — manual baseline tool.)
+
+---
+
+# Recommended sequence & self-review
+
+**Sequence:** W3 (lint clean, fast) → W1 (CI gate, now green) → W2 (custom-NNP repair, highest feature value) → W4, W5, W6 (small fixes) → W7 (docs) → W8, W9 (optional).
+
+**Self-review (spec coverage):** every backlog item from the prior turn maps to a workstream — CI (W1), broken userNNP2 (W2), lint debt (W3), models-info alias (W4), OOM batching (W5), input_format dedup (W6), docs (W7), ANI2xt fp64 (W8), benchmark (W9). Release was excluded per instruction.
+
+**Placeholder scan:** code steps show exact before/after or full file content; doc steps name exact files + the exact strings to remove (`AUTO3D_USE_ENSEMBLE`/`--use-ensemble`) and version numbers (3.10→3.11, 2.1→2.8). The only non-literal step is `padding.py:65`'s `strict=` (the variable names must be read at execution because the exact identifiers weren't captured) — flagged inline.
+
+**Risk/independence:** W1–W9 are independent and each is one PR. W1's lint job assumes W3 landed (noted). W2/W8 AIMNet2/ANI2xt paths are testable only with `aimnet` (W2: available now) or `[ani]` (W8: CI only).

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -23,6 +23,9 @@ mode_oe: 'classic'
 mpi_np: 4
 
 # Optimization settings
+# optimizing_engine accepts: AIMNET (alias for aimnet2), any aimnet registry
+# name (aimnet2, aimnet2-2025, aimnet2-nse, aimnet2-pd, ...), ANI2x, ANI2xt,
+# or a path to a custom NNP model file.
 optimizing_engine: 'AIMNET'
 use_gpu: True
 gpu_idx: [0]

--- a/scripts/bench_optimizer.py
+++ b/scripts/bench_optimizer.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+"""Opt-in micro-benchmark for the Auto3D geometry-optimization hot loop.
+
+This is a manual baseline tool, NOT a test: it lives outside ``tests/`` so it
+never runs in the default suite and never gates CI. Use it to get a wall-clock
+and throughput signal before/after changes to the FIRE optimizer, the batched
+model wrapper, or the bucketing logic in ``Auto3D.batch_opt``.
+
+It builds a fixed set of drug-like conformers (RDKit ETKDG, fixed seed so the
+geometries are identical run-to-run), then times a single
+``optimizing(...).run()`` pass for a fixed number of optimization steps and
+reports wall-time, throughput, and peak memory.
+
+Examples::
+
+    python scripts/bench_optimizer.py --engine AIMNET --n 200 --steps 200
+    python scripts/bench_optimizer.py --engine ANI2xt --n 50 --device cpu
+    python scripts/bench_optimizer.py --engine AIMNET --device cuda:0
+
+Note: throughput is reported against the *configured* ``--steps`` as an upper
+bound; individual conformers may converge and stop early, so steps/sec is a
+relative signal across runs of this script, not an absolute count of NN calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import resource
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# A small, fixed pool of diverse drug-like molecules (real drugs and fragments).
+# The pool is cycled to reach --n so the benchmark is deterministic at any size.
+_SMILES_POOL = [
+    "CC(=O)Oc1ccccc1C(=O)O",                       # aspirin
+    "CN1C=NC2=C1C(=O)N(C(=O)N2C)C",                 # caffeine
+    "CC(C)Cc1ccc(cc1)C(C)C(=O)O",                   # ibuprofen
+    "CC(=O)Nc1ccc(O)cc1",                           # paracetamol
+    "OC(=O)c1ccccc1O",                              # salicylic acid
+    "C1=CC=C(C=C1)C2=CC=CC=C2",                     # biphenyl
+    "CN1CCC[C@H]1c1cccnc1",                         # nicotine
+    "Cc1ccc(cc1)S(=O)(=O)N",                        # p-toluenesulfonamide
+    "C1CCC(CC1)NC(=O)c1ccccc1",                     # N-cyclohexylbenzamide
+    "Clc1ccccc1Cl",                                 # o-dichlorobenzene
+    "OCC(O)C(O)C(O)C(O)CO",                         # sorbitol
+    "c1ccc2c(c1)cccc2",                             # naphthalene
+    "CC(C)(C)OC(=O)N1CCNCC1",                       # boc-piperazine
+    "Fc1ccc(cc1)C(=O)c1ccccc1",                     # 4-fluorobenzophenone
+    "COc1ccc(cc1)CCN",                              # 4-methoxyphenethylamine
+    "O=C1CCCCC1",                                   # cyclohexanone
+    "CCN(CC)CCOC(=O)c1ccc(N)cc1",                   # procaine
+    "c1ccncc1",                                     # pyridine
+    "CC1=CC(=O)CC(C)(C)C1",                         # isophorone
+    "Oc1ccc(cc1)C(=O)c1ccc(O)cc1",                  # 4,4'-dihydroxybenzophenone
+]
+
+
+def _build_conformer_sdf(n: int, seed: int, out_path: str) -> int:
+    """Write ``n`` embedded, H-added conformers to ``out_path``; return count."""
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    params = AllChem.ETKDGv3()
+    params.randomSeed = seed
+
+    written = 0
+    with Chem.SDWriter(out_path) as writer:
+        for i in range(n):
+            smiles = _SMILES_POOL[i % len(_SMILES_POOL)]
+            mol = Chem.MolFromSmiles(smiles)
+            if mol is None:
+                continue
+            mol = Chem.AddHs(mol)
+            if AllChem.EmbedMolecule(mol, params) != 0:
+                # Embedding can fail for a bad seed/molecule combo; skip it.
+                continue
+            mol.SetProp("_Name", f"bench{i}")
+            writer.write(mol)
+            written += 1
+    return written
+
+
+def _peak_rss_mb() -> float:
+    """Peak resident set size of this process in MiB (Linux: ru_maxrss is KiB)."""
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--n", type=int, default=200, help="number of conformers")
+    parser.add_argument(
+        "--engine",
+        default="AIMNET",
+        help="optimizing engine (AIMNET, an aimnet registry name, ANI2x, ANI2xt, or a model path)",
+    )
+    parser.add_argument("--steps", type=int, default=200, help="max optimization steps")
+    parser.add_argument(
+        "--device", default="cpu", help="torch device: cpu, cuda, cuda:0, ..."
+    )
+    parser.add_argument("--seed", type=int, default=42, help="RDKit embedding seed")
+    parser.add_argument(
+        "--batchsize-atoms", type=int, default=1024, help="atoms per optimization batch"
+    )
+    args = parser.parse_args(argv)
+
+    import torch
+
+    from Auto3D.batch_opt.batchopt import optimizing
+    from Auto3D.config import OptimizationConfig
+
+    device = torch.device(args.device)
+    is_cuda = device.type == "cuda"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        in_sdf = str(Path(tmp) / "bench_in.sdf")
+        out_sdf = str(Path(tmp) / "bench_out.sdf")
+
+        print(f"Building {args.n} conformers (seed={args.seed}) ...", flush=True)
+        t0 = time.perf_counter()
+        n_built = _build_conformer_sdf(args.n, args.seed, in_sdf)
+        build_s = time.perf_counter() - t0
+        if n_built == 0:
+            print("ERROR: no conformers were embedded.", file=sys.stderr)
+            return 1
+        print(f"  embedded {n_built} conformers in {build_s:.2f}s", flush=True)
+
+        config = OptimizationConfig(
+            opt_steps=args.steps,
+            batchsize_atoms=args.batchsize_atoms,
+        )
+
+        # Build the engine OUTSIDE the timed region: model creation/download and
+        # the one-time weight load are not part of the optimization hot loop and
+        # would otherwise dominate small runs.
+        print(f"Loading engine={args.engine} on device={device} ...", flush=True)
+        opt = optimizing(in_sdf, out_sdf, args.engine, device, config)
+
+        if is_cuda:
+            torch.cuda.reset_peak_memory_stats(device)
+            torch.cuda.synchronize(device)
+
+        print(
+            f"Optimizing {n_built} conformers for up to {args.steps} steps ...",
+            flush=True,
+        )
+        t0 = time.perf_counter()
+        opt.run()
+        if is_cuda:
+            torch.cuda.synchronize(device)
+        wall_s = time.perf_counter() - t0
+
+    confs_per_s = n_built / wall_s if wall_s > 0 else float("nan")
+    steps_per_s = (n_built * args.steps) / wall_s if wall_s > 0 else float("nan")
+
+    print("\n=== bench_optimizer results ===")
+    print(f"engine            : {args.engine}")
+    print(f"device            : {device}")
+    print(f"conformers        : {n_built}")
+    print(f"max steps         : {args.steps}")
+    print(f"wall time         : {wall_s:.3f} s")
+    print(f"throughput        : {confs_per_s:.2f} conformers/s")
+    print(f"step throughput   : {steps_per_s:.0f} conformer-steps/s (upper bound)")
+    if is_cuda:
+        peak_mb = torch.cuda.max_memory_allocated(device) / (1024 * 1024)
+        print(f"peak GPU memory   : {peak_mb:.1f} MiB")
+    print(f"peak process RSS  : {_peak_rss_mb():.1f} MiB")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/Auto3D/batch_opt/ANI2xt_no_rep.py
+++ b/src/Auto3D/batch_opt/ANI2xt_no_rep.py
@@ -146,10 +146,15 @@ class ANI2xt(nn.Module):
             Tensor of shape (batch,) with molecular energies in eV
 
         Note:
-            Energies are computed in float32 (coords dtype). Self-atomic energy
-            shifts cancel in conformer energy differences (same atom counts), so
-            the float32 path does not affect ranking; absolute energies carry a
-            float32 ULP (~4e-3 eV) at typical total-energy magnitudes.
+            The AEV/network path runs in float32 (coords dtype), but the
+            per-atom and self-atomic energies are accumulated in float64 so the
+            float64 ``energy_shifts`` buffer is not silently truncated. This only
+            cleans up absolute energies -- self-atomic shifts cancel in conformer
+            energy differences (same atom counts), so ranking is unaffected, and
+            the float32 network output still caps usable precision at ~float32
+            ULP (~4e-3 eV) at typical total-energy magnitudes. Energy is returned
+            as float64 and forces as float32 (the autograd grad w.r.t. the
+            float32 coords), matching the AIMNet2 adapter's output contract.
         """
         if self.periodic:
             # Convert atomic numbers to sequential indices
@@ -162,9 +167,11 @@ class ANI2xt(nn.Module):
         # Compute AEVs (use new API: aev_computer(species, coords))
         aev = self.aev_computer(species_idx, coords)  # (batch, num_atoms, aev_dim)
 
-        # Compute per-atom energies
+        # Compute per-atom energies. Accumulate in float64 so the float64
+        # energy_shifts buffer is meaningful; the network output is float32 and
+        # is cast up explicitly (an fp64-dest, fp32-source index_put would raise).
         batch_size, num_atoms = species_idx.shape
-        atom_energies = torch.zeros(batch_size, num_atoms, device=coords.device, dtype=coords.dtype)
+        atom_energies = torch.zeros(batch_size, num_atoms, device=coords.device, dtype=torch.float64)
 
         for elem_idx, network in enumerate(self.networks):
             # Find atoms of this element type
@@ -174,16 +181,16 @@ class ANI2xt(nn.Module):
                 elem_aev = aev[mask]  # (num_elem_atoms, aev_dim)
                 # Compute atomic energies
                 elem_energies = network(elem_aev).squeeze(-1)  # (num_elem_atoms,)
-                atom_energies[mask] = elem_energies
+                atom_energies[mask] = elem_energies.to(torch.float64)
 
         # Sum per-atom energies to get molecular energies
         atomic_energies = atom_energies.sum(dim=1)  # (batch,)
 
         # Add self-energies (energy shifts)
-        self_energies = torch.zeros(batch_size, device=coords.device, dtype=coords.dtype)
+        self_energies = torch.zeros(batch_size, device=coords.device, dtype=torch.float64)
         for elem_idx in range(len(self.networks)):
             mask = (species_idx == elem_idx)
-            counts = mask.sum(dim=1).to(coords.dtype)  # (batch,)
+            counts = mask.sum(dim=1).to(torch.float64)  # (batch,)
             self_energies += counts * self.energy_shifts[elem_idx]
 
         # Total energy in Hartree, convert to eV

--- a/src/Auto3D/cli/results.py
+++ b/src/Auto3D/cli/results.py
@@ -109,7 +109,8 @@ def count_from_output(output_path: str) -> tuple[int, int]:
     """Return (unique_molecule_count, conformer_count) from an output SDF.
 
     Molecule identity is the input ID - the part of the conformer name
-    before the first '@'.
+    before the first '@' (the tautomer separator, "id@tautN"), so all
+    tautomers of one input molecule count as a single molecule.
     """
     from rdkit import Chem
 


### PR DESCRIPTION
Closes the remaining workstreams from the two post-hardening plans (W7–W9 of the tech-debt roadmap; both plans were otherwise already implemented across PRs #93/#94).

## Changes

- **Docs refresh for v3.5 (W7)** — removed all documentation of the deleted ensemble feature (`AUTO3D_USE_ENSEMBLE`, `--use-ensemble`, "8-model ensemble") across 10 doc pages; fixed version floors (Python 3.11, PyTorch 2.8); documented `aimnet` as a core dependency, the `[ani]`/`[ase]` pip extras, the `~/.cache/aimnet` model download/cache (`AIMNET_CACHE_DIR`), and the AIMNet2 registry model names. Sphinx build is clean (0 warnings).
- **ANI2xt fp64 accumulation (W8)** — accumulate the ANI2xt forward's per-atom and self-atomic energies in float64 so the float64 `energy_shifts` buffer is no longer silently truncated. Cosmetic: self-atomic shifts cancel in conformer energy differences, so ranking is unaffected; energy is returned as float64 and forces as float32, matching the AIMNet2 adapter contract. The fp32 network output still caps usable precision.
- **Optimizer benchmark harness (W9)** — `scripts/bench_optimizer.py`, an opt-in micro-benchmark (outside `tests/`, never gates CI) that times `optimizing(...).run()` on a fixed, deterministic drug-like conformer set and reports wall time, throughput, and peak memory. Documented in CONTRIBUTING.
- Small: clarified the `@` tautomer-separator docstring in `results.py`; recorded the two plan docs; bumped a stale "Python 3.10" mention in CONTRIBUTING to 3.11.

## Notes for review

- **W8 deviates from the written plan, on purpose.** The plan's "build `atom_energies` in float64" crashes at runtime (`Index put requires source and destination dtypes match` — fp64 destination, fp32 network output). This PR adds the explicit `elem_energies.to(torch.float64)` cast the plan omitted; verified via a standalone autograd reproduction (fp64 energy / fp32 forces, finite grads). ANI2xt cannot run without the optional `torchani` extra, so this path must be confirmed by the CI `[ani]` job — it is not exercised by the local suite.

## Verification

- ruff: clean (`src/`, `scripts/`)
- Sphinx docs build: clean, 0 warnings
- Test gate (`pytest -m "not slow"`): 631 passed, 8 skipped (torchani-gated), 45 slow deselected
