### PR TITLE
Sync docs, guides, and example configs with current code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to Auto3D will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Thermochemistry reference temperature is now 298.15 K** - The default
+  temperature for thermodynamic property calculation changed from 298 K to the
+  standard 298.15 K.
+- **Entropy SDF property renamed** - The thermo output property `S_hartree` is
+  now `S_hartree_per_K`, correctly reflecting its units (Hartree/Kelvin).
+
+### Fixed
+
+- **`smiles2mols()` no longer silently drops inputs that share an InChIKey** -
+  Distinct inputs that collapse to the same standard InChIKey (e.g. some
+  tautomers, or the same molecule written two ways) are now disambiguated with a
+  suffixed id and a log message instead of being dropped.
+- **Energy-guarded conformer deduplication** - Conformers within the heavy-atom
+  RMSD threshold are merged only when their energies also agree within
+  `DEFAULT_DUPLICATE_ENERGY_TOL`, so genuine O-H/N-H rotamers are no longer
+  collapsed.
+- **Thermochemistry robustness** - Spin multiplicity is derived from the
+  molecule's radical electrons (with a warning that NNP energies are
+  closed-shell), and imaginary vibrational modes are ignored rather than
+  failing the whole molecule.
+- **GPU index is validated up front** - An out-of-range `gpu_idx` now raises a
+  clear configuration error instead of crashing inside a worker; a CPU run with
+  a list of GPU indices no longer spawns redundant contending workers.
+- **CLI reports a real failure count** - `auto3d run` reports the number of
+  input molecules that produced no conformer instead of always reporting zero.
+- **Deterministic file handling** - `combine_smi` preserves input order, and
+  `.smi` molecule indexing is gap-free when blank lines are present.
+
+### Removed
+
+- Dead `torch.jit.optimized_execution` guard in the batch optimizer (a no-op for
+  the eager-mode model wrapper).
+
 ## [3.5.0] - 2026-06-11
 
 ### Breaking Changes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ We provide security updates for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 3.5.x   | :white_check_mark: |
 | 3.0.x   | :white_check_mark: |
-| 2.2.x   | :white_check_mark: |
-| < 2.2   | :x:                |
+| < 3.0   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -163,10 +163,8 @@ Validate input SMILES/SDF file without running optimization.
 
 This command checks:
 
-- File exists and is readable
-- SMILES syntax is valid
-- Molecules can be parsed by RDKit
-- Required atoms are supported by selected engine
+- File format is ``.smi`` or ``.sdf``
+- Each SMILES/SDF record parses successfully with RDKit
 
 auto3d config
 ~~~~~~~~~~~~~

--- a/docs/source/howto/drug_discovery.rst
+++ b/docs/source/howto/drug_discovery.rst
@@ -230,13 +230,13 @@ Key parameters for tautomer enumeration:
    * - Parameter
      - Description
    * - ``enumerate_tautomer``
-     - Enable tautomer enumeration (True/False)
+     - ``Auto3DOptions`` field: enable tautomer enumeration (True/False)
    * - ``tauto_engine``
-     - Engine: "rdkit" (free) or "oechem" (requires license)
+     - ``Auto3DOptions`` field: "rdkit" (free) or "oechem" (requires license)
    * - ``tauto_k``
-     - Number of stable tautomers to keep per input
+     - ``get_stable_tautomers()`` argument: number of stable tautomers to keep per input
    * - ``tauto_window``
-     - Energy window for tautomer selection (kcal/mol)
+     - ``get_stable_tautomers()`` argument: energy window for tautomer selection (kcal/mol)
 
 Stereoisomer Handling
 ---------------------
@@ -556,7 +556,9 @@ Comparing Conformer Ensembles
 
    mols = list(Chem.SDMolSupplier("output.sdf"))
 
-   # Group by molecule ID
+   # Group by molecule ID. In a standard output.sdf the _Name is already the
+   # molecule ID; the "id@tautN" form only appears in tautomer outputs, so
+   # split("@")[0] is a safe no-op there.
    conformers = {}
    for mol in mols:
        mol_id = mol.GetProp("_Name").split("@")[0]

