### PR TITLE
test: trim fast gate to ~11s; run moved NNP tests in a slow CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,42 @@ jobs:
       - name: Run fast tests
         run: pytest tests/ -q -m "not slow" --continue-on-collection-errors
 
+  slow:
+    name: slow tests (NNP integration)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Cache downloaded model weights
+        uses: actions/cache@v4
+        with:
+          # AIMNet2 weights download to ~/.cache/aimnet; torchani/torch.hub
+          # weights (ANI2x) land in ~/.cache/torch. Cache both so the slow
+          # suite does not re-download on every run.
+          path: |
+            ~/.cache/aimnet
+            ~/.cache/torch
+          key: nnp-model-cache-v1
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          # ase for thermo, ani for the torchani-gated slow tests, dev for pytest
+          pip install -e ".[ase,ani,dev]"
+      - name: Run NNP integration tests (moved out of the fast gate)
+        # These slow tests load a real AIMNet2 model -- energy/forces
+        # correctness, adapter/factory return types, and the Hessian-model load.
+        # This is exactly the real-NNP coverage moved out of the fast gate, so it
+        # still runs on every push/PR. The broader `-m slow` suite (full-pipeline
+        # test_auto3D / test_SPE / test_thermo) is intentionally NOT run here:
+        # those heavy end-to-end tests are flaky under combined/randomized
+        # ordering (they pass individually) and need separate isolation work.
+        run: >
+          pytest tests/test_model_adapter.py tests/test_model_factory.py
+          tests/test_thermo_helpers.py -m slow -q
+
   lint:
     name: ruff + mypy
     runs-on: ubuntu-latest

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -13,6 +13,7 @@ import torch
 # (see tests/conftest.py) so the model is loaded once per session, not per test.
 
 
+@pytest.mark.slow
 def test_model_adapter_interface(aimnet_model):
     """A concrete adapter should expose the ModelAdapter interface and a
     forward(coords, species, charges) -> (energy, forces) signature.
@@ -80,6 +81,7 @@ class TestBaseModelAdapter:
         assert adapter.species_pad == -1
 
 
+@pytest.mark.slow
 class TestAIMNet2Adapter:
     """Tests for the AIMNet2Adapter (aimnet-backed)."""
 
@@ -205,6 +207,7 @@ def test_try_compile_uses_dynamic_default_mode(monkeypatch):
     assert captured.get("dynamic") is True
 
 
+@pytest.mark.slow
 def test_aimnet2_adapter_energy_forces_water(aimnet_model):
     """Reuses the shared session ``aimnet_model`` adapter (read-only forward)
     instead of reloading the real AIMNet2 model (~7s)."""
@@ -221,6 +224,7 @@ def test_aimnet2_adapter_energy_forces_water(aimnet_model):
     assert ad.species_pad == 0 and ad.coord_pad == 0.0
 
 
+@pytest.mark.slow
 def test_aimnet2_adapter_padded_batch_matches_unpadded(aimnet_model):
     """Padded multi-size batch must give per-molecule energies equal to solo runs.
 

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -75,6 +75,7 @@ class TestModelFactory:
             model_factory.ModelFactory._adapters["ANI2X"]
         assert "ANI2XT" in model_factory.ModelFactory._adapters
 
+    @pytest.mark.slow
     def test_create_aimnet_returns_aimnet2_adapter(self, aimnet_model):
         """create('AIMNET') builds an AIMNet2Adapter bound to the 'aimnet2'
         registry name (no bundled .jpt path anymore).
@@ -170,6 +171,7 @@ class TestIsCustomModel:
 class TestFactoryReturnsAdapter:
     """Tests for ModelFactory returning adapter instances."""
 
+    @pytest.mark.slow
     def test_factory_returns_adapter(self, aimnet_model):
         """Factory should return ModelAdapter instances."""
         # Reuse the session-scoped aimnet_model fixture (one shared load that
@@ -183,6 +185,7 @@ class TestFactoryReturnsAdapter:
         assert model.coord_pad == 0.0
         assert model.species_pad == 0
 
+    @pytest.mark.slow
     def test_factory_returns_aimnet_adapter(self, aimnet_model):
         """Factory should return an AIMNet2Adapter for AIMNET."""
         from Auto3D.models.adapter import AIMNet2Adapter


### PR DESCRIPTION
Follow-up to #98: trims the fast gate to ~11s and recovers the real-NNP coverage in a dedicated CI job.

## Fast gate: ~27s → ~11s
Marks the 8 tests that load the real AIMNet2 model (via the session `aimnet_model` fixture) `@pytest.mark.slow` — 5 in `test_model_adapter.py`, 3 in `test_model_factory.py`. With no real NNP load left, `pytest -m "not slow"` is **621 passed in ~11s, fully deterministic** (all durations < 1.1s). That's ~9.5× faster than the original ~104s baseline.

## New `slow` CI job
To keep the real-NNP coverage running on every push/PR, adds a `slow` job to `tests.yml` that:
- installs `.[ase,ani,dev]`,
- caches the AIMNet2 (`~/.cache/aimnet`) and torch/torchani (`~/.cache/torch`) model downloads,
- runs the moved tests — `test_model_adapter.py`, `test_model_factory.py`, `test_thermo_helpers.py` under `-m slow`.

Verified locally: those 3 files under `-m slow` are **10 passed, ~22s**, deterministic across runs.

## Why scoped, not the full `-m slow` suite
A local run of the entire `-m slow` suite was **18 failed / 25 passed**. The failures are pre-existing and unrelated to this change:
- ~7 are `ModuleNotFoundError: torchani` (they pass with the `[ani]` extra the CI job installs);
- the rest are heavy full-pipeline tests (`test_auto3D` / `test_SPE` / `test_thermo`) that **pass individually but fail under combined, randomized ordering** (e.g. `test_auto3D_config2` passes alone in 18s). That's a test-isolation problem in the multiprocessing pipeline, tracked as separate hardening work — running the whole suite in CI as-is would be flaky-red.

So this job runs exactly the deterministic NNP integration tests that moved out of the fast gate; the heavy suite stays out until its isolation is fixed.
