### PR TITLE
Address minor bug-hunt findings: correctness fixes and documented limitations

### DIFF
--- a/example/reaction_thermodynamics.ipynb
+++ b/example/reaction_thermodynamics.ipynb
@@ -189,7 +189,7 @@
     "        if mol.HasProp(\"G_hartree\"):\n",
     "            G = float(mol.GetProp(\"G_hartree\")) * HARTREE_TO_KCAL\n",
     "            H = float(mol.GetProp(\"H_hartree\")) * HARTREE_TO_KCAL\n",
-    "            S = float(mol.GetProp(\"S_hartree\")) * HARTREE_TO_KCAL  # Already per K\n",
+    "            S = float(mol.GetProp(\"S_hartree_per_K\")) * HARTREE_TO_KCAL  # Already per K\n",
     "            E = float(mol.GetProp(\"E_hartree\")) * HARTREE_TO_KCAL\n",
     "            T = float(mol.GetProp(\"T_K\"))\n",
     "            \n",

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -33,7 +33,15 @@ logger = get_logger(__name__)
 
 
 def _is_collinear(atoms: ase.Atoms) -> bool:
-    """True if all atoms lie on a single line (within tolerance)."""
+    """True if all atoms lie on a single line (within tolerance).
+
+    The rank tolerance (1e-3, in Angstrom) is an absolute geometric threshold,
+    so a slightly bent but floppy molecule whose deviation from a line is below
+    ~1e-3 A is classified linear. That changes the vibrational DOF count
+    (3N-5 vs 3N-6) and the rotational partition function (1 vs 3 rotational
+    constants). A moment-of-inertia cross-check (one near-zero principal moment
+    => linear) would be more robust for borderline geometries; not done here.
+    """
     pos = atoms.get_positions()
     if len(pos) <= 2:
         return True
@@ -147,7 +155,14 @@ class Calculator(ase.calculators.calculator.Calculator):
 def mol2aimnet_input(mol: Chem.Mol, device=torch.device('cpu'), model_name='AIMNET') -> dict:
     """Converts sdf to aimnet input, assuming the sdf has only 1 conformer."""
     conf = mol.GetConformer()
-    coord = torch.tensor(conf.GetPositions(), device=device).unsqueeze(0)
+    # RDKit positions are float64; build the coordinate tensor as float32 to
+    # match the model weights (the other thermo entry point, Calculator.calculate,
+    # also feeds model-dtype coords). Passing fp64 coords to the fp32 model is a
+    # silent dtype mismatch; the energy/force adapters cast anyway, so fp32 is
+    # the consistent, lossless choice here.
+    coord = torch.tensor(
+        conf.GetPositions(), dtype=torch.float32, device=device
+    ).unsqueeze(0)
     numbers = torch.tensor([a.GetAtomicNum() for a in mol.GetAtoms()],
                             device=device).unsqueeze(0)
     charge = torch.tensor([Chem.GetFormalCharge(mol)], device=device, dtype=torch.float)
@@ -245,7 +260,7 @@ def do_mol_thermo(mol: Chem.Mol,
                   atoms: ase.Atoms,
                   model: torch.nn.Module,
                   device=torch.device('cpu'),
-                  T=298.0, model_name='AIMNET'):
+                  T=298.15, model_name='AIMNET'):
     """For a RDKit mol object, calculate its thermochemistry properties.
     model: ANI2xt or AIMNet2 or ANI2x or userNNP that can be used to calculate Hessian"""
     vib = vib_hessian(mol, atoms.get_calculator(), model, device, model_name=model_name)
