### PR TITLE
Fix major bug-hunt findings: silent data loss, thermochemistry, resource use

### DIFF
--- a/example/reaction_thermodynamics.ipynb
+++ b/example/reaction_thermodynamics.ipynb
@@ -189,7 +189,7 @@
     "        if mol.HasProp(\"G_hartree\"):\n",
     "            G = float(mol.GetProp(\"G_hartree\")) * HARTREE_TO_KCAL\n",
     "            H = float(mol.GetProp(\"H_hartree\")) * HARTREE_TO_KCAL\n",
-    "            S = float(mol.GetProp(\"S_hartree\")) * HARTREE_TO_KCAL  # Already per K\n",
+    "            S = float(mol.GetProp(\"S_hartree_per_K\")) * HARTREE_TO_KCAL  # Already per K\n",
     "            E = float(mol.GetProp(\"E_hartree\")) * HARTREE_TO_KCAL\n",
     "            T = float(mol.GetProp(\"T_K\"))\n",
     "            \n",

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -74,6 +74,32 @@ def _symmetry_number(mol: Chem.Mol) -> int:
     return 1
 
 
+def _resolve_multiplicity(mol: Chem.Mol) -> int:
+    """Spin multiplicity (2S+1) for IdealGasThermo's electronic-degeneracy term.
+
+    Uses an explicit integer 'multiplicity' molecule property when present.
+    Otherwise derives it from the radical-electron count
+    (multiplicity = unpaired electrons + 1) and records it on the mol, instead of
+    silently assuming a closed-shell singlet -- which would zero the electronic
+    entropy term for every radical. The NNP *energy* stays closed-shell
+    regardless (AIMNet2 takes only coords/species/charge, no spin), so warn for
+    open-shell species that the energy is an approximation.
+    """
+    if mol.HasProp("multiplicity"):
+        return mol.GetUnsignedProp("multiplicity")
+    n_radical = sum(a.GetNumRadicalElectrons() for a in mol.GetAtoms())
+    multiplicity = n_radical + 1
+    mol.SetUnsignedProp("multiplicity", int(multiplicity))
+    if n_radical > 0:
+        logger.warning(
+            "Open-shell species detected (%d unpaired electron(s), "
+            "multiplicity %d); the NNP energy is a closed-shell approximation.",
+            n_radical,
+            multiplicity,
+        )
+    return multiplicity
+
+
 class Calculator(ase.calculators.calculator.Calculator):
     """ASE calculator interface for AIMNET and ANI2xt"""
     implemented_properties = ['energy', 'forces']
