### PR TITLE
fix: force spawn so optimization workers never fork a CUDA context

### DIFF
--- a/src/Auto3D/auto3D.py
+++ b/src/Auto3D/auto3D.py
@@ -56,11 +56,19 @@ def main(args: Auto3DOptions) -> str:
 
     from Auto3D.workflow import WorkflowOrchestrator
 
-    # Set multiprocessing start method (spawn is safer for CUDA)
-    try:
-        mp.set_start_method("spawn")
-    except RuntimeError:
-        pass  # Already set by another call
+    # Force the 'spawn' start method for the optimization worker processes.
+    #
+    # The workers run PyTorch. Forking a process that has already initialized a
+    # CUDA context yields a broken context in the child: the worker crashes and
+    # the run produces no output (surfacing as "no 3D structure converged").
+    # force=True is REQUIRED, not optional: a default-context ProcessPoolExecutor
+    # (the isomer-embedding pool, or an earlier pipeline run in the same process)
+    # can already have locked the global start method to the platform default
+    # ('fork' on Linux). The previous best-effort set_start_method("spawn") would
+    # then raise RuntimeError, get swallowed, and the pipeline silently ran on
+    # fork -- breaking whenever any CUDA work had touched the parent process
+    # (e.g. a prior use_gpu=True call in the same interpreter / test session).
+    mp.set_start_method("spawn", force=True)
 
     orchestrator = WorkflowOrchestrator(args)
     return orchestrator.run()

--- a/tests/test_mp_start_method.py
+++ b/tests/test_mp_start_method.py
@@ -1,0 +1,44 @@
+"""Regression test for the multiprocessing start-method handling in ``main()``.
+
+The optimization workers run PyTorch. Forking a worker from a process that has
+already initialized a CUDA context yields a broken context in the child: the
+worker crashes and the run produces no output ("no 3D structure converged").
+
+A default-context ``ProcessPoolExecutor`` (the isomer-embedding pool, or an
+earlier pipeline run in the same interpreter) can lock the global start method
+to the platform default (``fork`` on Linux) *before* ``main()`` runs. The old
+best-effort ``set_start_method("spawn")`` would then raise ``RuntimeError``,
+swallow it, and the pipeline silently ran on fork -- which is exactly the
+ordering/isolation failure this guards against. ``main()`` must therefore
+*force* spawn.
+"""
+from __future__ import annotations
+
+import multiprocessing as mp
+import types
+
+
+def test_main_forces_spawn_even_when_fork_is_locked(monkeypatch):
+    """main() must force the 'spawn' start method even if 'fork' was locked in."""
+    import Auto3D.auto3D as auto3D
+    import Auto3D.workflow as workflow
+    from Auto3D.config import Auto3DOptions
+
+    # Simulate a prior default-context pool having locked the method to fork.
+    mp.set_start_method("fork", force=True)
+    assert mp.get_start_method() == "fork"
+
+    # Stub the orchestrator so we exercise only main()'s start-method handling,
+    # not the slow, GPU-dependent real pipeline. main() does a local
+    # ``from Auto3D.workflow import WorkflowOrchestrator``, so patch it there.
+    monkeypatch.setattr(
+        workflow,
+        "WorkflowOrchestrator",
+        lambda args: types.SimpleNamespace(run=lambda: "out.sdf"),
+    )
+
+    out = auto3D.main(Auto3DOptions(path="unused.smi", k=1))
+
+    assert out == "out.sdf"
+    # The fix: main() forced spawn despite fork having been locked first.
+    assert mp.get_start_method() == "spawn"


### PR DESCRIPTION
Fixes the root cause of the slow-suite ordering/isolation failures.

## Root cause
`main()` set the multiprocessing start method with a best-effort `set_start_method("spawn")` wrapped in `except RuntimeError: pass`. A default-context `ProcessPoolExecutor` (the isomer-embedding pool, `parallel_embed.py:112`) locks the global start method to the platform default (**fork** on Linux) the first time it spawns workers — after which that best-effort call raises `RuntimeError` and is swallowed, so the pipeline silently runs on **fork**.

Forking the optimization workers (which run PyTorch) from a process that has already initialized a **CUDA context** yields a broken context in the child: the worker crashes and the run produces no output, surfacing as `OptimizationError("…no 3D structure converged")`. In a test session this happened once any `use_gpu=True` test had initialized CUDA in the parent — so full-pipeline tests passed individually but failed under combined/randomized ordering.

**Proof** (decisive experiment): `fork` + CUDA-in-parent reproduces the exact failure; `spawn` + CUDA-in-parent succeeds.

## Fix
`mp.set_start_method("spawn", force=True)` so the pipeline always spawns, regardless of a previously-locked fork context. Adds a fast regression test (`tests/test_mp_start_method.py`) that locks fork first and asserts `main()` forces spawn — it passes with the fix and would fail on the old swallowed-`RuntimeError` code.

## Verification
- Against the failing seeded slow run, the 6 AIMNet2 `OptimizationError` tests now pass (`test_auto3D` `config2/3/6`, `rdkit_aimnet`, `sdf_rdkit_aimnet`, `userNNP3`).
- Fast gate: 622 passed, ~10.6s.

The remaining slow-suite failures are unrelated to this fix: ~11 are `torchani`-only (CI's `[ani]` covers them; GPU/multi-GPU ones skip), and 1 (`test_calc_thermo_aimnet`) is a separate global-state nondeterminism bug tracked for follow-up.