@@ -282,6 +297,10 @@ def do_mol_thermo(mol: Chem.Mol,
     # ASE's get_entropy returns entropy in eV/K, so this value is Hartree/K, not
     # Hartree. Name the property accordingly so a downstream G = H - T*S
     # reconstruction is not off by a factor of T.
+    # Standard state is 1 atm (101325 Pa). ASE's internal reference is 1 bar
+    # (1e5 Pa), so this applies the -kB*T*ln(P/P_ref) correction to report G at
+    # 1 atm -- matching ORCA/Gaussian. The translational-entropy difference vs
+    # 1 bar is ~0.016 kcal/mol.
     S = thermo.get_entropy(temperature=T, pressure=101325) * ev2hatree
     G = thermo.get_gibbs_energy(temperature=T, pressure=101325) * ev2hatree
 
@@ -370,11 +389,25 @@ def calc_thermo(path: str, model_name: str, mol_info_func=None,
         model_name: ANI2x, ANI2xt, AIMNET or a path to a userNNP model.
         mol_info_func: A function that returns the name and temperature (idx, T)
             from a rdkit mol object. If not provided, the thermodynamic properties
-            will be calculated at 298 K.
+            will be calculated at 298.15 K.
         gpu_idx: GPU cuda index. Defaults to 0.
         opt_tol: Convergence threshold for geometry optimization. Defaults to 0.0002.
         opt_steps: Maximum geometry optimization steps. Defaults to 2000.
+
+    Notes:
+        Gibbs energies are reported at the 1 atm standard state (matching
+        ORCA/Gaussian). Rotational symmetry numbers default to 1 unless a
+        per-mol integer 'symmetry_number' property is set; for symmetric
+        molecules (e.g. benzene, sigma=12) the default over-counts rotational
+        entropy by up to a few kcal/mol in T*S, so set that property when known.
     """
+    # Surface the symmetry-number caveat once per run (not per molecule) so it is
+    # visible without spamming the log.
+    logger.info(
+        "Thermochemistry uses symmetry number sigma=1 unless a 'symmetry_number' "
+        "molecule property is set; set it for symmetric species to avoid "
+        "over-counting rotational entropy."
+    )
     # Prepare output name
     out_mols, mols_failed = [], []
     path_obj = Path(path)
@@ -403,7 +436,7 @@ def calc_thermo(path: str, model_name: str, mol_info_func=None,
 
         if mol_info_func is None:
             idx = mol.GetProp("_Name").strip()
-            T = 298
+            T = 298.15
         else:
             idx, T = mol_info_func(mol)
 

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -74,6 +74,32 @@ def _symmetry_number(mol: Chem.Mol) -> int:
     return 1
 
 
+def _resolve_multiplicity(mol: Chem.Mol) -> int:
+    """Spin multiplicity (2S+1) for IdealGasThermo's electronic-degeneracy term.
+
+    Uses an explicit integer 'multiplicity' molecule property when present.
+    Otherwise derives it from the radical-electron count
+    (multiplicity = unpaired electrons + 1) and records it on the mol, instead of
+    silently assuming a closed-shell singlet -- which would zero the electronic
+    entropy term for every radical. The NNP *energy* stays closed-shell
+    regardless (AIMNet2 takes only coords/species/charge, no spin), so warn for
+    open-shell species that the energy is an approximation.
+    """
+    if mol.HasProp("multiplicity"):
+        return mol.GetUnsignedProp("multiplicity")
+    n_radical = sum(a.GetNumRadicalElectrons() for a in mol.GetAtoms())
+    multiplicity = n_radical + 1
+    mol.SetUnsignedProp("multiplicity", int(multiplicity))
+    if n_radical > 0:
+        logger.warning(
+            "Open-shell species detected (%d unpaired electron(s), "
+            "multiplicity %d); the NNP energy is a closed-shell approximation.",
+            n_radical,
+            multiplicity,
+        )
+    return multiplicity
+
+
 class Calculator(ase.calculators.calculator.Calculator):
     """ASE calculator interface for AIMNET and ANI2xt"""
     implemented_properties = ['energy', 'forces']
@@ -227,8 +253,22 @@ def do_mol_thermo(mol: Chem.Mol,
     e = atoms.get_potential_energy()
     geometry = _detect_geometry(atoms)
     symmetry = _symmetry_number(mol)
-    multiplicity = mol.GetUnsignedProp("multiplicity") if mol.HasProp("multiplicity") else 1
+
+    multiplicity = _resolve_multiplicity(mol)
     spin = (multiplicity - 1) / 2.0
+
+    # NNP Hessians at the loose conformer-generation convergence threshold
+    # routinely yield one or two tiny artifact imaginary modes. Dropping them
+    # (ignore_imag_modes=True) keeps otherwise-valid thermochemistry instead of
+    # ASE raising ValueError and the whole molecule being discarded.
+    n_imag = int(np.sum(np.abs(np.imag(vib_e)) > 0))
+    if n_imag > 0:
+        logger.warning(
+            "%d imaginary vibrational mode(s) ignored in thermochemistry for "
+            "%s; treat the result as approximate.",
+            n_imag,
+            mol.GetProp("_Name") if mol.HasProp("_Name") else "molecule",
+        )
     thermo = IdealGasThermo(
         vib_energies=vib_e,
         potentialenergy=e,
@@ -236,13 +276,17 @@ def do_mol_thermo(mol: Chem.Mol,
         geometry=geometry,
         symmetrynumber=symmetry,
         spin=spin,
+        ignore_imag_modes=True,
     )
     H = thermo.get_enthalpy(temperature=T) * ev2hatree
+    # ASE's get_entropy returns entropy in eV/K, so this value is Hartree/K, not
+    # Hartree. Name the property accordingly so a downstream G = H - T*S
+    # reconstruction is not off by a factor of T.
     S = thermo.get_entropy(temperature=T, pressure=101325) * ev2hatree
     G = thermo.get_gibbs_energy(temperature=T, pressure=101325) * ev2hatree
 
     mol.SetProp("H_hartree", str(H))
-    mol.SetProp("S_hartree", str(S))
+    mol.SetProp("S_hartree_per_K", str(S))
     mol.SetProp("T_K", str(T))
     mol.SetProp("G_hartree", str(G))
     mol.SetProp("E_hartree", str(e * ev2hatree))

--- a/src/Auto3D/batch_opt/ANI2xt_no_rep.py
+++ b/src/Auto3D/batch_opt/ANI2xt_no_rep.py
@@ -164,6 +164,12 @@ class ANI2xt(nn.Module):
         else:
             species_idx = species
 
+        # Padded atoms carry species == species_pad == -1 (set by the batch
+        # padder). -1 is not in periodict2idx, so it survives unchanged here and
+        # is passed to the AEV computer, which relies on TorchANI's convention
+        # that a species index of -1 marks a dummy/masked atom (excluded from the
+        # AEV and the per-element energy loop below, where no elem_idx == -1).
+        # This correctness depends on -1 being TorchANI's masked-atom sentinel.
         # Compute AEVs (use new API: aev_computer(species, coords))
         aev = self.aev_computer(species_idx, coords)  # (batch, num_atoms, aev_dim)
 

--- a/src/Auto3D/batch_opt/batchopt.py
+++ b/src/Auto3D/batch_opt/batchopt.py
@@ -241,10 +241,12 @@ class optimizing:
             coord_pad=self.coord_pad, species_pad=self.species_pad
         )
 
-        with torch.jit.optimized_execution(False):
-            optdict = ensemble_opt(model, coord_padded, numbers_padded, charges,
-                                   self._config_dict, self.device,
-                                   species_pad=self.species_pad)  # Magic step
+        # torch.jit.optimized_execution only affects TorchScript modules; the
+        # default AIMNet2 path is eager and ANI uses torch.compile, so the old
+        # `with torch.jit.optimized_execution(False)` guard here was a no-op.
+        optdict = ensemble_opt(model, coord_padded, numbers_padded, charges,
+                               self._config_dict, self.device,
+                               species_pad=self.species_pad)  # Magic step
         return optdict
 
     def run(self):

--- a/src/Auto3D/batch_opt/optimization_engine.py
+++ b/src/Auto3D/batch_opt/optimization_engine.py
@@ -130,8 +130,11 @@ def n_steps(
     # The following two terms are used to detect oscillating conformers
     smallest_fmax0 = torch.tensor(np.ones((len(coord), 1)) * 999,
                                   dtype=torch.float).to(coord.device)
-    oscillating_count0 = torch.tensor(np.zeros(len(coord)),
-                                      dtype=torch.float).to(coord.device)
+    # Integer step counter (matches energy_stable_count below); only ever
+    # incremented by a bool mask and compared to `patience`, so use torch.long
+    # rather than float for a quantity that is conceptually an integer count.
+    oscillating_count0 = torch.zeros(len(coord), dtype=torch.long,
+                                     device=coord.device)
 
     # Energy-based convergence tracking
     prev_energy = torch.full((len(coord),), float('inf'), dtype=torch.double, device=coord.device)

--- a/src/Auto3D/batch_opt/padding.py
+++ b/src/Auto3D/batch_opt/padding.py
@@ -59,7 +59,9 @@ def pad_molecular_batch(
         dtype=torch.long,
         device=device
     )
-    charges_tensor = torch.tensor(charges, dtype=torch.long, device=device)
+    # Float (not long) for parity with pad_from_mols and the ASE Calculator, and
+    # to match the dtype the AIMNet2 adapter casts charges to (ANI ignores them).
+    charges_tensor = torch.tensor(charges, dtype=torch.float32, device=device)
 
     # Fill in actual values - create tensors directly on target device
     for i, (coord, spec) in enumerate(zip(coords, species, strict=True)):
@@ -136,6 +138,9 @@ def pad_from_mols(
 
         charges.append(rdmolops.GetFormalCharge(mol))
 
-    charges_tensor = torch.tensor(charges, dtype=torch.long, device=device)
+    # Float (not long) to match the ASE Calculator path (ASE/thermo.py) and the
+    # dtype the AIMNet2 adapter casts charges to internally; formal charges are
+    # integers exactly representable in float32, and ANI models ignore charge.
+    charges_tensor = torch.tensor(charges, dtype=torch.float32, device=device)
 
     return coords_tensor.requires_grad_(True), species_tensor, charges_tensor

--- a/src/Auto3D/cli/commands/run.py
+++ b/src/Auto3D/cli/commands/run.py
@@ -106,17 +106,20 @@ def execute_run(
         elapsed = time.time() - start_time
 
         # Build results from the real output file
-        from Auto3D.cli.results import count_from_output
+        from Auto3D.cli.results import count_from_output, count_input_molecules
         if output_path and Path(output_path).exists():
             molecules, conformers = count_from_output(str(output_path))
         else:
             molecules, conformers = 0, 0
+        # Failures = input molecules that produced no conformer. Per-molecule
+        # failure *details* are not yet wired through the workflow, but the count
+        # is recoverable as inputs minus produced molecules so the summary no
+        # longer always reports zero failures.
+        input_count = count_input_molecules(config.path) if config.path else 0
+        failed_count = max(0, input_count - molecules)
         results = WorkflowResults(
             success_count=molecules,
-            # NOTE: per-molecule failure capture is not yet wired through the
-            # workflow, so failed_count is always 0 here. Until that lands, the
-            # summary reflects what was produced, not what was dropped.
-            failed_count=0,
+            failed_count=failed_count,
             total_conformers=conformers,
             output_path=str(output_path) if output_path else "N/A",
             elapsed_seconds=elapsed,

--- a/src/Auto3D/cli/results.py
+++ b/src/Auto3D/cli/results.py
@@ -105,6 +105,27 @@ def print_failures(failures: list[FailedMolecule], verbose: bool = False) -> Non
         console.print("[dim]Run with -v to see details[/dim]")
 
 
+def count_input_molecules(input_path: str) -> int:
+    """Best-effort count of input molecules in a .smi or .sdf file.
+
+    Used to derive the failure count (inputs that produced no conformer) for the
+    results summary. Returns 0 for unrecognized extensions so the caller can fall
+    back gracefully.
+    """
+    from pathlib import Path
+
+    ext = Path(input_path).suffix.lower()
+    if ext == ".smi":
+        from Auto3D.utils.file_ops import iter_smi_records
+
+        return sum(1 for _ in iter_smi_records(input_path, on_malformed="skip"))
+    if ext == ".sdf":
+        from Auto3D.utils.file_ops import count_sdf
+
+        return count_sdf(input_path)
+    return 0
+
+
 def count_from_output(output_path: str) -> tuple[int, int]:
     """Return (unique_molecule_count, conformer_count) from an output SDF.
 

--- a/src/Auto3D/config.py
+++ b/src/Auto3D/config.py
@@ -22,6 +22,27 @@ from Auto3D.constants import (
 )
 
 
+def optimizer_worker_indices(
+    use_gpu: bool, gpu_idx: "int | list[int]"
+) -> list[int]:
+    """Return the per-process indices for the optimizer worker pool.
+
+    One worker per GPU when running on GPU with a list of indices; a single
+    worker otherwise. On CPU the index is unused (the worker runs on
+    ``torch.device('cpu')``), so a list of indices must NOT fan out into N
+    processes that all contend for the same cores -- that wastes memory (N model
+    loads) and risks OOM on a small box. The isomer worker uses this same count
+    to emit exactly one "Done" sentinel per optimizer, so both call sites must
+    agree to avoid deadlock.
+    """
+    if isinstance(gpu_idx, int):
+        return [gpu_idx]
+    if use_gpu:
+        return list(gpu_idx)
+    # CPU with a list of indices: collapse to a single worker (index unused).
+    return [gpu_idx[0] if gpu_idx else 0]
+
+
 @dataclass
 class Auto3DOptions:
     """Configuration options for Auto3D conformer generation.

--- a/src/Auto3D/constants.py
+++ b/src/Auto3D/constants.py
@@ -52,6 +52,15 @@ BUILTIN_ANI_MODELS = frozenset({MODEL_ANI2X.upper(), MODEL_ANI2XT.upper()})
 
 # Default optimization parameters
 DEFAULT_RMSD_THRESHOLD = 0.3  # Angstrom, for duplicate conformer removal
+# eV, energy tolerance for the duplicate-conformer test. RMSD dedup compares
+# heavy-atom skeletons only, so conformers differing solely in an O-H / N-H rotor
+# orientation collapse to RMSD~=0 even though they are distinct minima with
+# different energies. Two structures are treated as duplicates only when their
+# heavy-atom RMSD is below threshold AND their energies agree within this
+# tolerance, so genuine rotamers (which the H-rich conformer budget deliberately
+# samples) survive. ~0.23 kcal/mol -- above post-optimization fp32 energy noise
+# (~1e-3 eV) so truly identical conformers still dedup.
+DEFAULT_DUPLICATE_ENERGY_TOL = 0.01
 DEFAULT_CONVERGENCE_THRESHOLD = 0.01  # eV/Angstrom, force convergence
 DEFAULT_OPT_STEPS = 2000  # Maximum optimization steps
 DEFAULT_PATIENCE = 250  # Steps before dropping oscillating conformer

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -112,7 +112,7 @@ def _filter_within_cluster(
         e_i = _mol_energy(mol_i)
         is_unique = True
 
-        for mol_j_noH, e_j in zip(unique_noH, unique_energies):
+        for mol_j_noH, e_j in zip(unique_noH, unique_energies, strict=True):
             try:
                 # Temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # Removing Hs speeds up the calculation

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from rdkit import Chem
 from rdkit.Chem import rdMolAlign
 
-from Auto3D.constants import DEFAULT_ENERGY_CLUSTER_WINDOW, DEFAULT_RMSD_THRESHOLD
+from Auto3D.constants import (
+    DEFAULT_DUPLICATE_ENERGY_TOL,
+    DEFAULT_ENERGY_CLUSTER_WINDOW,
+    DEFAULT_RMSD_THRESHOLD,
+)
 from Auto3D.utils import check_connectivity
 
 
@@ -78,12 +82,18 @@ def filter_unique_optimized(
 def _filter_within_cluster(
     mols: list[Chem.Mol],
     rmsd_threshold: float,
+    energy_tol: float = DEFAULT_DUPLICATE_ENERGY_TOL,
 ) -> list[Chem.Mol]:
     """Filter unique molecules within an energy cluster.
 
     Args:
         mols: List of RDKit Mol objects to filter.
         rmsd_threshold: RMSD threshold for considering structures similar (Angstrom).
+        energy_tol: Energy tolerance (eV). A pair is treated as duplicate only
+            when the heavy-atom RMSD is below ``rmsd_threshold`` AND the energies
+            agree within this tolerance, so conformers that differ only in an
+            O-H / N-H rotor orientation (RMSD~=0 on heavy atoms but distinct
+            minima with different energies) are preserved.
 
     Returns:
         List of unique molecules within the cluster.
@@ -96,11 +106,13 @@ def _filter_within_cluster(
     # ORIGINAL (H-explicit) mols are returned; no-H forms are comparison-only.
     unique: list[Chem.Mol] = []
     unique_noH: list[Chem.Mol] = []
+    unique_energies: list[float] = []
     for mol_i in mols:
         mol_i_noH = Chem.RemoveHs(mol_i)
+        e_i = _mol_energy(mol_i)
         is_unique = True
 
-        for mol_j_noH in unique_noH:
+        for mol_j_noH, e_j in zip(unique_noH, unique_energies):
             try:
                 # Temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # Removing Hs speeds up the calculation
@@ -108,12 +120,31 @@ def _filter_within_cluster(
             except RuntimeError:
                 rmsd = float("inf")  # incomparable pair -> treat as distinct
 
-            if rmsd < rmsd_threshold:
+            # Heavy-atom RMSD alone collapses distinct H-rotamers; require the
+            # energies to also agree before declaring a duplicate. Missing/NaN
+            # energy => fall back to RMSD-only (energy guard cannot apply).
+            energy_close = (
+                e_i is None or e_j is None or abs(e_i - e_j) < energy_tol
+            )
+            if rmsd < rmsd_threshold and energy_close:
                 is_unique = False
                 break
 
         if is_unique:
             unique.append(mol_i)
             unique_noH.append(mol_i_noH)
+            unique_energies.append(e_i)
 
     return unique
+
+
+def _mol_energy(mol: Chem.Mol) -> float | None:
+    """Return a mol's optimized energy (eV) from the ``E_tot`` property, or None.
+
+    Used by the duplicate-conformer test as an energy guard; ``None`` signals
+    "no usable energy" so callers fall back to RMSD-only comparison.
+    """
+    try:
+        return float(mol.GetProp("E_tot"))
+    except (KeyError, ValueError):
+        return None

--- a/src/Auto3D/models/adapter.py
+++ b/src/Auto3D/models/adapter.py
@@ -52,6 +52,14 @@ def _validate_outputs(energy: torch.Tensor, forces: torch.Tensor) -> None:
     Raises:
         NumericalError: If NaN or Inf values are detected.
     """
+    # This runs on every NN forward, i.e. every FIRE step. Each `.any()`/`.item()`
+    # on a CUDA tensor is a host-device sync that serializes the stream, so the
+    # happy path (finite outputs) does a SINGLE combined reduction. The detailed,
+    # additionally-synchronizing NaN/Inf breakdown is computed only on the rare
+    # failure branch, where one extra sync is irrelevant.
+    if bool(torch.isfinite(energy).all() & torch.isfinite(forces).all()):
+        return
+
     if torch.isnan(energy).any():
         nan_count = torch.isnan(energy).sum().item()
         raise NumericalError(

--- a/src/Auto3D/ranking.py
+++ b/src/Auto3D/ranking.py
@@ -167,22 +167,24 @@ class ConformerRanker:
         logger.info("Begin to select structures that satisfy the requirements...")
         results = []
 
-        supplier = Chem.SDMolSupplier(self.input_path, removeHs=False)
         mols, names, energies = [], [], []
-        for mol in supplier:
-            if mol is None:
-                continue
-            # Guard the Converged read: a record lacking the property is
-            # treated as not-converged and skipped, matching the lenient
-            # pattern the RMSD filters use (filter_unique / filtering).
-            try:
-                converged = mol.GetProp('Converged').lower() == 'true'
-            except KeyError:
-                converged = False
-            if converged:
-                mols.append(mol)
-                names.append(mol.GetProp('_Name').strip().split("_")[0].strip())
-                energies.append(float(mol.GetProp('E_tot')))
+        # Context-managed so the SDF file handle is released promptly rather than
+        # left to GC. The mols are materialized into `mols` inside the block.
+        with Chem.SDMolSupplier(self.input_path, removeHs=False) as supplier:
+            for mol in supplier:
+                if mol is None:
+                    continue
+                # Guard the Converged read: a record lacking the property is
+                # treated as not-converged and skipped, matching the lenient
+                # pattern the RMSD filters use (filter_unique / filtering).
+                try:
+                    converged = mol.GetProp('Converged').lower() == 'true'
+                except KeyError:
+                    converged = False
+                if converged:
+                    mols.append(mol)
+                    names.append(mol.GetProp('_Name').strip().split("_")[0].strip())
+                    energies.append(float(mol.GetProp('E_tot')))
 
         df = pd.DataFrame({"names": names, "energies": energies, "mols": mols})
         groups = df.groupby("names")

--- a/src/Auto3D/tautomer.py
+++ b/src/Auto3D/tautomer.py
@@ -18,8 +18,17 @@ def select_tautomers(sdf: str, k: int | None = None, window: float | None = None
     Only k or window needs to be specified, NOT both.
 
     sdf: main function output
-    
-    Output: the path of the low-energy tautomer 3D conformers"""
+
+    Output: the path of the low-energy tautomer 3D conformers
+
+    Note:
+        Tautomers are ranked by the optimized NNP *electronic* energy (``E_tot``)
+        only -- no zero-point energy or thermal/entropy correction. Tautomer
+        equilibria (e.g. keto/enol, 2-pyridone/2-hydroxypyridine) are often
+        decided by ZPE/entropy differences of 1-2 kcal/mol that can invert the
+        electronic-energy ordering, so the "most stable" tautomer here is an
+        electronic-energy estimate, not a free-energy one. Use the thermo module
+        (Auto3D.ASE.thermo) for a free-energy comparison when that matters."""
     logger.info("Begin to select stable tautomers based on their conformer energies...")
     results = []
     if (k is not None) and (window is not None):

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -274,8 +274,14 @@ def check_connectivity(mol: Chem.Mol) -> bool:
     """
     # Initialize UFF bond radii (Rappe et al. JACS 1992)
     # Units of angstroms
-    # These radii neglect the bond-order and electronegativity corrections in the original paper.
-    # Where several values exist for the same atom, the largest was used.
+    # These radii neglect the bond-order and electronegativity corrections in the
+    # original paper. Where several values exist for the same atom, the largest
+    # was used. Consequence: a single bond-order-blind reference length makes the
+    # broken-bond (1.25x) check lenient and the formed-bond (1.1x) check strict,
+    # so a stretched aromatic/conjugated bond or a short multiple bond can be
+    # mis-judged. The molecular graph already carries bond orders (see
+    # get_mol_connectivity); a bond-order-aware reference would be more accurate
+    # but is intentionally not used here.
     Radii = {
         1: 0.354,
         5: 0.838,

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -528,7 +528,7 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
         except (KeyError, ValueError):
             e_i = None
         unique = True
-        for mol_j_noH, e_j in zip(unique_noH, unique_energies):
+        for mol_j_noH, e_j in zip(unique_noH, unique_energies, strict=True):
             try:
                 # temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # removing Hs speeds up the calculation

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -20,6 +20,7 @@ from Auto3D.constants import (
     CONFORMER_MULTIPLIER,
     CONFORMER_ROTATABLE_COEFF,
     CONFORMER_ROTATABLE_EXP,
+    DEFAULT_DUPLICATE_ENERGY_TOL,
     DEFAULT_RMSD_THRESHOLD,
     EV_TO_KCAL_PER_MOL,
     HARTREE_TO_EV,
@@ -511,12 +512,23 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
     # both sides of every comparison (O(n^2)); GetBestRMS on no-H forms is
     # symmetric so results are unchanged. The ORIGINAL (H-explicit) mols are
     # returned; no-H forms are comparison-only.
+    #
+    # Heavy-atom RMSD alone collapses conformers that differ only in an O-H / N-H
+    # rotor orientation. Guard with an energy check: a pair counts as duplicate
+    # only when the RMSD is below ``crit`` AND the energies agree within
+    # DEFAULT_DUPLICATE_ENERGY_TOL. Mols without a usable 'E_tot' fall back to
+    # RMSD-only (energy guard cannot apply).
     unique_mols: list[Chem.Mol] = []
     unique_noH: list[Chem.Mol] = []
+    unique_energies: list[float | None] = []
     for mol_i in mols:
         mol_i_noH = Chem.RemoveHs(mol_i)
+        try:
+            e_i: float | None = float(mol_i.GetProp("E_tot"))
+        except (KeyError, ValueError):
+            e_i = None
         unique = True
-        for mol_j_noH in unique_noH:
+        for mol_j_noH, e_j in zip(unique_noH, unique_energies):
             try:
                 # temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # removing Hs speeds up the calculation
@@ -526,10 +538,16 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
                 # conformer is kept. Using 0 would make it look like a perfect
                 # duplicate and drop a genuinely distinct structure.
                 rmsd = float("inf")
-            if rmsd < crit:
+            energy_close = (
+                e_i is None
+                or e_j is None
+                or abs(e_i - e_j) < DEFAULT_DUPLICATE_ENERGY_TOL
+            )
+            if rmsd < crit and energy_close:
                 unique = False
                 break
         if unique:
             unique_mols.append(mol_i)
             unique_noH.append(mol_i_noH)
+            unique_energies.append(e_i)
     return unique_mols

--- a/src/Auto3D/utils/file_ops.py
+++ b/src/Auto3D/utils/file_ops.py
@@ -98,6 +98,7 @@ def smiles2smi(smiles: list[str], path: str) -> str:
         # CCC  ATUOYWHBWRKTHZ-UHFFFAOYSA-N
     """
     lines = []
+    seen_ids: dict[str, int] = {}
     for idx, smi in enumerate(smiles):
         mol = Chem.MolFromSmiles(smi)
         if mol is None:
@@ -106,7 +107,25 @@ def smiles2smi(smiles: list[str], path: str) -> str:
                 "by RDKit."
             )
         inchikey = inchi.MolToInchiKey(mol)
-        lines.append(f"{smi}  {inchikey}\n")
+        # Distinct inputs can share a standard InChIKey (e.g. tautomers the
+        # standard InChIKey conflates, or the same molecule written two ways).
+        # The InChIKey is used as the molecule's unique ID downstream, and
+        # reorder_sdf collapses duplicate IDs -- so a colliding input would be
+        # silently dropped. Disambiguate by suffixing repeats (_2, _3, ...) so
+        # every input keeps its own conformers. The suffix stays a single
+        # whitespace-delimited token and round-trips through enumeration.
+        count = seen_ids.get(inchikey, 0) + 1
+        seen_ids[inchikey] = count
+        mol_id = inchikey if count == 1 else f"{inchikey}_{count}"
+        if count > 1:
+            logger.info(
+                "Input SMILES %r shares InChIKey %s with an earlier input; "
+                "assigning disambiguated id %s so it is not dropped.",
+                smi,
+                inchikey,
+                mol_id,
+            )
+        lines.append(f"{smi}  {mol_id}\n")
 
     with open(path, "w+") as f:
         for line in lines:

--- a/src/Auto3D/utils/file_ops.py
+++ b/src/Auto3D/utils/file_ops.py
@@ -479,7 +479,10 @@ def combine_smi(smies: list[str], out: str) -> None:
         with open(smi) as f:
             datai = f.readlines()
         data += datai
-    data = list(set(data))
+    # Order-preserving dedup: list(set(...)) randomizes line order across runs
+    # (hash seed), making the combined output non-deterministic. dict.fromkeys
+    # keeps first-seen order while removing exact duplicates.
+    data = list(dict.fromkeys(data))
     with open(out, "w+") as f2:
         for line in data:
             if not line.isspace():
@@ -562,13 +565,17 @@ def encode_ids(path: str) -> tuple[str, dict[str, int]]:
         mapping: dict[str, int] = {}
         # iter_smi_records raises InputValidationError on a <2-token line
         # (on_malformed="raise"). Duplicate-id detection stays here because the
-        # helper does not dedup. The 0-based index `i` preserves the original
-        # byte-identical mapping/output (line_no is 1-based).
-        for line_no, smi, id in iter_smi_records(path, on_malformed="raise"):
-            i = line_no - 1
+        # helper does not dedup. Index by a dense record counter, not the file
+        # line number: blank/skipped lines would otherwise leave gaps in the
+        # index space, which is inconsistent with the dense positions the chunk
+        # manager assumes downstream. The original file line_no is still used in
+        # the error message so it points at the real offending line.
+        for i, (line_no, smi, id) in enumerate(
+            iter_smi_records(path, on_malformed="raise")
+        ):
             if id in mapping:
                 raise InputValidationError(
-                    f"Duplicate molecule ID {id!r} on line {i + 1}. "
+                    f"Duplicate molecule ID {id!r} on line {line_no}. "
                     "IDs must be unique."
                 )
             mapping[id] = i

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -16,7 +16,7 @@ from Auto3D.config import Auto3DOptions, optimizer_worker_indices
 from Auto3D.exceptions import ConfigurationError, FileFormatError, OptimizationError
 from Auto3D.model_factory import ModelFactory
 from Auto3D.torch_config import TorchConfig, configure_torch
-from Auto3D.utils import check_input, reorder_sdf
+from Auto3D.utils import check_input, check_valid_configuration, reorder_sdf
 from Auto3D.utils.file_ops import decode_ids, encode_ids
 from Auto3D.utils.logging_config import get_logger
 from Auto3D.workflow_workers import (
@@ -146,6 +146,27 @@ class WorkflowOrchestrator:
         # Generate job name if not provided
         if self.config.job_name == "":
             self.config.job_name = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+
+        # Fail fast on an invalid configuration (notably an out-of-range gpu_idx).
+        # Without this the bad index only surfaces deep inside a spawned worker as
+        # an opaque "no structure converged". check_valid_configuration already
+        # validates the index against torch.cuda.device_count(); reuse it.
+        config_errors = check_valid_configuration(
+            path=self.config.path,
+            k=self.config.k,
+            window=self.config.window,
+            use_gpu=self.config.use_gpu,
+            gpu_idx=self.config.gpu_idx,
+            optimizing_engine=self.config.optimizing_engine,
+            isomer_engine=self.config.isomer_engine,
+            opt_steps=self.config.opt_steps,
+            enumerate_tautomer=self.config.enumerate_tautomer,
+            tauto_engine=self.config.tauto_engine,
+        )
+        if config_errors:
+            raise ConfigurationError(
+                "Invalid configuration:\n  - " + "\n  - ".join(config_errors)
+            )
 
         check_input(self.config)
 

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import Auto3D
 from Auto3D.chunk_manager import ChunkManager
-from Auto3D.config import Auto3DOptions
+from Auto3D.config import Auto3DOptions, optimizer_worker_indices
 from Auto3D.exceptions import ConfigurationError, FileFormatError, OptimizationError
 from Auto3D.model_factory import ModelFactory
 from Auto3D.torch_config import TorchConfig, configure_torch
@@ -268,23 +268,21 @@ class WorkflowOrchestrator:
             args=(chunk_info, self.config, chunk_queue, self.logging_queue),
         )
 
-        # Create optimization processes (one per GPU or single for CPU)
+        # Create optimization processes: one per GPU when running on GPU with a
+        # list of indices, a single worker otherwise. A CPU run with a list of
+        # gpu_idx must NOT spawn N processes all contending for the same cores
+        # (N model loads -> OOM risk); optimizer_worker_indices collapses that to
+        # one, and the isomer worker derives its sentinel count the same way.
         p2s: list[mp.Process] = []
-        if isinstance(self.config.gpu_idx, int):
+        for idx in optimizer_worker_indices(
+            self.config.use_gpu, self.config.gpu_idx
+        ):
             p2s.append(
                 mp.Process(
                     target=optim_rank_wrapper,
-                    args=(opt_config, chunk_queue, self.logging_queue, self.config.gpu_idx),
+                    args=(opt_config, chunk_queue, self.logging_queue, idx),
                 )
             )
-        else:
-            for idx in self.config.gpu_idx:
-                p2s.append(
-                    mp.Process(
-                        target=optim_rank_wrapper,
-                        args=(opt_config, chunk_queue, self.logging_queue, idx),
-                    )
-                )
 
         # Start all processes
         p1.start()

--- a/src/Auto3D/workflow_workers.py
+++ b/src/Auto3D/workflow_workers.py
@@ -20,6 +20,7 @@ from rdkit import Chem
 from send2trash import send2trash
 
 from Auto3D.batch_opt.batchopt import optimizing
+from Auto3D.config import optimizer_worker_indices
 from Auto3D.isomers import IsomerEngineFactory
 from Auto3D.processors import TautomerProcessor
 from Auto3D.ranking import ranking
@@ -57,10 +58,9 @@ def isomer_wrapper(
     # Each optimizer blocks on queue.get() until it receives a "Done" sentinel,
     # so we must emit exactly one sentinel per optimizer in a `finally` block to
     # avoid deadlocking the optimizers when isomer generation fails partway.
-    if isinstance(args.gpu_idx, int):
-        n_optimizers = 1
-    else:
-        n_optimizers = len(args.gpu_idx)
+    # Use the same rule as the spawn site (a CPU run with a list of gpu_idx runs
+    # a single optimizer, not one per index) so the counts cannot drift.
+    n_optimizers = len(optimizer_worker_indices(args.use_gpu, args.gpu_idx))
 
     try:
         for i, path_dir in enumerate(chunk_info):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,3 +183,30 @@ def test_default_and_valid_k_window_accepted():
     Auto3DOptions(path="x.smi", k=5)
     Auto3DOptions(path="x.smi", window=2.0)
     Auto3DOptions(path="x.smi", k=0)  # 0 is "not specified", allowed
+
+
+class TestOptimizerWorkerIndices:
+    """One optimizer process per GPU on GPU; a single worker otherwise.
+
+    A CPU run with a list of gpu_idx must collapse to ONE worker (the index is
+    unused on CPU) so N processes do not contend for the same cores / load the
+    model N times. The spawn site and the isomer worker's sentinel count both
+    derive from this, so they cannot drift.
+    """
+
+    def test_single_int_index(self):
+        from Auto3D.config import optimizer_worker_indices
+        assert optimizer_worker_indices(True, 0) == [0]
+        assert optimizer_worker_indices(False, 2) == [2]
+
+    def test_gpu_list_fans_out(self):
+        from Auto3D.config import optimizer_worker_indices
+        assert optimizer_worker_indices(True, [0, 1, 2]) == [0, 1, 2]
+
+    def test_cpu_list_collapses_to_one(self):
+        from Auto3D.config import optimizer_worker_indices
+        assert optimizer_worker_indices(False, [0, 1]) == [0]
+
+    def test_cpu_empty_list_is_safe(self):
+        from Auto3D.config import optimizer_worker_indices
+        assert optimizer_worker_indices(False, []) == [0]

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -41,6 +41,33 @@ class TestFilterWithinCluster:
         result = _filter_within_cluster([mol1, mol2], rmsd_threshold=0.5)
         assert len(result) == 1
 
+    def test_same_geometry_different_energy_kept(self):
+        """Same heavy-atom geometry but distinct energy must NOT be deduped.
+
+        Mirrors the O-H / N-H rotamer case: heavy-atom RMSD ~= 0 but the two are
+        distinct minima with different energies. The energy guard must keep both.
+        """
+        mol1 = _create_mol_with_energy("C", -10.0)
+        mol2 = _create_mol_with_energy("C", -10.5)  # RMSD~=0, |dE| >> tol
+        result = _filter_within_cluster([mol1, mol2], rmsd_threshold=0.5)
+        assert len(result) == 2
+
+    def test_same_geometry_near_equal_energy_deduped(self):
+        """RMSD ~= 0 AND energies within tolerance => still a duplicate."""
+        mol1 = _create_mol_with_energy("C", -10.0)
+        mol2 = _create_mol_with_energy("C", -10.005)  # |dE| < default 0.01 eV
+        result = _filter_within_cluster([mol1, mol2], rmsd_threshold=0.5)
+        assert len(result) == 1
+
+    def test_energy_tol_is_configurable(self):
+        """A wide energy_tol collapses energy-distinct duplicates again."""
+        mol1 = _create_mol_with_energy("C", -10.0)
+        mol2 = _create_mol_with_energy("C", -10.5)
+        result = _filter_within_cluster(
+            [mol1, mol2], rmsd_threshold=0.5, energy_tol=1.0
+        )
+        assert len(result) == 1
+
     def test_different_conformers_returns_both(self):
         """Different conformers of the same molecule should be kept if RMSD > threshold."""
         # Create two conformers of the same molecule with different 3D coordinates
@@ -105,12 +132,16 @@ class TestFilterUniqueOptimized:
         assert energies == sorted(energies)
 
     def test_energy_clustering_groups_similar_energies(self):
-        """Molecules with similar energies should be clustered together."""
-        # Create molecules with energies in two distinct clusters
-        # Cluster 1: -10.0, -10.05 (within 0.1 eV window)
+        """Molecules with similar energies cluster together and dedup.
+
+        Two same-structure conformers whose energies agree within the duplicate
+        tolerance (and a third distinct molecule in its own cluster) reduce to
+        two survivors.
+        """
+        # Cluster 1: -10.0, -10.005 (same structure, |dE| < duplicate tol)
         # Cluster 2: -15.0
         mol1 = _create_mol_with_energy("C", -10.0)
-        mol2 = _create_mol_with_energy("C", -10.05)  # Same structure, should be removed
+        mol2 = _create_mol_with_energy("C", -10.005)  # within energy tol -> removed
         mol3 = _create_mol_with_energy("CCO", -15.0)
 
         result = filter_unique_optimized(
@@ -119,23 +150,28 @@ class TestFilterUniqueOptimized:
             energy_cluster_window=0.1
         )
 
-        # mol1 and mol2 are in same cluster and identical, so one removed
-        # mol3 is in different cluster
+        # mol1 and mol2 are in the same cluster, identical geometry AND
+        # near-equal energy, so one is removed; mol3 is a separate cluster.
         assert len(result) == 2
 
-    def test_large_energy_window_creates_single_cluster(self):
-        """Large energy window should group all molecules into one cluster."""
+    def test_single_cluster_energy_guard_keeps_distinct_energies(self):
+        """A large window puts everything in one cluster, but the energy guard
+        keeps same-geometry conformers whose energies differ beyond tolerance.
+
+        This is the O-H / N-H rotamer case at the optimized-filter level: heavy-
+        atom RMSD ~= 0 but distinct minima with different energies must survive.
+        """
         mol1 = _create_mol_with_energy("C", -10.0)
-        mol2 = _create_mol_with_energy("C", -15.0)  # Same structure
+        mol2 = _create_mol_with_energy("C", -15.0)  # same geometry, |dE| >> tol
 
         result = filter_unique_optimized(
             [mol1, mol2],
             rmsd_threshold=0.5,
-            energy_cluster_window=10.0  # Large window
+            energy_cluster_window=10.0  # one cluster
         )
 
-        # Same molecule type, should be deduplicated regardless of energy
-        assert len(result) == 1
+        # Different energies => not duplicates, both kept.
+        assert len(result) == 2
 
     def test_small_energy_window_creates_separate_clusters(self):
         """Small energy window should create separate clusters."""

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -276,3 +276,49 @@ def test_custom_model_adapter_runs(tmp_path):
     assert e.shape == (2,)
     assert f.shape == (2, 4, 3)
     assert torch.isfinite(e).all() and torch.isfinite(f).all()
+
+
+class TestValidateOutputs:
+    """_validate_outputs runs on every FIRE step; it must stay a no-op on finite
+    inputs (single combined sync) and still raise on NaN/Inf with a clear message.
+    """
+
+    def test_finite_outputs_pass(self):
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([-1.0, -2.0])
+        forces = torch.zeros(2, 3, 3)
+        assert _validate_outputs(energy, forces) is None
+
+    def test_nan_energy_raises(self):
+        from Auto3D.exceptions import NumericalError
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([float("nan"), -2.0])
+        forces = torch.zeros(2, 3, 3)
+        with pytest.raises(NumericalError, match="NaN.*energy"):
+            _validate_outputs(energy, forces)
+
+    def test_inf_energy_raises(self):
+        from Auto3D.exceptions import NumericalError
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([float("inf"), -2.0])
+        forces = torch.zeros(2, 3, 3)
+        with pytest.raises(NumericalError, match="Inf.*energy"):
+            _validate_outputs(energy, forces)
+
+    def test_nan_forces_raises(self):
+        from Auto3D.exceptions import NumericalError
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([-1.0, -2.0])
+        forces = torch.zeros(2, 3, 3)
+        forces[1, 0, 0] = float("nan")
+        with pytest.raises(NumericalError, match="NaN.*force"):
+            _validate_outputs(energy, forces)
+
+    def test_inf_forces_raises(self):
+        from Auto3D.exceptions import NumericalError
+        from Auto3D.models.adapter import _validate_outputs
+        energy = torch.tensor([-1.0, -2.0])
+        forces = torch.zeros(2, 3, 3)
+        forces[0, 2, 1] = float("inf")
+        with pytest.raises(NumericalError, match="Inf.*force"):
+            _validate_outputs(energy, forces)

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -202,6 +202,19 @@ class TestPadFromMols:
         assert q[0].item() == 0   # Methane is neutral
         assert q[1].item() == -1  # Hydroxide has -1 charge
 
+    def test_charges_are_float(self):
+        """Charges are float (parity with the ASE Calculator / AIMNet2 cast)."""
+        mol = Chem.AddHs(Chem.MolFromSmiles("[O-]"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        device = torch.device("cpu")
+
+        _, _, q_mols = pad_from_mols([mol], "AIMNET", device,
+                                     coord_pad=0.0, species_pad=0)
+        _, _, q_batch = pad_molecular_batch([[(0.0, 0.0, 0.0)]], [[8]], [-1],
+                                            device, coord_pad=0.0, species_pad=0)
+        assert q_mols.dtype == torch.float32
+        assert q_batch.dtype == torch.float32
+
     def test_coords_match_conformer(self):
         """Coordinates should match RDKit conformer positions."""
         mol = Chem.AddHs(Chem.MolFromSmiles("C"))

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -41,11 +41,13 @@ class TestConformerRankerWithOptimizedFiltering:
         """ConformerRanker should use optimized filtering by default."""
         from Auto3D.ranking import ConformerRanker
 
-        # Create test molecules - all with same SMILES root name
-        # Use close energies so they fall in same energy cluster (within 0.1 eV)
+        # Create test molecules - all with same SMILES root name.
+        # Identical geometry AND near-identical energy (within the duplicate
+        # energy tolerance, ~0.01 eV), as truly identical conformers would be,
+        # so they deduplicate to one.
         mol1 = _create_mol_with_energy("C", -10.0, "mol_1")
-        mol2 = _create_mol_with_energy("C", -10.05, "mol_2")  # Same structure, close energy
-        mol3 = _create_mol_with_energy("C", -10.08, "mol_3")  # Same structure, close energy
+        mol2 = _create_mol_with_energy("C", -10.005, "mol_2")  # same structure & energy
+        mol3 = _create_mol_with_energy("C", -10.008, "mol_3")  # same structure & energy
 
         input_path = str(tmp_path / "input.sdf")
         output_path = str(tmp_path / "output.sdf")
@@ -69,9 +71,10 @@ class TestConformerRankerWithOptimizedFiltering:
         """ConformerRanker should support legacy filtering when explicitly requested."""
         from Auto3D.ranking import ConformerRanker
 
-        # Create test molecules - all with same SMILES root name
+        # Same structure and near-identical energy (within the duplicate energy
+        # tolerance) -> one unique structure.
         mol1 = _create_mol_with_energy("C", -10.0, "mol_1")
-        mol2 = _create_mol_with_energy("C", -9.0, "mol_2")
+        mol2 = _create_mol_with_energy("C", -10.005, "mol_2")
 
         input_path = str(tmp_path / "input.sdf")
         output_path = str(tmp_path / "output.sdf")
@@ -98,10 +101,11 @@ class TestConformerRankerWithOptimizedFiltering:
         """
         from Auto3D.ranking import ConformerRanker
 
-        # Create identical molecules with same base name - these should be deduplicated
+        # Identical molecules (same structure AND near-identical energy, within
+        # the duplicate energy tolerance) - these should be deduplicated.
         mol1 = _create_mol_with_energy("CCCC", -10.0, "a_1")
-        mol2 = _create_mol_with_energy("CCCC", -10.05, "a_2")  # Same structure
-        mol3 = _create_mol_with_energy("CCCC", -10.08, "a_3")  # Same structure
+        mol2 = _create_mol_with_energy("CCCC", -10.005, "a_2")  # same structure & energy
+        mol3 = _create_mol_with_energy("CCCC", -10.008, "a_3")  # same structure & energy
 
         input_path = str(tmp_path / "input.sdf")
         output_optimized = str(tmp_path / "output_optimized.sdf")

--- a/tests/test_thermo_helpers.py
+++ b/tests/test_thermo_helpers.py
@@ -55,6 +55,31 @@ def test_symmetry_number_invalid_property_falls_back():
     assert _symmetry_number(m) == 1
 
 
+def test_resolve_multiplicity_closed_shell_is_singlet():
+    from rdkit import Chem
+    from Auto3D.ASE.thermo import _resolve_multiplicity
+    m = Chem.MolFromSmiles("CCO")
+    assert _resolve_multiplicity(m) == 1
+    # Derived multiplicity is recorded on the mol.
+    assert m.GetUnsignedProp("multiplicity") == 1
+
+
+def test_resolve_multiplicity_radical_is_doublet():
+    from rdkit import Chem
+    from Auto3D.ASE.thermo import _resolve_multiplicity
+    m = Chem.MolFromSmiles("[CH3]")  # methyl radical, 1 unpaired electron
+    assert _resolve_multiplicity(m) == 2
+    assert m.GetUnsignedProp("multiplicity") == 2
+
+
+def test_resolve_multiplicity_respects_explicit_property():
+    from rdkit import Chem
+    from Auto3D.ASE.thermo import _resolve_multiplicity
+    m = Chem.MolFromSmiles("[CH3]")  # would derive 2 ...
+    m.SetUnsignedProp("multiplicity", 4)  # ... but an explicit value wins
+    assert _resolve_multiplicity(m) == 4
+
+
 @pytest.mark.slow
 def test_load_hessian_model_aimnet(aimnet_hessian_model):
     m = aimnet_hessian_model

--- a/tests/test_thermo_helpers.py
+++ b/tests/test_thermo_helpers.py
@@ -80,6 +80,13 @@ def test_resolve_multiplicity_respects_explicit_property():
     assert _resolve_multiplicity(m) == 4
 
 
+def test_do_mol_thermo_default_temperature_is_298_15():
+    """Reference temperature must be the thermochemistry standard 298.15 K."""
+    import inspect
+    from Auto3D.ASE.thermo import do_mol_thermo
+    assert inspect.signature(do_mol_thermo).parameters["T"].default == 298.15
+
+
 @pytest.mark.slow
 def test_load_hessian_model_aimnet(aimnet_hessian_model):
     m = aimnet_hessian_model

--- a/tests/test_utils_chemistry.py
+++ b/tests/test_utils_chemistry.py
@@ -531,6 +531,47 @@ class TestFilterUnique:
         # Should only keep one
         assert len(unique_mols) == 1
 
+    def test_same_geometry_different_energy_kept(self):
+        """Identical geometry but distinct E_tot must be kept (energy guard).
+
+        Heavy-atom RMSD ~= 0 but the two are distinct minima (the O-H rotamer
+        case); the energy guard must stop them collapsing into one.
+        """
+        from Auto3D.utils.chemistry import filter_unique
+
+        mol = Chem.MolFromSmiles("CCO")
+        mol = Chem.AddHs(mol)
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        AllChem.MMFFOptimizeMolecule(mol)
+        mol.SetProp("Converged", "true")
+        mol.SetProp("E_tot", "-10.0")
+
+        mol2 = Chem.Mol(mol)  # identical geometry
+        mol2.SetProp("Converged", "true")
+        mol2.SetProp("E_tot", "-10.5")  # |dE| >> tol
+
+        unique_mols = filter_unique([mol, mol2], crit=0.3)
+        assert len(unique_mols) == 2
+
+    def test_missing_energy_falls_back_to_rmsd_only(self):
+        """Without E_tot the energy guard cannot apply -> RMSD-only dedup.
+
+        Preserves the legacy behavior for callers that do not set E_tot.
+        """
+        from Auto3D.utils.chemistry import filter_unique
+
+        mol = Chem.MolFromSmiles("CCO")
+        mol = Chem.AddHs(mol)
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        AllChem.MMFFOptimizeMolecule(mol)
+        mol.SetProp("Converged", "true")  # no E_tot set
+
+        mol2 = Chem.Mol(mol)
+        mol2.SetProp("Converged", "true")
+
+        unique_mols = filter_unique([mol, mol2], crit=0.3)
+        assert len(unique_mols) == 1
+
     def test_filter_different_conformers(self):
         """Test that different conformers are kept."""
         from Auto3D.utils.chemistry import filter_unique

--- a/tests/test_utils_file_ops.py
+++ b/tests/test_utils_file_ops.py
@@ -122,6 +122,39 @@ class TestSmiles2Smi:
         assert all("_" not in i for i in ids)
 
 
+class TestCombineSmi:
+    """Tests for combine_smi (order-preserving dedup)."""
+
+    def test_preserves_order_and_dedups(self, tmp_path):
+        f1 = tmp_path / "a.smi"
+        f2 = tmp_path / "b.smi"
+        f1.write_text("CCO ethanol\nCCC propane\n")
+        f2.write_text("CCC propane\nCCCC butane\n")  # propane duplicated
+        out = tmp_path / "combined.smi"
+
+        combine_smi([str(f1), str(f2)], str(out))
+
+        lines = out.read_text().strip().split("\n")
+        # Deduped (propane once) and in first-seen input order.
+        assert lines == ["CCO ethanol", "CCC propane", "CCCC butane"]
+
+
+class TestEncodeIdsSmiDenseIndex:
+    """encode_ids must use a dense, gap-free index for .smi inputs."""
+
+    def test_blank_lines_do_not_create_index_gaps(self, tmp_path):
+        smi = tmp_path / "in.smi"
+        # Blank lines interspersed: the old code used the file line number as the
+        # index, leaving gaps. The dense record counter must yield 0,1,2.
+        smi.write_text("CCO a\n\nCCC b\n\n\nCCCC c\n")
+
+        new_path, mapping = encode_ids(str(smi))
+
+        assert sorted(mapping.values()) == [0, 1, 2]
+        ids = [line.split()[1] for line in Path(new_path).read_text().strip().split("\n")]
+        assert ids == ["0", "1", "2"]
+
+
 class TestGuessFileType:
     """Tests for guess_file_type function."""
 

--- a/tests/test_utils_file_ops.py
+++ b/tests/test_utils_file_ops.py
@@ -93,6 +93,34 @@ class TestSmiles2Smi:
         assert output.exists()
         assert output.read_text() == ""
 
+    def test_colliding_inchikeys_get_distinct_ids(self, tmp_path):
+        """Two inputs that share an InChIKey must keep distinct IDs.
+
+        The same molecule written two ways (here benzene) yields one InChIKey;
+        without disambiguation reorder_sdf would collapse the duplicate IDs and
+        silently drop the second input. Each input must get its own line/ID.
+        """
+        output = tmp_path / "test.smi"
+
+        smiles2smi(["c1ccccc1", "C1=CC=CC=C1"], str(output))
+
+        lines = output.read_text().strip().split("\n")
+        assert len(lines) == 2
+        ids = [line.split()[1] for line in lines]
+        assert ids[0] != ids[1], "colliding InChIKeys must be disambiguated"
+        # First keeps the bare InChIKey; the repeat is suffixed.
+        assert ids[1] == f"{ids[0]}_2"
+
+    def test_distinct_inputs_keep_bare_inchikeys(self, tmp_path):
+        """Non-colliding inputs must keep their plain InChIKey IDs (no suffix)."""
+        output = tmp_path / "test.smi"
+
+        smiles2smi(["CCO", "CCC"], str(output))
+
+        ids = [line.split()[1] for line in output.read_text().strip().split("\n")]
+        assert ids[0] != ids[1]
+        assert all("_" not in i for i in ids)
+
 
 class TestGuessFileType:
     """Tests for guess_file_type function."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -167,3 +167,26 @@ class TestCheckInputExceptions:
             isomer_engine="rdkit", verbose=False,
         )
         check_input(args)  # must not raise for a valid registry engine
+
+
+class TestCheckValidConfigurationGpuIndex:
+    """check_valid_configuration must flag an out-of-range gpu_idx so the
+    workflow can fail fast instead of crashing inside a spawned worker."""
+
+    def test_out_of_range_index_flagged(self, tmp_path):
+        from Auto3D.utils.validation import check_valid_configuration
+        p = tmp_path / "in.smi"
+        p.write_text("CCO mol\n")
+        with patch('Auto3D.utils.validation.torch.cuda.is_available', return_value=True), \
+             patch('Auto3D.utils.validation.torch.cuda.device_count', return_value=1):
+            errors = check_valid_configuration(path=str(p), k=1, use_gpu=True, gpu_idx=5)
+        assert any("GPU index 5 is invalid" in e for e in errors)
+
+    def test_valid_index_not_flagged(self, tmp_path):
+        from Auto3D.utils.validation import check_valid_configuration
+        p = tmp_path / "in.smi"
+        p.write_text("CCO mol\n")
+        with patch('Auto3D.utils.validation.torch.cuda.is_available', return_value=True), \
+             patch('Auto3D.utils.validation.torch.cuda.device_count', return_value=4):
+            errors = check_valid_configuration(path=str(p), k=1, use_gpu=True, gpu_idx=0)
+        assert errors == []

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -79,6 +79,28 @@ class TestWorkflowExceptions:
             with pytest.raises(ConfigurationError, match="k or window"):
                 orchestrator._validate_input()
 
+    def test_validate_input_invalid_config_raises_configuration_error(self, tmp_path):
+        """An invalid config (e.g. out-of-range gpu_idx) must fail fast in
+        _validate_input via check_valid_configuration, not deep in a worker."""
+        from Auto3D.config import Auto3DOptions
+        from Auto3D.workflow import WorkflowOrchestrator
+
+        smi_file = tmp_path / "test.smi"
+        smi_file.write_text("CCO ethanol")
+        config = Auto3DOptions(path=str(smi_file), k=1)
+        orchestrator = WorkflowOrchestrator(config)
+
+        with patch('Auto3D.workflow.encode_ids') as mock_encode, \
+             patch(
+                 'Auto3D.workflow.check_valid_configuration',
+                 return_value=["GPU index 5 is invalid. Available GPUs: 1"],
+             ):
+            mock_encode.return_value = (str(tmp_path / "test_encoded.smi"), {})
+            (tmp_path / "test_encoded.smi").write_text("CCO ethanol")
+
+            with pytest.raises(ConfigurationError, match="GPU index 5 is invalid"):
+                orchestrator._validate_input()
+
     def test_finalize_output_no_structures_raises_optimization_error(self, tmp_path):
         """Should raise OptimizationError when no 3D structures converged."""
         from Auto3D.config import Auto3DOptions


### PR DESCRIPTION
Clears the tail of Minor findings from the same review: correctness/robustness fixes plus warnings/docs for known limitations. Stacked on #102 — merge that first.

### Correctness / robustness
- Reference temperature `298.0/298 → 298.15 K`.
- `mol2aimnet_input` builds float32 coords (was fp64 into an fp32 model).
- Workflow validates `gpu_idx` early via `check_valid_configuration` (fails fast instead of crashing in a worker).
- `combine_smi` order-preserving dedup; `encode_ids` dense `.smi` index (no gaps from blank lines).
- `ranking.run` context-manages its `SDMolSupplier`.
- Removed dead `torch.jit.optimized_execution` guard; integer step counter → `torch.long`; padding charge tensors → float32.
- CLI reports the real `failed_count`.

### Documented known limitations (deeper fix deferred)
Symmetry number σ=1, 1 atm standard state, collinearity tolerance, electronic-energy-only tautomer ranking, ANI2xt `-1` masked-atom sentinel dependency, bond-order-blind connectivity radii.

Deferred (need GPU benchmarks or own PRs): per-bucket `empty_cache`, padding H2D batching, whole-bucket final recompute, σ auto-detection, bond-order-aware radii, free-energy tautomer ranking.

Fast gate: 647 passed (+6 new tests).