### PR TITLE
test: cut fast-gate runtime ~104s->27s by removing redundant NNP model loads

### DIFF
--- a/tests/test_batchopt.py
+++ b/tests/test_batchopt.py
@@ -188,12 +188,21 @@ class TestGPUCleanup:
         assert 'cuda.is_available' in source, "CUDA availability check missing"
 
 
-def test_make_buckets_groups_by_size(tmp_path):
+def test_make_buckets_groups_by_size(tmp_path, monkeypatch):
     """Buckets must be size-homogeneous; a size outlier splits into its own bucket."""
+    from types import SimpleNamespace
+
     from rdkit import Chem
     from rdkit.Chem import AllChem
     import torch
     from Auto3D.batch_opt.batchopt import optimizing
+
+    # _make_buckets is pure-Python; stub create_model so this never loads the
+    # real AIMNet2 model.
+    monkeypatch.setattr(
+        "Auto3D.batch_opt.batchopt.create_model",
+        lambda *a, **k: SimpleNamespace(coord_pad=0.0, species_pad=-1),
+    )
 
     # Build an optimizing instance without running (just to call _make_buckets)
     inp = tmp_path / "in.sdf"
@@ -214,6 +223,8 @@ def test_make_buckets_groups_by_size(tmp_path):
 
 def test_optimizing_preserves_input_order(tmp_path, monkeypatch):
     """Bucketing reorders internally but output order must match input."""
+    from types import SimpleNamespace
+
     from rdkit import Chem
     from rdkit.Chem import AllChem
     import torch
@@ -234,6 +245,12 @@ def test_optimizing_preserves_input_order(tmp_path, monkeypatch):
                     numbers=numbers.tolist(), converged_mask=[True]*n,
                     oscillating_count=[0]*n)
     monkeypatch.setattr(bo, "ensemble_opt", fake_ensemble_opt)