@@ -227,8 +253,22 @@ def do_mol_thermo(mol: Chem.Mol,
     e = atoms.get_potential_energy()
     geometry = _detect_geometry(atoms)
     symmetry = _symmetry_number(mol)
-    multiplicity = mol.GetUnsignedProp("multiplicity") if mol.HasProp("multiplicity") else 1
+
+    multiplicity = _resolve_multiplicity(mol)
     spin = (multiplicity - 1) / 2.0
+
+    # NNP Hessians at the loose conformer-generation convergence threshold
+    # routinely yield one or two tiny artifact imaginary modes. Dropping them
+    # (ignore_imag_modes=True) keeps otherwise-valid thermochemistry instead of
+    # ASE raising ValueError and the whole molecule being discarded.
+    n_imag = int(np.sum(np.abs(np.imag(vib_e)) > 0))
+    if n_imag > 0:
+        logger.warning(
+            "%d imaginary vibrational mode(s) ignored in thermochemistry for "
+            "%s; treat the result as approximate.",
+            n_imag,
+            mol.GetProp("_Name") if mol.HasProp("_Name") else "molecule",
+        )
     thermo = IdealGasThermo(
         vib_energies=vib_e,
         potentialenergy=e,
@@ -236,13 +276,17 @@ def do_mol_thermo(mol: Chem.Mol,
         geometry=geometry,
         symmetrynumber=symmetry,
         spin=spin,
+        ignore_imag_modes=True,
     )
     H = thermo.get_enthalpy(temperature=T) * ev2hatree
+    # ASE's get_entropy returns entropy in eV/K, so this value is Hartree/K, not
+    # Hartree. Name the property accordingly so a downstream G = H - T*S
+    # reconstruction is not off by a factor of T.
     S = thermo.get_entropy(temperature=T, pressure=101325) * ev2hatree
     G = thermo.get_gibbs_energy(temperature=T, pressure=101325) * ev2hatree
 
     mol.SetProp("H_hartree", str(H))
-    mol.SetProp("S_hartree", str(S))
+    mol.SetProp("S_hartree_per_K", str(S))
     mol.SetProp("T_K", str(T))
     mol.SetProp("G_hartree", str(G))
     mol.SetProp("E_hartree", str(e * ev2hatree))

--- a/src/Auto3D/config.py
+++ b/src/Auto3D/config.py
@@ -22,6 +22,27 @@ from Auto3D.constants import (
 )
 
 
+def optimizer_worker_indices(
+    use_gpu: bool, gpu_idx: "int | list[int]"
+) -> list[int]:
+    """Return the per-process indices for the optimizer worker pool.
+
+    One worker per GPU when running on GPU with a list of indices; a single
+    worker otherwise. On CPU the index is unused (the worker runs on
+    ``torch.device('cpu')``), so a list of indices must NOT fan out into N
+    processes that all contend for the same cores -- that wastes memory (N model
+    loads) and risks OOM on a small box. The isomer worker uses this same count
+    to emit exactly one "Done" sentinel per optimizer, so both call sites must
+    agree to avoid deadlock.
+    """
+    if isinstance(gpu_idx, int):
+        return [gpu_idx]
+    if use_gpu:
+        return list(gpu_idx)
+    # CPU with a list of indices: collapse to a single worker (index unused).
+    return [gpu_idx[0] if gpu_idx else 0]
+
+
 @dataclass
 class Auto3DOptions:
     """Configuration options for Auto3D conformer generation.

--- a/src/Auto3D/constants.py
+++ b/src/Auto3D/constants.py
@@ -52,6 +52,15 @@ BUILTIN_ANI_MODELS = frozenset({MODEL_ANI2X.upper(), MODEL_ANI2XT.upper()})
 
 # Default optimization parameters
 DEFAULT_RMSD_THRESHOLD = 0.3  # Angstrom, for duplicate conformer removal
+# eV, energy tolerance for the duplicate-conformer test. RMSD dedup compares
+# heavy-atom skeletons only, so conformers differing solely in an O-H / N-H rotor
+# orientation collapse to RMSD~=0 even though they are distinct minima with
+# different energies. Two structures are treated as duplicates only when their
+# heavy-atom RMSD is below threshold AND their energies agree within this
+# tolerance, so genuine rotamers (which the H-rich conformer budget deliberately
+# samples) survive. ~0.23 kcal/mol -- above post-optimization fp32 energy noise
+# (~1e-3 eV) so truly identical conformers still dedup.
+DEFAULT_DUPLICATE_ENERGY_TOL = 0.01
 DEFAULT_CONVERGENCE_THRESHOLD = 0.01  # eV/Angstrom, force convergence
 DEFAULT_OPT_STEPS = 2000  # Maximum optimization steps
 DEFAULT_PATIENCE = 250  # Steps before dropping oscillating conformer

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -112,7 +112,7 @@ def _filter_within_cluster(
         e_i = _mol_energy(mol_i)
         is_unique = True
 
-        for mol_j_noH, e_j in zip(unique_noH, unique_energies):
+        for mol_j_noH, e_j in zip(unique_noH, unique_energies, strict=True):
             try:
                 # Temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # Removing Hs speeds up the calculation

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from rdkit import Chem
 from rdkit.Chem import rdMolAlign
 
-from Auto3D.constants import DEFAULT_ENERGY_CLUSTER_WINDOW, DEFAULT_RMSD_THRESHOLD
+from Auto3D.constants import (
+    DEFAULT_DUPLICATE_ENERGY_TOL,
+    DEFAULT_ENERGY_CLUSTER_WINDOW,
+    DEFAULT_RMSD_THRESHOLD,
+)
 from Auto3D.utils import check_connectivity
 
 
@@ -78,12 +82,18 @@ def filter_unique_optimized(
 def _filter_within_cluster(
     mols: list[Chem.Mol],
     rmsd_threshold: float,
+    energy_tol: float = DEFAULT_DUPLICATE_ENERGY_TOL,
 ) -> list[Chem.Mol]:
     """Filter unique molecules within an energy cluster.
 
     Args:
         mols: List of RDKit Mol objects to filter.
         rmsd_threshold: RMSD threshold for considering structures similar (Angstrom).
+        energy_tol: Energy tolerance (eV). A pair is treated as duplicate only
+            when the heavy-atom RMSD is below ``rmsd_threshold`` AND the energies
+            agree within this tolerance, so conformers that differ only in an
+            O-H / N-H rotor orientation (RMSD~=0 on heavy atoms but distinct
+            minima with different energies) are preserved.
 
     Returns:
         List of unique molecules within the cluster.
@@ -96,11 +106,13 @@ def _filter_within_cluster(
     # ORIGINAL (H-explicit) mols are returned; no-H forms are comparison-only.
     unique: list[Chem.Mol] = []
     unique_noH: list[Chem.Mol] = []
+    unique_energies: list[float] = []
     for mol_i in mols:
         mol_i_noH = Chem.RemoveHs(mol_i)
+        e_i = _mol_energy(mol_i)
         is_unique = True
 
-        for mol_j_noH in unique_noH:
+        for mol_j_noH, e_j in zip(unique_noH, unique_energies):
             try:
                 # Temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # Removing Hs speeds up the calculation
@@ -108,12 +120,31 @@ def _filter_within_cluster(
             except RuntimeError:
                 rmsd = float("inf")  # incomparable pair -> treat as distinct
 
-            if rmsd < rmsd_threshold:
+            # Heavy-atom RMSD alone collapses distinct H-rotamers; require the
+            # energies to also agree before declaring a duplicate. Missing/NaN
+            # energy => fall back to RMSD-only (energy guard cannot apply).
+            energy_close = (
+                e_i is None or e_j is None or abs(e_i - e_j) < energy_tol
+            )
+            if rmsd < rmsd_threshold and energy_close:
                 is_unique = False
                 break
 
         if is_unique:
             unique.append(mol_i)
             unique_noH.append(mol_i_noH)
+            unique_energies.append(e_i)
 
     return unique
+
+
+def _mol_energy(mol: Chem.Mol) -> float | None:
+    """Return a mol's optimized energy (eV) from the ``E_tot`` property, or None.
+
+    Used by the duplicate-conformer test as an energy guard; ``None`` signals
+    "no usable energy" so callers fall back to RMSD-only comparison.
+    """
+    try:
+        return float(mol.GetProp("E_tot"))
+    except (KeyError, ValueError):
+        return None

--- a/src/Auto3D/models/adapter.py
+++ b/src/Auto3D/models/adapter.py
@@ -52,6 +52,14 @@ def _validate_outputs(energy: torch.Tensor, forces: torch.Tensor) -> None:
     Raises:
         NumericalError: If NaN or Inf values are detected.
     """
+    # This runs on every NN forward, i.e. every FIRE step. Each `.any()`/`.item()`
+    # on a CUDA tensor is a host-device sync that serializes the stream, so the
+    # happy path (finite outputs) does a SINGLE combined reduction. The detailed,
+    # additionally-synchronizing NaN/Inf breakdown is computed only on the rare
+    # failure branch, where one extra sync is irrelevant.
+    if bool(torch.isfinite(energy).all() & torch.isfinite(forces).all()):
+        return
+
     if torch.isnan(energy).any():
         nan_count = torch.isnan(energy).sum().item()
         raise NumericalError(

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -528,7 +528,7 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
         except (KeyError, ValueError):
             e_i = None
         unique = True
-        for mol_j_noH, e_j in zip(unique_noH, unique_energies):
+        for mol_j_noH, e_j in zip(unique_noH, unique_energies, strict=True):
             try:
                 # temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # removing Hs speeds up the calculation

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -20,6 +20,7 @@ from Auto3D.constants import (
     CONFORMER_MULTIPLIER,
     CONFORMER_ROTATABLE_COEFF,
     CONFORMER_ROTATABLE_EXP,
+    DEFAULT_DUPLICATE_ENERGY_TOL,
     DEFAULT_RMSD_THRESHOLD,
     EV_TO_KCAL_PER_MOL,
     HARTREE_TO_EV,
@@ -511,12 +512,23 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
     # both sides of every comparison (O(n^2)); GetBestRMS on no-H forms is
     # symmetric so results are unchanged. The ORIGINAL (H-explicit) mols are
     # returned; no-H forms are comparison-only.
+    #
+    # Heavy-atom RMSD alone collapses conformers that differ only in an O-H / N-H
+    # rotor orientation. Guard with an energy check: a pair counts as duplicate
+    # only when the RMSD is below ``crit`` AND the energies agree within
+    # DEFAULT_DUPLICATE_ENERGY_TOL. Mols without a usable 'E_tot' fall back to
+    # RMSD-only (energy guard cannot apply).
     unique_mols: list[Chem.Mol] = []
     unique_noH: list[Chem.Mol] = []
+    unique_energies: list[float | None] = []
     for mol_i in mols:
         mol_i_noH = Chem.RemoveHs(mol_i)
+        try:
+            e_i: float | None = float(mol_i.GetProp("E_tot"))
+        except (KeyError, ValueError):
+            e_i = None
         unique = True
-        for mol_j_noH in unique_noH:
+        for mol_j_noH, e_j in zip(unique_noH, unique_energies):
             try:
                 # temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # removing Hs speeds up the calculation
@@ -526,10 +538,16 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
                 # conformer is kept. Using 0 would make it look like a perfect
                 # duplicate and drop a genuinely distinct structure.
                 rmsd = float("inf")
-            if rmsd < crit:
+            energy_close = (
+                e_i is None
+                or e_j is None
+                or abs(e_i - e_j) < DEFAULT_DUPLICATE_ENERGY_TOL
+            )
+            if rmsd < crit and energy_close:
                 unique = False
                 break
         if unique:
             unique_mols.append(mol_i)
             unique_noH.append(mol_i_noH)
+            unique_energies.append(e_i)
     return unique_mols

--- a/src/Auto3D/utils/file_ops.py
+++ b/src/Auto3D/utils/file_ops.py
@@ -98,6 +98,7 @@ def smiles2smi(smiles: list[str], path: str) -> str:
         # CCC  ATUOYWHBWRKTHZ-UHFFFAOYSA-N
     """
     lines = []
+    seen_ids: dict[str, int] = {}
     for idx, smi in enumerate(smiles):
         mol = Chem.MolFromSmiles(smi)
         if mol is None:
@@ -106,7 +107,25 @@ def smiles2smi(smiles: list[str], path: str) -> str:
                 "by RDKit."
             )
         inchikey = inchi.MolToInchiKey(mol)
-        lines.append(f"{smi}  {inchikey}\n")
+        # Distinct inputs can share a standard InChIKey (e.g. tautomers the
+        # standard InChIKey conflates, or the same molecule written two ways).
+        # The InChIKey is used as the molecule's unique ID downstream, and
+        # reorder_sdf collapses duplicate IDs -- so a colliding input would be
+        # silently dropped. Disambiguate by suffixing repeats (_2, _3, ...) so
+        # every input keeps its own conformers. The suffix stays a single
+        # whitespace-delimited token and round-trips through enumeration.
+        count = seen_ids.get(inchikey, 0) + 1
+        seen_ids[inchikey] = count
+        mol_id = inchikey if count == 1 else f"{inchikey}_{count}"
+        if count > 1:
+            logger.info(
+                "Input SMILES %r shares InChIKey %s with an earlier input; "
+                "assigning disambiguated id %s so it is not dropped.",
+                smi,
+                inchikey,
+                mol_id,
+            )
+        lines.append(f"{smi}  {mol_id}\n")
 
     with open(path, "w+") as f:
         for line in lines:

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import Auto3D
 from Auto3D.chunk_manager import ChunkManager
-from Auto3D.config import Auto3DOptions
+from Auto3D.config import Auto3DOptions, optimizer_worker_indices
 from Auto3D.exceptions import ConfigurationError, FileFormatError, OptimizationError
 from Auto3D.model_factory import ModelFactory
 from Auto3D.torch_config import TorchConfig, configure_torch
@@ -268,23 +268,21 @@ class WorkflowOrchestrator:
             args=(chunk_info, self.config, chunk_queue, self.logging_queue),
         )
 
-        # Create optimization processes (one per GPU or single for CPU)
+        # Create optimization processes: one per GPU when running on GPU with a
+        # list of indices, a single worker otherwise. A CPU run with a list of
+        # gpu_idx must NOT spawn N processes all contending for the same cores
+        # (N model loads -> OOM risk); optimizer_worker_indices collapses that to
+        # one, and the isomer worker derives its sentinel count the same way.
         p2s: list[mp.Process] = []
-        if isinstance(self.config.gpu_idx, int):
+        for idx in optimizer_worker_indices(
+            self.config.use_gpu, self.config.gpu_idx
+        ):
             p2s.append(
                 mp.Process(
                     target=optim_rank_wrapper,
-                    args=(opt_config, chunk_queue, self.logging_queue, self.config.gpu_idx),
+                    args=(opt_config, chunk_queue, self.logging_queue, idx),
                 )
             )
-        else:
-            for idx in self.config.gpu_idx:
-                p2s.append(
-                    mp.Process(
-                        target=optim_rank_wrapper,
-                        args=(opt_config, chunk_queue, self.logging_queue, idx),
-                    )
-                )
 
         # Start all processes
         p1.start()

--- a/src/Auto3D/workflow_workers.py
+++ b/src/Auto3D/workflow_workers.py
@@ -20,6 +20,7 @@ from rdkit import Chem
 from send2trash import send2trash
 
 from Auto3D.batch_opt.batchopt import optimizing
+from Auto3D.config import optimizer_worker_indices
 from Auto3D.isomers import IsomerEngineFactory
 from Auto3D.processors import TautomerProcessor
 from Auto3D.ranking import ranking
@@ -57,10 +58,9 @@ def isomer_wrapper(
     # Each optimizer blocks on queue.get() until it receives a "Done" sentinel,
     # so we must emit exactly one sentinel per optimizer in a `finally` block to
     # avoid deadlocking the optimizers when isomer generation fails partway.
-    if isinstance(args.gpu_idx, int):
-        n_optimizers = 1
-    else:
-        n_optimizers = len(args.gpu_idx)
+    # Use the same rule as the spawn site (a CPU run with a list of gpu_idx runs
+    # a single optimizer, not one per index) so the counts cannot drift.
+    n_optimizers = len(optimizer_worker_indices(args.use_gpu, args.gpu_idx))
 
     try:
         for i, path_dir in enumerate(chunk_info):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,3 +183,30 @@ def test_default_and_valid_k_window_accepted():
     Auto3DOptions(path="x.smi", k=5)
     Auto3DOptions(path="x.smi", window=2.0)
     Auto3DOptions(path="x.smi", k=0)  # 0 is "not specified", allowed
+
+
+class TestOptimizerWorkerIndices:
+    """One optimizer process per GPU on GPU; a single worker otherwise.
+
+    A CPU run with a list of gpu_idx must collapse to ONE worker (the index is
+    unused on CPU) so N processes do not contend for the same cores / load the
+    model N times. The spawn site and the isomer worker's sentinel count both
+    derive from this, so they cannot drift.
+    """
+
+    def test_single_int_index(self):
+        from Auto3D.config import optimizer_worker_indices
+        assert optimizer_worker_indices(True, 0) == [0]
+        assert optimizer_worker_indices(False, 2) == [2]
+
+    def test_gpu_list_fans_out(self):
+        from Auto3D.config import optimizer_worker_indices
+        assert optimizer_worker_indices(True, [0, 1, 2]) == [0, 1, 2]
+
+    def test_cpu_list_collapses_to_one(self):
+        from Auto3D.config import optimizer_worker_indices
+        assert optimizer_worker_indices(False, [0, 1]) == [0]
+
+    def test_cpu_empty_list_is_safe(self):
+        from Auto3D.config import optimizer_worker_indices
+        assert optimizer_worker_indices(False, []) == [0]

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -41,6 +41,33 @@ class TestFilterWithinCluster:
         result = _filter_within_cluster([mol1, mol2], rmsd_threshold=0.5)
         assert len(result) == 1
 
+    def test_same_geometry_different_energy_kept(self):
+        """Same heavy-atom geometry but distinct energy must NOT be deduped.
+
+        Mirrors the O-H / N-H rotamer case: heavy-atom RMSD ~= 0 but the two are
+        distinct minima with different energies. The energy guard must keep both.
+        """
+        mol1 = _create_mol_with_energy("C", -10.0)
+        mol2 = _create_mol_with_energy("C", -10.5)  # RMSD~=0, |dE| >> tol
+        result = _filter_within_cluster([mol1, mol2], rmsd_threshold=0.5)
+        assert len(result) == 2
+
+    def test_same_geometry_near_equal_energy_deduped(self):
+        """RMSD ~= 0 AND energies within tolerance => still a duplicate."""
+        mol1 = _create_mol_with_energy("C", -10.0)
+        mol2 = _create_mol_with_energy("C", -10.005)  # |dE| < default 0.01 eV
+        result = _filter_within_cluster([mol1, mol2], rmsd_threshold=0.5)
+        assert len(result) == 1
+
+    def test_energy_tol_is_configurable(self):
+        """A wide energy_tol collapses energy-distinct duplicates again."""
+        mol1 = _create_mol_with_energy("C", -10.0)
+        mol2 = _create_mol_with_energy("C", -10.5)
+        result = _filter_within_cluster(
+            [mol1, mol2], rmsd_threshold=0.5, energy_tol=1.0
+        )
+        assert len(result) == 1
+
     def test_different_conformers_returns_both(self):
         """Different conformers of the same molecule should be kept if RMSD > threshold."""
         # Create two conformers of the same molecule with different 3D coordinates
@@ -105,12 +132,16 @@ class TestFilterUniqueOptimized:
         assert energies == sorted(energies)
 
     def test_energy_clustering_groups_similar_energies(self):
-        """Molecules with similar energies should be clustered together."""
-        # Create molecules with energies in two distinct clusters
-        # Cluster 1: -10.0, -10.05 (within 0.1 eV window)
+        """Molecules with similar energies cluster together and dedup.
+
+        Two same-structure conformers whose energies agree within the duplicate
+        tolerance (and a third distinct molecule in its own cluster) reduce to
+        two survivors.
+        """
+        # Cluster 1: -10.0, -10.005 (same structure, |dE| < duplicate tol)
         # Cluster 2: -15.0
         mol1 = _create_mol_with_energy("C", -10.0)
-        mol2 = _create_mol_with_energy("C", -10.05)  # Same structure, should be removed
+        mol2 = _create_mol_with_energy("C", -10.005)  # within energy tol -> removed
         mol3 = _create_mol_with_energy("CCO", -15.0)
 
         result = filter_unique_optimized(
@@ -119,23 +150,28 @@ class TestFilterUniqueOptimized:
             energy_cluster_window=0.1
         )
 
-        # mol1 and mol2 are in same cluster and identical, so one removed
-        # mol3 is in different cluster
+        # mol1 and mol2 are in the same cluster, identical geometry AND
+        # near-equal energy, so one is removed; mol3 is a separate cluster.
         assert len(result) == 2
 
-    def test_large_energy_window_creates_single_cluster(self):
-        """Large energy window should group all molecules into one cluster."""
+    def test_single_cluster_energy_guard_keeps_distinct_energies(self):
+        """A large window puts everything in one cluster, but the energy guard
+        keeps same-geometry conformers whose energies differ beyond tolerance.
+
+        This is the O-H / N-H rotamer case at the optimized-filter level: heavy-
+        atom RMSD ~= 0 but distinct minima with different energies must survive.
+        """
         mol1 = _create_mol_with_energy("C", -10.0)
-        mol2 = _create_mol_with_energy("C", -15.0)  # Same structure
+        mol2 = _create_mol_with_energy("C", -15.0)  # same geometry, |dE| >> tol
 
         result = filter_unique_optimized(
             [mol1, mol2],
             rmsd_threshold=0.5,
-            energy_cluster_window=10.0  # Large window
+            energy_cluster_window=10.0  # one cluster
         )
 
-        # Same molecule type, should be deduplicated regardless of energy
-        assert len(result) == 1
+        # Different energies => not duplicates, both kept.
+        assert len(result) == 2
 
     def test_small_energy_window_creates_separate_clusters(self):
         """Small energy window should create separate clusters."""

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -276,3 +276,49 @@ def test_custom_model_adapter_runs(tmp_path):
     assert e.shape == (2,)
     assert f.shape == (2, 4, 3)
     assert torch.isfinite(e).all() and torch.isfinite(f).all()
+
+
+class TestValidateOutputs:
+    """_validate_outputs runs on every FIRE step; it must stay a no-op on finite
+    inputs (single combined sync) and still raise on NaN/Inf with a clear message.
+    """
+
+    def test_finite_outputs_pass(self):
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([-1.0, -2.0])
+        forces = torch.zeros(2, 3, 3)
+        assert _validate_outputs(energy, forces) is None
+
+    def test_nan_energy_raises(self):
+        from Auto3D.exceptions import NumericalError
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([float("nan"), -2.0])
+        forces = torch.zeros(2, 3, 3)
+        with pytest.raises(NumericalError, match="NaN.*energy"):
+            _validate_outputs(energy, forces)
+
+    def test_inf_energy_raises(self):
+        from Auto3D.exceptions import NumericalError
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([float("inf"), -2.0])
+        forces = torch.zeros(2, 3, 3)
+        with pytest.raises(NumericalError, match="Inf.*energy"):
+            _validate_outputs(energy, forces)
+
+    def test_nan_forces_raises(self):
+        from Auto3D.exceptions import NumericalError
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([-1.0, -2.0])
+        forces = torch.zeros(2, 3, 3)
+        forces[1, 0, 0] = float("nan")
+        with pytest.raises(NumericalError, match="NaN.*force"):
+            _validate_outputs(energy, forces)
+
+    def test_inf_forces_raises(self):
+        from Auto3D.exceptions import NumericalError
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([-1.0, -2.0])
+        forces = torch.zeros(2, 3, 3)
+        forces[0, 2, 1] = float("inf")
+        with pytest.raises(NumericalError, match="Inf.*force"):
+            _validate_outputs(energy, forces)

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -41,11 +41,13 @@ class TestConformerRankerWithOptimizedFiltering:
         """ConformerRanker should use optimized filtering by default."""
         from Auto3D.ranking import ConformerRanker
 
-        # Create test molecules - all with same SMILES root name
-        # Use close energies so they fall in same energy cluster (within 0.1 eV)
+        # Create test molecules - all with same SMILES root name.
+        # Identical geometry AND near-identical energy (within the duplicate
+        # energy tolerance, ~0.01 eV), as truly identical conformers would be,
+        # so they deduplicate to one.
         mol1 = _create_mol_with_energy("C", -10.0, "mol_1")
-        mol2 = _create_mol_with_energy("C", -10.05, "mol_2")  # Same structure, close energy
-        mol3 = _create_mol_with_energy("C", -10.08, "mol_3")  # Same structure, close energy
+        mol2 = _create_mol_with_energy("C", -10.005, "mol_2")  # same structure & energy
+        mol3 = _create_mol_with_energy("C", -10.008, "mol_3")  # same structure & energy
 
         input_path = str(tmp_path / "input.sdf")
         output_path = str(tmp_path / "output.sdf")
@@ -69,9 +71,10 @@ class TestConformerRankerWithOptimizedFiltering:
         """ConformerRanker should support legacy filtering when explicitly requested."""
         from Auto3D.ranking import ConformerRanker
 
-        # Create test molecules - all with same SMILES root name
+        # Same structure and near-identical energy (within the duplicate energy
+        # tolerance) -> one unique structure.
         mol1 = _create_mol_with_energy("C", -10.0, "mol_1")
-        mol2 = _create_mol_with_energy("C", -9.0, "mol_2")
+        mol2 = _create_mol_with_energy("C", -10.005, "mol_2")
 
         input_path = str(tmp_path / "input.sdf")
         output_path = str(tmp_path / "output.sdf")
@@ -98,10 +101,11 @@ class TestConformerRankerWithOptimizedFiltering:
         """
         from Auto3D.ranking import ConformerRanker
 
-        # Create identical molecules with same base name - these should be deduplicated
+        # Identical molecules (same structure AND near-identical energy, within
+        # the duplicate energy tolerance) - these should be deduplicated.
         mol1 = _create_mol_with_energy("CCCC", -10.0, "a_1")
-        mol2 = _create_mol_with_energy("CCCC", -10.05, "a_2")  # Same structure
-        mol3 = _create_mol_with_energy("CCCC", -10.08, "a_3")  # Same structure
+        mol2 = _create_mol_with_energy("CCCC", -10.005, "a_2")  # same structure & energy
+        mol3 = _create_mol_with_energy("CCCC", -10.008, "a_3")  # same structure & energy
 
         input_path = str(tmp_path / "input.sdf")
         output_optimized = str(tmp_path / "output_optimized.sdf")

--- a/tests/test_thermo_helpers.py
+++ b/tests/test_thermo_helpers.py
@@ -55,6 +55,31 @@ def test_symmetry_number_invalid_property_falls_back():
     assert _symmetry_number(m) == 1
 
 
+def test_resolve_multiplicity_closed_shell_is_singlet():
+    from rdkit import Chem
+    from Auto3D.ASE.thermo import _resolve_multiplicity
+    m = Chem.MolFromSmiles("CCO")
+    assert _resolve_multiplicity(m) == 1
+    # Derived multiplicity is recorded on the mol.
+    assert m.GetUnsignedProp("multiplicity") == 1
+
+
+def test_resolve_multiplicity_radical_is_doublet():
+    from rdkit import Chem
+    from Auto3D.ASE.thermo import _resolve_multiplicity
+    m = Chem.MolFromSmiles("[CH3]")  # methyl radical, 1 unpaired electron
+    assert _resolve_multiplicity(m) == 2
+    assert m.GetUnsignedProp("multiplicity") == 2
+
+
+def test_resolve_multiplicity_respects_explicit_property():
+    from rdkit import Chem
+    from Auto3D.ASE.thermo import _resolve_multiplicity
+    m = Chem.MolFromSmiles("[CH3]")  # would derive 2 ...
+    m.SetUnsignedProp("multiplicity", 4)  # ... but an explicit value wins
+    assert _resolve_multiplicity(m) == 4
+
+
 @pytest.mark.slow
 def test_load_hessian_model_aimnet(aimnet_hessian_model):
     m = aimnet_hessian_model

--- a/tests/test_utils_chemistry.py
+++ b/tests/test_utils_chemistry.py
@@ -531,6 +531,47 @@ class TestFilterUnique:
         # Should only keep one
         assert len(unique_mols) == 1
 
+    def test_same_geometry_different_energy_kept(self):
+        """Identical geometry but distinct E_tot must be kept (energy guard).
+
+        Heavy-atom RMSD ~= 0 but the two are distinct minima (the O-H rotamer
+        case); the energy guard must stop them collapsing into one.
+        """
+        from Auto3D.utils.chemistry import filter_unique
+
+        mol = Chem.MolFromSmiles("CCO")
+        mol = Chem.AddHs(mol)
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        AllChem.MMFFOptimizeMolecule(mol)
+        mol.SetProp("Converged", "true")
+        mol.SetProp("E_tot", "-10.0")
+
+        mol2 = Chem.Mol(mol)  # identical geometry
+        mol2.SetProp("Converged", "true")
+        mol2.SetProp("E_tot", "-10.5")  # |dE| >> tol
+
+        unique_mols = filter_unique([mol, mol2], crit=0.3)
+        assert len(unique_mols) == 2
+
+    def test_missing_energy_falls_back_to_rmsd_only(self):
+        """Without E_tot the energy guard cannot apply -> RMSD-only dedup.
+
+        Preserves the legacy behavior for callers that do not set E_tot.
+        """
+        from Auto3D.utils.chemistry import filter_unique
+
+        mol = Chem.MolFromSmiles("CCO")
+        mol = Chem.AddHs(mol)
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        AllChem.MMFFOptimizeMolecule(mol)
+        mol.SetProp("Converged", "true")  # no E_tot set
+
+        mol2 = Chem.Mol(mol)
+        mol2.SetProp("Converged", "true")
+
+        unique_mols = filter_unique([mol, mol2], crit=0.3)
+        assert len(unique_mols) == 1
+
     def test_filter_different_conformers(self):
         """Test that different conformers are kept."""
         from Auto3D.utils.chemistry import filter_unique

--- a/tests/test_utils_file_ops.py
+++ b/tests/test_utils_file_ops.py
@@ -93,6 +93,34 @@ class TestSmiles2Smi:
         assert output.exists()
         assert output.read_text() == ""
 
+    def test_colliding_inchikeys_get_distinct_ids(self, tmp_path):
+        """Two inputs that share an InChIKey must keep distinct IDs.
+
+        The same molecule written two ways (here benzene) yields one InChIKey;
+        without disambiguation reorder_sdf would collapse the duplicate IDs and
+        silently drop the second input. Each input must get its own line/ID.
+        """
+        output = tmp_path / "test.smi"
+
+        smiles2smi(["c1ccccc1", "C1=CC=CC=C1"], str(output))
+
+        lines = output.read_text().strip().split("\n")
+        assert len(lines) == 2
+        ids = [line.split()[1] for line in lines]
+        assert ids[0] != ids[1], "colliding InChIKeys must be disambiguated"
+        # First keeps the bare InChIKey; the repeat is suffixed.
+        assert ids[1] == f"{ids[0]}_2"
+
+    def test_distinct_inputs_keep_bare_inchikeys(self, tmp_path):
+        """Non-colliding inputs must keep their plain InChIKey IDs (no suffix)."""
+        output = tmp_path / "test.smi"
+
+        smiles2smi(["CCO", "CCC"], str(output))
+
+        ids = [line.split()[1] for line in output.read_text().strip().split("\n")]
+        assert ids[0] != ids[1]
+        assert all("_" not in i for i in ids)
+
 
 class TestGuessFileType:
     """Tests for guess_file_type function."""


### PR DESCRIPTION
Addresses the seven Major findings from a whole-codebase review.

### Silent data loss
- `smiles2mols()` disambiguates colliding InChIKeys instead of silently dropping the second input.
- RMSD dedup is energy-guarded so distinct O–H/N–H rotamers (same heavy-atom skeleton, different energy) survive.

### Thermochemistry correctness
- `ignore_imag_modes=True` so tiny artifact imaginary modes no longer discard a molecule's thermo.
- Entropy property renamed `S_hartree` → `S_hartree_per_K` (it is Hartree/K, not Hartree); example notebook updated.
- Multiplicity derived from radical electrons + warning that the NNP energy is closed-shell.

### Resource / performance
- CPU run with a list `gpu_idx` no longer spawns N contending workers (shared `optimizer_worker_indices` helper keeps spawn count and sentinel count in sync).
- `_validate_outputs` collapses 4 per-step GPU syncs to one `isfinite().all()` check.

Two reviewer findings were verified as false positives and intentionally not changed (FIRE displacement clamp matches ASE FIRE; the CLI already exits non-zero on failure).

Fast gate: 641 passed. New RDKit-only unit tests cover each fix; thermo/NNP and multiprocessing paths are exercised by the slow CI job.