--- a/docs/source/howto/quickstart.rst
+++ b/docs/source/howto/quickstart.rst
@@ -22,7 +22,8 @@ Installation
 
 .. code:: console
 
-   conda install -c conda-forge auto3d
+   # from a clone of the repository (creates a ready-to-use environment)
+   conda env create -f installation.yml
 
 Verify installation:
 
@@ -63,8 +64,8 @@ Auto3D creates a timestamped folder with results:
 The output SDF file contains:
 
 - Optimized 3D coordinates
-- Energy in Hartree (``E_tot`` property)
-- Relative energy in kcal/mol (``E_relative`` property)
+- Energy in Hartree (``E_tot`` / ``E_tot(Hartree)`` property)
+- Relative energy in kcal/mol (``E_rel(kcal/mol)`` property)
 - Original SMILES and molecule name
 
 View in Python:

--- a/docs/source/howto/troubleshooting.rst
+++ b/docs/source/howto/troubleshooting.rst
@@ -147,10 +147,13 @@ CUDA Out of Memory
       pip uninstall torch
       pip install torch --index-url https://download.pytorch.org/whl/cu118
 
-"Invalid device ordinal"
+"GPU index N is invalid"
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Problem**: Requested GPU index doesn't exist.
+**Problem**: The requested ``gpu_idx`` is out of range. Auto3D validates the GPU
+index up front and raises ``Invalid configuration: GPU index N is invalid.
+Available GPUs: M`` rather than letting CUDA fail later with "invalid device
+ordinal".
 
 **Solutions**:
 
@@ -632,7 +635,7 @@ Common Error Messages
 
    * - Error
      - Solution
-   * - ``ValueError: k and window cannot both be set``
+   * - ``ValueError: Only k OR window needs to be specified``
      - Use only ``k`` OR ``window``, not both
    * - ``RuntimeError: CUDA out of memory``
      - Reduce ``batchsize_atoms`` or use CPU

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -172,8 +172,9 @@ New API for creating models directly:
    # Create a model for custom workflows
    model = create_model("AIMNET", device="cuda:0")
 
-   # NOTE: the old ``use_ensemble=True`` argument is removed in v3.5 -- a single
-   # registry model is always used. Pick a specific registry model instead:
+   # NOTE: ``use_ensemble`` is deprecated and has no effect in v3.5 -- a single
+   # registry model is always used (passing use_ensemble=True only warns). Pick a
+   # specific registry model instead:
    model = create_model("aimnet2-2025", device="cuda:0")
 
 Environment variables
@@ -186,8 +187,9 @@ New environment variables for runtime configuration:
 
 .. note::
 
-   ``AUTO3D_USE_ENSEMBLE`` and the ``use_ensemble=True`` argument are removed in
-   v3.5 and have no effect; a single AIMNet2 registry model is always used.
+   ``AUTO3D_USE_ENSEMBLE`` and the ``use_ensemble=True`` argument are deprecated
+   and have no effect in v3.5 (setting them only warns); a single AIMNet2
+   registry model is always used.
 
 Migration Checklist
 -------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -222,8 +222,8 @@ Output Control
    # JSON output (for scripting)
    auto3d run molecules.smi --k=1 --json
 
-   # Custom output directory
-   auto3d run molecules.smi --k=1 --job-name=my_results
+   # Custom output directory name (job_name is set via a config file, not a flag)
+   auto3d run molecules.smi --k=1 -c config.yaml   # config.yaml: job_name: my_results
 
 Legacy YAML Mode
 ~~~~~~~~~~~~~~~~
@@ -476,7 +476,7 @@ Auto3D creates a timestamped folder with results:
 The output SDF contains:
 
 - **Optimized 3D coordinates** for each conformer
