### PR TITLE
test: harden slow-suite GPU isolation; stop mp regression test leaking spawn

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,3 +86,32 @@ def skip_without_gpu():
     """Skip test if GPU is not available."""
     if not torch.cuda.is_available():
         pytest.skip("No GPU available")
+
+
+@pytest.fixture(autouse=True)
+def _release_gpu_memory_after_slow_tests(request):
+    """Release cached models and GPU memory after each *slow* test.
+
+    The slow suite runs many full GPU pipelines and AIMNet2 Hessian/thermo
+    calculations back-to-back in a single process. Without releasing GPU memory
+    and cached models between them, memory pressure accumulates and
+    non-deterministically corrupts later GPU work -- e.g. ``calc_thermo``'s
+    AIMNet2 Hessian yields imaginary frequencies, so the thermochemistry result
+    is garbage (or its properties are never written, giving a ``KeyError``).
+    This made the slow tests pass individually but fail under combined ordering.
+
+    Scoped to slow tests on purpose: fast tests skip this teardown so the
+    session-scoped ``aimnet_model`` fixture stays warm (the fast gate must not
+    reload models). It is also a no-op on CPU / CI, where there is no CUDA cache.
+    """
+    yield
+    if request.node.get_closest_marker("slow") is None:
+        return
+    import gc
+
+    from Auto3D.model_factory import ModelFactory
+
+    ModelFactory.clear_cache()
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()

--- a/tests/test_mp_start_method.py
+++ b/tests/test_mp_start_method.py
@@ -24,21 +24,30 @@ def test_main_forces_spawn_even_when_fork_is_locked(monkeypatch):
     import Auto3D.workflow as workflow
     from Auto3D.config import Auto3DOptions
 
-    # Simulate a prior default-context pool having locked the method to fork.
-    mp.set_start_method("fork", force=True)
-    assert mp.get_start_method() == "fork"
+    # Save and restore the global start method. main() forces 'spawn' process-
+    # wide; without restoring it this test would leak spawn into the rest of the
+    # session, where other tests (e.g. the parallel-embedding ones) rely on the
+    # platform default 'fork' and run much slower -- or skip -- under spawn.
+    previous = mp.get_start_method(allow_none=True)
+    try:
+        # Simulate a prior default-context pool having locked the method to fork.
+        mp.set_start_method("fork", force=True)
+        assert mp.get_start_method() == "fork"
 
-    # Stub the orchestrator so we exercise only main()'s start-method handling,
-    # not the slow, GPU-dependent real pipeline. main() does a local
-    # ``from Auto3D.workflow import WorkflowOrchestrator``, so patch it there.
-    monkeypatch.setattr(
-        workflow,
-        "WorkflowOrchestrator",
-        lambda args: types.SimpleNamespace(run=lambda: "out.sdf"),
-    )
+        # Stub the orchestrator so we exercise only main()'s start-method
+        # handling, not the slow, GPU-dependent real pipeline. main() does a
+        # local ``from Auto3D.workflow import WorkflowOrchestrator``, so patch
+        # it there.
+        monkeypatch.setattr(
+            workflow,
+            "WorkflowOrchestrator",
+            lambda args: types.SimpleNamespace(run=lambda: "out.sdf"),
+        )
 
-    out = auto3D.main(Auto3DOptions(path="unused.smi", k=1))
+        out = auto3D.main(Auto3DOptions(path="unused.smi", k=1))
 
-    assert out == "out.sdf"
-    # The fix: main() forced spawn despite fork having been locked first.
-    assert mp.get_start_method() == "spawn"
+        assert out == "out.sdf"
+        # The fix: main() forced spawn despite fork having been locked first.
+        assert mp.get_start_method() == "spawn"
+    finally:
+        mp.set_start_method(previous or "fork", force=True)


### PR DESCRIPTION
Two test-isolation fixes found while investigating the slow-suite ordering failures (follow-up to #100).

## 1. The second isolation bug: `test_calc_thermo_aimnet`
`calc_thermo` passes alone but produced garbage Gibbs energies (4.28 / 1.14 / **59,352,587** hartree) or a `KeyError: 'G_hartree'` under combined ordering — and the failure mode itself varied run-to-run with the same seed, i.e. **non-deterministic**.

Root cause: the slow suite runs many full GPU pipelines and AIMNet2 Hessian/thermo calculations back-to-back in one process. Without releasing GPU memory and cached models between them, **memory pressure accumulates** and corrupts later GPU work — the AIMNet2 Hessian yields imaginary frequencies, so the thermo result is garbage or its properties are never written. (Confirmed by experiment: clearing the model cache + `cuda.empty_cache()` between tests flips `calc_thermo_aimnet` back to passing.)

Fix: an autouse conftest fixture that releases cached models + GPU memory **after each slow test**. Scoped to slow tests so the fast gate keeps its warm session model fixture; **no-op on CPU/CI**.

## 2. The mp regression test leaked `spawn`
The start-method regression test added in #100 calls `main()`, which forces `spawn` process-wide, and didn't restore it — leaking `spawn` into the rest of the fast-gate session. That made the parallel-embedding tests run on slow spawn pools (fast gate ~11s → **~30s**) and skip the fork-only case. Now it saves/restores the start method.

## Verification
- `test_calc_thermo_aimnet` now passes in the combined GPU run (remaining slow-suite failures are torchani-only, covered by the `[ani]` extra in the slow CI job).
- Fast gate restored: **622 passed, 8 skipped, ~11s**, deterministic across runs.
- The slow CI job's tests (`test_model_adapter` + `test_model_factory` + `test_thermo_helpers` under `-m slow`): 10 passed.

Note: bug #1 is most acute on memory-constrained / shared-GPU hosts; on CI (CPU) `calc_thermo` runs on CPU and the fixture is a no-op there.