+    # The optimization itself is faked above; stub create_model so constructing
+    # `optimizing` does not load the real AIMNet2 model.
+    monkeypatch.setattr(
+        bo, "create_model",
+        lambda *a, **k: SimpleNamespace(coord_pad=0.0, species_pad=-1),
+    )
 
     out = tmp_path / "out.sdf"
     eng = bo.optimizing(str(inp), str(out), "AIMNET", torch.device("cpu"),

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -8,14 +8,22 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from Auto3D.models.adapter import ModelAdapter, AIMNet2Adapter
+# Adapter classes are imported locally inside the tests that need them; the
+# real-AIMNet2 tests now reuse the session-scoped ``aimnet_model`` fixture
+# (see tests/conftest.py) so the model is loaded once per session, not per test.
 
 
-def test_model_adapter_interface():
+def test_model_adapter_interface(aimnet_model):
     """A concrete adapter should expose the ModelAdapter interface and a
-    forward(coords, species, charges) -> (energy, forces) signature."""
+    forward(coords, species, charges) -> (energy, forces) signature.
+
+    Uses the session-scoped ``aimnet_model`` fixture (an ``AIMNet2Adapter``
+    built once via ``create_model("AIMNET", ...)``) instead of loading the real
+    AIMNet2 model per-test (~7s). The test is read-only (reads attributes and
+    calls ``forward``), so sharing the adapter is safe.
+    """
     device = torch.device("cpu")
-    adapter = AIMNet2Adapter("aimnet2", device)
+    adapter = aimnet_model
 
     # Test interface attributes exist
     assert hasattr(adapter, 'coord_pad')
@@ -75,19 +83,25 @@ class TestBaseModelAdapter:
 class TestAIMNet2Adapter:
     """Tests for the AIMNet2Adapter (aimnet-backed)."""
 
-    def test_aimnet2_adapter_loads_default_model(self):
-        """AIMNet2Adapter resolves the 'aimnet2' registry name (no .jpt path)."""
-        device = torch.device("cpu")
-        adapter = AIMNet2Adapter("aimnet2", device)
+    def test_aimnet2_adapter_loads_default_model(self, aimnet_model):
+        """AIMNet2Adapter resolves the 'aimnet2' registry name (no .jpt path).
+
+        Uses the shared session ``aimnet_model`` fixture (built via
+        ``create_model("AIMNET", ...)``, which resolves to the ``aimnet2``
+        registry default) rather than reloading the real model. Read-only.
+        """
+        adapter = aimnet_model
 
         assert adapter.model_name == "aimnet2"
         # An underlying nn.Module is built from the aimnet registry.
         assert adapter.model is not None
 
-    def test_aimnet2_adapter_has_correct_padding(self):
-        """AIMNet2Adapter should have coord_pad=0.0 and species_pad=0."""
-        device = torch.device("cpu")
-        adapter = AIMNet2Adapter("aimnet2", device)
+    def test_aimnet2_adapter_has_correct_padding(self, aimnet_model):
+        """AIMNet2Adapter should have coord_pad=0.0 and species_pad=0.
+
+        Reuses the shared session ``aimnet_model`` fixture (read-only).
+        """
+        adapter = aimnet_model
 
         assert adapter.coord_pad == 0.0
         assert adapter.species_pad == 0
@@ -191,11 +205,12 @@ def test_try_compile_uses_dynamic_default_mode(monkeypatch):
     assert captured.get("dynamic") is True
 
 
-def test_aimnet2_adapter_energy_forces_water():
+def test_aimnet2_adapter_energy_forces_water(aimnet_model):
+    """Reuses the shared session ``aimnet_model`` adapter (read-only forward)
+    instead of reloading the real AIMNet2 model (~7s)."""
     import torch
-    from Auto3D.models.adapter import AIMNet2Adapter
 
-    ad = AIMNet2Adapter("aimnet2", torch.device("cpu"))
+    ad = aimnet_model
     coord = torch.tensor([[[0.0, 0, 0], [0, 0, 0.97], [0, 0.92, -0.25]]])
     species = torch.tensor([[8, 1, 1]])
     charges = torch.tensor([0.0])
@@ -206,11 +221,13 @@ def test_aimnet2_adapter_energy_forces_water():
     assert ad.species_pad == 0 and ad.coord_pad == 0.0
 
 
-def test_aimnet2_adapter_padded_batch_matches_unpadded():
-    """Padded multi-size batch must give per-molecule energies equal to solo runs."""
+def test_aimnet2_adapter_padded_batch_matches_unpadded(aimnet_model):
+    """Padded multi-size batch must give per-molecule energies equal to solo runs.
+
+    Reuses the shared session ``aimnet_model`` adapter (read-only forward).
+    """
     import torch
-    from Auto3D.models.adapter import AIMNet2Adapter
-    ad = AIMNet2Adapter("aimnet2", torch.device("cpu"))
+    ad = aimnet_model
 
     water_c = torch.tensor([[0.,0,0],[0,0,0.97],[0,0.92,-0.25]])
     water_n = torch.tensor([8,1,1])

--- a/tests/test_model_caching.py
+++ b/tests/test_model_caching.py
@@ -4,7 +4,32 @@ from __future__ import annotations
 import pytest
 import torch
 
+import Auto3D.model_factory as model_factory
 from Auto3D.model_factory import ModelFactory, create_model
+
+
+class _FakeAIMNet2Adapter:
+    """Lightweight stand-in for ``AIMNet2Adapter``.
+
+    Mirrors the real constructor signature so ``ModelFactory.create`` builds
+    its cache key (registry_name, device, use_ensemble, compile_model) and
+    stores/returns instances exactly as in production, but skips the multi-
+    second real AIMNet2 model load. The caching dict, identity semantics, and
+    ``get_cache_info()`` size are all exercised unchanged; only the expensive
+    object construction is replaced with an instant one.
+    """
+
+    def __init__(
+        self,
+        model_name="aimnet2",
+        device=None,
+        compile_model=False,
+        use_ensemble=False,
+    ):
+        self.model_name = model_name
+        self.device = device
+        self.compile_model = compile_model
+        self.use_ensemble = use_ensemble
 
 
 class TestModelCaching:
@@ -17,6 +42,19 @@ class TestModelCaching:
     def teardown_method(self):
         """Clear cache after each test."""
         ModelFactory.clear_cache()
+
+    @pytest.fixture(autouse=True)
+    def _fake_aimnet_adapter(self, monkeypatch):
+        """Replace the real AIMNet2 adapter with an instant fake.
+
+        Patches the ``AIMNet2Adapter`` symbol used by ``ModelFactory.create``
+        so that ``create_model("AIMNET", ...)`` returns a cheap stub instead of
+        loading the real ~4-7s NNP. The cache-key / cache-dict logic in
+        ``create`` runs verbatim, so all identity and cache-size assertions stay
+        meaningful. ANI-based tests ``importorskip("torchani")`` before reaching
+        ``create_model`` and are unaffected by this patch.
+        """
+        monkeypatch.setattr(model_factory, "AIMNet2Adapter", _FakeAIMNet2Adapter)
 
     def test_same_model_returns_cached_instance(self):
         """Test that calling create_model with same args returns cached instance."""

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -75,16 +75,18 @@ class TestModelFactory:
             model_factory.ModelFactory._adapters["ANI2X"]
         assert "ANI2XT" in model_factory.ModelFactory._adapters
 
-    def test_create_aimnet_returns_aimnet2_adapter(self):
+    def test_create_aimnet_returns_aimnet2_adapter(self, aimnet_model):
         """create('AIMNET') builds an AIMNet2Adapter bound to the 'aimnet2'
-        registry name (no bundled .jpt path anymore)."""
+        registry name (no bundled .jpt path anymore).
+
+        Reuses the session-scoped ``aimnet_model`` fixture (itself built via
+        ``create_model("AIMNET", ...)`` -> ``ModelFactory.create``) so the real
+        NNP is loaded once per session instead of an extra ~4s load here.
+        """
         from Auto3D.models.adapter import AIMNet2Adapter
 
-        device = torch.device("cpu")
-        model = ModelFactory.create("AIMNET", device=device)
-
-        assert isinstance(model, AIMNet2Adapter)
-        assert model.model_name == "aimnet2"
+        assert isinstance(aimnet_model, AIMNet2Adapter)
+        assert aimnet_model.model_name == "aimnet2"
 
     @patch("Auto3D.model_factory.Path.exists")
     @patch("Auto3D.models.adapter.torch.jit.load")
@@ -168,10 +170,11 @@ class TestIsCustomModel:
 class TestFactoryReturnsAdapter:
     """Tests for ModelFactory returning adapter instances."""
 
-    def test_factory_returns_adapter(self):
+    def test_factory_returns_adapter(self, aimnet_model):
         """Factory should return ModelAdapter instances."""
-        device = torch.device("cpu")
-        model = create_model("AIMNET", device)
+        # Reuse the session-scoped aimnet_model fixture (one shared load that
+        # survives ModelFactory.clear_cache()) instead of a fresh create_model.
+        model = aimnet_model
 
         # Check it's an adapter with the right interface
         assert hasattr(model, 'coord_pad')
@@ -180,12 +183,12 @@ class TestFactoryReturnsAdapter:
         assert model.coord_pad == 0.0
         assert model.species_pad == 0
 
-    def test_factory_returns_aimnet_adapter(self):
+    def test_factory_returns_aimnet_adapter(self, aimnet_model):
         """Factory should return an AIMNet2Adapter for AIMNET."""
         from Auto3D.models.adapter import AIMNet2Adapter
 
-        device = torch.device("cpu")
-        model = create_model("AIMNET", device)
+        # Reuse the session-scoped aimnet_model fixture (one shared load).
+        model = aimnet_model
 
         assert isinstance(model, AIMNet2Adapter)
         assert model.model_name == "aimnet2"

--- a/tests/test_thermo_helpers.py
+++ b/tests/test_thermo_helpers.py
@@ -3,7 +3,24 @@
 These cover the pure-Python helpers in Auto3D.ASE.thermo and do not run any
 neural-network potential or thermodynamic calculation, so they stay in the
 fast test suite (the main tests/test_thermo.py module is marked slow).
+
+The two AIMNET Hessian-model checks below are marked ``slow``: each requires a
+real ~9s NNP load (a separate model from the conftest ``aimnet_model`` adapter,
+since ``_load_hessian_model`` returns the bare AIMNet2Calculator). They share a
+module-scoped ``aimnet_hessian_model`` fixture so that, in the slow suite, the
+model still loads only once instead of twice.
 """
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def aimnet_hessian_model():
+    """Load the AIMNET Hessian evaluator once for this module's NNP checks."""
+    import torch
+    from Auto3D.ASE.thermo import _load_hessian_model
+    return _load_hessian_model("AIMNET", torch.device("cpu"))
 
 
 def test_detect_geometry_linear_vs_nonlinear():
@@ -38,20 +55,18 @@ def test_symmetry_number_invalid_property_falls_back():
     assert _symmetry_number(m) == 1
 
 
-def test_load_hessian_model_aimnet():
-    import torch
-    from Auto3D.ASE.thermo import _load_hessian_model
-    m = _load_hessian_model("AIMNET", torch.device("cpu"))
+@pytest.mark.slow
+def test_load_hessian_model_aimnet(aimnet_hessian_model):
+    m = aimnet_hessian_model
     # An AIMNet2Calculator from the aimnet registry (not a bundled .jpt);
     # vib_hessian routes it through the calculator's full-pipeline analytic Hessian.
     assert m is not None
     assert hasattr(m, "model")  # the calculator wraps the underlying nn.Module
 
 
-def test_load_hessian_model_aimnet_is_fp32():
+@pytest.mark.slow
+def test_load_hessian_model_aimnet_is_fp32(aimnet_hessian_model):
     import torch
-    from Auto3D.ASE.thermo import _load_hessian_model
-    m = _load_hessian_model("AIMNET", torch.device("cpu"))
     # The underlying aimnet module stays fp32 (no whole-graph fp64 upcast).
-    p = next(m.model.parameters())
+    p = next(aimnet_hessian_model.model.parameters())
     assert p.dtype == torch.float32

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -217,13 +217,22 @@ class TestIsomerWrapperFailure:
 class TestOptimizerEmptyInput:
     """Tests for optimizer handling of empty/missing input files."""
 
-    def test_optimizer_handles_missing_file(self, tmp_path, caplog):
+    def test_optimizer_handles_missing_file(self, tmp_path, caplog, monkeypatch):
         """Optimizer should gracefully handle missing input files."""
         import logging
+        from types import SimpleNamespace
 
         import torch
 
         from Auto3D.batch_opt.batchopt import optimizing
+
+        # This test exercises missing-file handling only -- run() returns before
+        # touching the model -- so stub create_model to skip the multi-second
+        # real AIMNet2 load (and stay robust to sibling tests clearing the cache).
+        monkeypatch.setattr(
+            "Auto3D.batch_opt.batchopt.create_model",
+            lambda *a, **k: SimpleNamespace(coord_pad=0.0, species_pad=-1),
+        )
 
         device = torch.device("cpu")
         config = {
@@ -242,13 +251,21 @@ class TestOptimizerEmptyInput:
 
         assert "does not exist" in caplog.text
 
-    def test_optimizer_handles_empty_file(self, tmp_path, caplog):
+    def test_optimizer_handles_empty_file(self, tmp_path, caplog, monkeypatch):
         """Optimizer should gracefully handle empty input files."""
         import logging
+        from types import SimpleNamespace
 
         import torch
 
         from Auto3D.batch_opt.batchopt import optimizing
+
+        # Empty-file handling returns before the model is used; stub create_model
+        # to skip the real AIMNet2 load (see test_optimizer_handles_missing_file).
+        monkeypatch.setattr(
+            "Auto3D.batch_opt.batchopt.create_model",
+            lambda *a, **k: SimpleNamespace(coord_pad=0.0, species_pad=-1),
+        )
 
         device = torch.device("cpu")
         config = {


### PR DESCRIPTION
Speeds up the default test gate (`pytest -m "not slow"`) from **~104s to ~27s** (3.85×) and eliminates the run-to-run variance.

## Root cause (from `pytest --durations`)
~12 tests accounted for ~93 of the 104s — all loading the real AIMNet2 NNP (~4–10s each). The cache-semantics tests call `ModelFactory.clear_cache()`, evicting the shared model so redundant reloads landed on different tests each run (the 32–38s variance).

## Changes (one decision per slow test)
- **`test_model_caching`** — fake `AIMNet2Adapter` via monkeypatch; caching is generic dict logic and the identity/size assertions stay meaningful (44s → 0.33s).
- **`test_model_adapter`** — the 5 AIMNet2 correctness tests share the session `aimnet_model` fixture (one load, not five); verified no in-place mutation of the shared adapter.
- **`test_model_factory`** — factory return-type tests reuse the session fixture (it survives `clear_cache()`, unlike a fresh `create_model`), so exactly **one** AIMNet2 load happens in the whole gate — this removes the variance.
- **`test_workflow` / `test_batchopt`** — stub `create_model` in tests that only exercise file-handling, bucketing, or already-faked optimization (`run()` returns before the model is used, or the optimization is monkeypatched).
- **`test_thermo_helpers`** — mark the two AIMNET Hessian-load checks `@pytest.mark.slow` (a separate ~9–10s model load, the single biggest remaining item; optional thermo path).

## Coverage note
The fast gate now does exactly **one** real AIMNet2 load, kept deliberately for the adapter energy/forces correctness smoke test — so real-NNP numerical coverage still runs in CI (`tests.yml` runs `-m "not slow"`). Only the heaviest, lowest-value item (the Hessian load) moved to the slow suite.

## Verification
- `pytest -m "not slow"`: 629 passed, 8 skipped, 47 deselected — deterministic at 26.4 / 27.0 / 27.3s across three runs.
- Slow-marked Hessian tests still pass under `-m slow`.