-- **E_tot**: Total energy in Hartree
-- **E_rel** or **E_relative**: Relative energy in kcal/mol
+- **E_tot** / **E_tot(Hartree)**: Total energy in Hartree
+- **E_rel(kcal/mol)**: Relative energy in kcal/mol
 - **_Name**: Molecule identifier
 - Original SMILES (if input was SMILES file)

--- a/example/tautomer_with_userNNP.ipynb
+++ b/example/tautomer_with_userNNP.ipynb
@@ -5,7 +5,18 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import Auto3D\nfrom Auto3D import Auto3DOptions, main\nfrom Auto3D.tautomer import get_stable_tautomers"
+   "source": [
+    "import os\n",
+    "\n",
+    "import torch\n",
+    "import torchani\n",
+    "\n",
+    "import Auto3D\n",
+    "from Auto3D import Auto3DOptions\n",
+    "from Auto3D.tautomer import get_stable_tautomers\n",
+    "\n",
+    "print(Auto3D.__version__)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -18,7 +29,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# define a custom NNP\n"
+    "# Define a custom NNP. The wrapper must expose coord_pad and species_pad\n",
+    "# attributes and a forward(species, coords, charges) -> energies (eV) method.\n",
+    "class userNNP(torch.nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        # Example backend built on ANI2x; replace with your own NNP.\n",
+    "        self.model = torchani.models.ANI2x(periodic_table_index=True)\n",
+    "        self.coord_pad = 0     # padding value for coordinates\n",
+    "        self.species_pad = -1  # padding value for species (atomic numbers)\n",
+    "\n",
+    "    def forward(self,\n",
+    "                species: torch.Tensor,\n",
+    "                coords: torch.Tensor,\n",
+    "                charges: torch.Tensor) -> torch.Tensor:\n",
+    "        \"\"\"species: [B, N] atomic numbers; coords: [B, N, 3]; charges: [B].\n",
+    "        Returns molecular energies [B] in eV.\"\"\"\n",
+    "        energies = self.model((species, coords)).energies * 27.211386245988\n",
+    "        return energies"
    ]
   },
   {
@@ -26,14 +54,30 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Initialize, script, and save the custom NNP to a file.\n",
+    "root = os.path.dirname(os.path.dirname(os.path.abspath(\"__file__\")))\n",
+    "model_path = os.path.join(root, \"myNNP.pt\")\n",
+    "torch.jit.save(torch.jit.script(userNNP()), model_path)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import os, sys\nroot = os.path.dirname(os.path.dirname(os.path.abspath(\"__file__\")))\nsys.path.append(os.path.dirname(__file__))\n\nimport Auto3D\nfrom Auto3D import Auto3DOptions\nfrom Auto3D.tautomer import get_stable_tautomers\n\ninput_path = os.path.join(root, \"example\", \"files\", \"sildnafil.smi\")\n\nif __name__ == \"__main__\":\n    config = Auto3DOptions(\n        path=input_path, k=1, enumerate_tautomer=True, tauto_engine=\"rdkit\",\n        optimizing_engine=\"userNNP\",  # Use userNNP for tautomers\n        max_confs=10, patience=200, use_gpu=False\n    )\n    tautomer_out = get_stable_tautomers(config, tauto_k=3)"
+   "source": [
+    "input_path = os.path.join(root, \"example\", \"files\", \"sildnafil.smi\")\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    config = Auto3DOptions(\n",
+    "        path=input_path, k=1, enumerate_tautomer=True, tauto_engine=\"rdkit\",\n",
+    "        optimizing_engine=model_path,  # path to the saved custom NNP\n",
+    "        max_confs=10, patience=200, use_gpu=False,\n",
+    "    )\n",
+    "    tautomer_out = get_stable_tautomers(config, tauto_k=3)\n",
+    "    print(tautomer_out)"
+   ]
   }
  ],
  "metadata": {

--- a/example/thermodynamic_calculation.ipynb
+++ b/example/thermodynamic_calculation.ipynb
@@ -379,7 +379,7 @@
    ],
    "source": [
     "\"\"\"\n",
-    "If the thermodynamic properties are calculated in 298 K, it's straightforward to get the thermodynamic properties.\n",
+    "If the thermodynamic properties are calculated in 298.15 K, it's straightforward to get the thermodynamic properties.\n",
     "\"\"\"\n",
     "\n",
     "out_thermo = calc_thermo(out, \"ANI2x\", opt_tol=0.003)\n",
@@ -690,9 +690,9 @@
    ],
    "source": [
     "\"\"\"\n",
-    "If the thermodynamic properties are NOT calculated in 298 K,\n",
+    "If the thermodynamic properties are NOT calculated in 298.15 K,\n",
     "you need to define a function that gets the unique ID and temperature for each molecules in the input path,\n",
-    "then pass the custom function as the value of argument get_mol_idx_t.\n",
+    "then pass the custom function as the value of argument mol_info_func.\n",
     "For example, the following functions works for Auto3D output. It sets the thermodynamic calculation temperature at 273 K and gets the molecular ID. You can set the temperature to any value you want for a given molecule.\n",
     "You can customize the function for other special needs.\n",
     "\"\"\"\n",
@@ -703,40 +703,15 @@
     "    return (id, t)\n",
     "\n",
     "\n",
-    "out_thermo = calc_thermo(out, \"ANI2x\", get_mol_idx_t=custom_func, opt_tol=0.003)\n",
+    "out_thermo = calc_thermo(out, \"ANI2x\", mol_info_func=custom_func, opt_tol=0.003)\n",
     "print(out_thermo)  #enthalpy, entropy and Gibbs free energy are stored in the SDF file"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Help on function calc_thermo in module Auto3D.ASE.thermo:\n",
-      "\n",
-      "calc_thermo(path: str, model_name: str, get_mol_idx_t=None, gpu_idx=0, opt_tol=0.0002, opt_steps=5000)\n",
-      "    ASE interface for calculation thermo properties using ANI2x, ANI2xt or AIMNET.\n",
-      "    \n",
-      "    :param path: Input sdf file\n",
-      "    :type path: str\n",
-      "    :param model_name: ANI2x, ANI2xt or AIMNET\n",
-      "    :type model_name: str\n",
-      "    :param get_mol_idx_t: A function that returns (idx, T) from a pybel mol object, by default using the 298 K temperature, defaults to None\n",
-      "    :type get_mol_idx_t: function, optional\n",
-      "    :param gpu_idx: GPU cuda index, defaults to 0\n",
-      "    :type gpu_idx: int, optional\n",
-      "    :param opt_tol: Convergence_threshold for geometry optimization, defaults to 0.0002\n",
-      "    :type opt_tol: float, optional\n",
-      "    :param opt_steps: Maximum geometry optimization steps, defaults to 5000\n",
-      "    :type opt_steps: int, optional\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "help(calc_thermo)"
    ]

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -4,7 +4,7 @@ path: "tests/files/smiles2.smi"
 
 # Output selection (k and window are mutually exclusive - specify only one)
 k: 1
-window: False
+window: None
 
 # General settings
 memory: None

--- a/src/Auto3D/cli/config_schema.py
+++ b/src/Auto3D/cli/config_schema.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from Auto3D.config import Auto3DOptions
 from Auto3D.constants import (
+    DEFAULT_BATCHSIZE_ATOMS,
     DEFAULT_CAPACITY,
     DEFAULT_CONVERGENCE_THRESHOLD,
     DEFAULT_OPT_STEPS,
@@ -54,10 +55,12 @@ class CLIConfig(BaseModel):
     convergence_threshold: float = Field(DEFAULT_CONVERGENCE_THRESHOLD, gt=0)
     patience: int = Field(DEFAULT_PATIENCE, ge=1)
     threshold: float = Field(DEFAULT_RMSD_THRESHOLD, gt=0)
+    batchsize_atoms: int = Field(DEFAULT_BATCHSIZE_ATOMS, ge=1)
 
     # Resource settings
     memory: int | None = Field(None, ge=1)
     capacity: int = Field(DEFAULT_CAPACITY, ge=1)
+    allow_tf32: bool = False
 
     # Output settings
     verbose: bool = False
@@ -125,8 +128,10 @@ class CLIConfig(BaseModel):
             convergence_threshold=self.convergence_threshold,
             patience=self.patience,
             threshold=self.threshold,
+            batchsize_atoms=self.batchsize_atoms,
             memory=self.memory,
             capacity=self.capacity,
+            allow_tf32=self.allow_tf32,
             verbose=self.verbose,
             job_name=self.job_name,
         )

--- a/tests/test_cli_config_schema.py
+++ b/tests/test_cli_config_schema.py
@@ -114,3 +114,28 @@ def test_merge_cli_overrides():
     merged = merge_configs(base, overrides)
     assert merged.k == 10
     assert merged.use_gpu is False
+
+
+def test_config_exposes_batchsize_and_tf32():
+    """batchsize_atoms and allow_tf32 are accepted by CLIConfig and forwarded to
+    Auto3DOptions (so the shipped parameters.yaml loads via `auto3d run -c`)."""
+    from Auto3D.cli.config_schema import CLIConfig
+
+    cfg = CLIConfig(path="x.smi", k=1, batchsize_atoms=2048, allow_tf32=True)
+    assert cfg.batchsize_atoms == 2048
+    assert cfg.allow_tf32 is True
+    opts = cfg.to_auto3d_options()
+    assert opts.batchsize_atoms == 2048
+    assert opts.allow_tf32 is True
+
+
+def test_shipped_parameters_yaml_loads():
+    """The repo-root parameters.yaml must validate against the modern CLI schema."""
+    from Auto3D.cli.config_schema import load_yaml_config
+
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = load_yaml_config(repo_root / "parameters.yaml")
+    # k/window are mutually exclusive; the example sets k and leaves window unset.
+    assert cfg.k == 1
+    assert cfg.window is None
+    cfg.to_auto3d_options()  # must not raise


### PR DESCRIPTION
Audited the active documentation (the `docs/source` Sphinx site, top-level docs, and `example/` notebooks) against the current source after the recent bug-hunt merges, and fixed every divergence found by a four-agent parallel review. Left `docs/legacy-v2/` (frozen v2 snapshot) and auto-generated API stubs untouched.

### Docs (`docs/source`)
- Output SDF property names corrected (`E_rel`/`E_relative` → `E_rel(kcal/mol)`; `E_tot` also shown as `E_tot(Hartree)`).
- Removed the non-existent `--job-name` CLI flag example (it's a config-file field).
- `auto3d validate` description trimmed to what it actually does.
- `use_ensemble` / `AUTO3D_USE_ENSEMBLE` documented as deprecated no-ops (they warn), not "removed".
- Replaced an unverifiable `conda install -c conda-forge auto3d` with `conda env create -f installation.yml`.
- Troubleshooting error strings now match the real messages (GPU-index validation; "Only k OR window needs to be specified").
- Clarified `tauto_k`/`tauto_window` are `get_stable_tautomers()` arguments.

### Top-level
- `SECURITY.md` supported-versions table → 3.5.x.
- `CHANGELOG.md` gains an `[Unreleased]` section for the recent fixes.

### Example notebooks
- `thermodynamic_calculation`: fixed the removed `get_mol_idx_t=` kwarg → `mol_info_func=`, refreshed 298 → 298.15 K prose, cleared stale `help()` output.
- `tautomer_with_userNNP`: was non-runnable (empty model cells, bogus `optimizing_engine="userNNP"`) — populated the userNNP wrapper and pass the saved model path.

### Small code change (to make the shipped example valid)
- `cli/config_schema`: expose `batchsize_atoms` and `allow_tf32` in `CLIConfig` and forward to `Auto3DOptions`. The shipped `parameters.yaml` previously failed to load via the documented `auto3d run -c` path (`extra=forbid`) and used an invalid `window: False`; both fixed, with tests.

Fast gate: 649 passed (+2 new CLIConfig tests). All edited .rst parse cleanly.