### PR TITLE
Make the CLI a first-class citizen: energy/optimize/thermo/tautomers + modernization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **First-class property subcommands** - `auto3d energy`, `auto3d optimize`,
+  `auto3d thermo`, and `auto3d tautomers` expose single-point energy, geometry
+  optimization, thermochemistry, and tautomer ranking from the CLI (previously
+  Python-only). Each supports `--engine`, `--gpu/--no-gpu`, `--gpu-idx`,
+  `-o/--output`, and `--json`.
+- **CLI ergonomics** - `auto3d run` gains `--job-name` and `--save-intermediate`;
+  `config init` gains `--force`; choice flags use enums with shell completion;
+  input paths are validated up front; and commands return differentiated exit
+  codes (2 config/input, 3 dependency, 4 GPU, 5 model).
+- **API**: `calc_spe`, `opt_geometry`, and `calc_thermo` accept `out_path`,
+  `use_gpu`, and `allow_tf32` (backwards-compatible).
+
 ### Changed
 
+- **`allow_tf32` now applies to the energy/optimize/thermo paths.** These
+  previously selected the device inline and ignored TF32; they now route through
+  the shared device + torch configuration, so enabling TF32 affects them too
+  (a small numerical change for anyone who had set it expecting it to apply).
 - **Thermochemistry reference temperature is now 298.15 K** - The default
   temperature for thermodynamic property calculation changed from 298 K to the
   standard 298.15 K.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ for mol in mols:
 | Command | Description |
 |---------|-------------|
 | `auto3d run <input> [options]` | Generate conformers from SMILES/SDF |
+| `auto3d energy <input.sdf>` | Single-point energy for an SDF |
+| `auto3d optimize <input.sdf>` | Geometry-optimize the structures in an SDF |
+| `auto3d thermo <input.sdf>` | Thermochemistry (enthalpy/entropy/Gibbs); needs the `ase` extra |
+| `auto3d tautomers <input.smi>` | Enumerate and rank stable tautomers |
 | `auto3d config init` | Create a configuration template |
 | `auto3d config show <file>` | Display config with syntax highlighting |
 | `auto3d config validate <file>` | Validate a configuration file |

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -166,6 +166,56 @@ This command checks:
 - File format is ``.smi`` or ``.sdf``
 - Each SMILES/SDF record parses successfully with RDKit
 
+Property commands
+~~~~~~~~~~~~~~~~~
+
+These wrap the corresponding Python API functions so single-point energy,
+geometry optimization, thermochemistry, and tautomer ranking are first-class CLI
+operations (not Python-only). Each takes an input file (validated for existence),
+shares ``--engine``, ``--gpu/--no-gpu``, ``--gpu-idx``, ``-o/--output``, and
+``--json``, writes an SDF, and prints its path.
+
+.. code:: console
+
+   # Single-point energy -> writes <input>_<engine>_E.sdf (adds E_hartree)
+   auto3d energy molecules.sdf --engine AIMNET
+
+   # Geometry-only optimization of an existing SDF
+   auto3d optimize molecules.sdf --opt-tol 0.01 --opt-steps 2000
+
+   # Thermochemistry (enthalpy/entropy/Gibbs) at a temperature; needs the ase extra
+   auto3d thermo molecules.sdf --temperature 298.15
+
+   # Enumerate tautomers and keep the most stable ones
+   auto3d tautomers molecules.smi --tauto-k 3      # or --tauto-window 2.0
+
+``--engine`` accepts ``AIMNET``, ``ANI2x``, ``ANI2xt``, an aimnet registry name,
+or a path to a custom model; known names are offered via shell completion.
+
+Exit codes
+~~~~~~~~~~
+
+Commands return differentiated exit codes for scripting:
+
+.. list-table::
+   :widths: 15 85
+   :header-rows: 1
+
+   * - Code
+     - Meaning
+   * - ``0``
+     - Success
+   * - ``1``
+     - Generic / unexpected error
+   * - ``2``
+     - Configuration or input-validation error (also Click usage errors)
+   * - ``3``
+     - Missing optional dependency (e.g. ASE for ``thermo``)
+   * - ``4``
+     - GPU/CUDA error (e.g. invalid GPU index)
+   * - ``5``
+     - Model error (not found / failed to load / numerical)
+
 auto3d config
 ~~~~~~~~~~~~~
 

--- a/src/Auto3D/ASE/geometry.py
+++ b/src/Auto3D/ASE/geometry.py
@@ -6,15 +6,13 @@ from __future__ import annotations
 
 import os
 
-import torch
 from rdkit import Chem
 
 from Auto3D.batch_opt.batchopt import optimizing
 from Auto3D.config import OptimizationConfig
+from Auto3D.model_factory import get_device
+from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
-
-# TF32 settings are configured centrally via Auto3D.torch_config.configure_torch()
-# and the allow_tf32 option in Auto3DOptions.
 
 
 def opt_geometry(
@@ -25,6 +23,9 @@ def opt_geometry(
     opt_steps: int = 2000,
     patience: int | None = None,
     batchsize_atoms: int = 1024,
+    use_gpu: bool = True,
+    allow_tf32: bool = False,
+    out_path: str | None = None,
 ) -> str:
     """Geometry optimization interface with FIRE optimizer.
 
@@ -46,6 +47,10 @@ def opt_geometry(
         batchsize_atoms: Number of atoms per optimization batch. Larger values
             use more GPU memory but may be faster. Defaults to 1024.
             Recommendation: ~1024 per GB of GPU memory.
+        use_gpu: Use the GPU when available. Defaults to True.
+        allow_tf32: Enable TF32 matmul precision on Ampere+ GPUs. Defaults to False.
+        out_path: Output SDF path. Defaults to ``<input_stem>_<model>_opt.sdf``
+            next to the input file.
 
     Returns:
         Path to output SDF file with optimized geometries.
@@ -61,21 +66,25 @@ def opt_geometry(
         ... )
     """
     ev2hatree = 1 / hartree2ev
-    # Create output path in the same directory as the input file.
-    # splitext (not split(".")) so an input like 'batch.v2.sdf' keeps 'batch.v2'
-    # instead of collapsing to 'batch' and risking output collisions.
-    dir = os.path.dirname(path)
-    stem = os.path.splitext(os.path.basename(path))[0]
-    if os.path.exists(model_name):  # custom NNP passed as a file path
-        basename = stem + "_userNNP_opt.sdf"
-    else:
-        basename = stem + f"_{model_name}_opt.sdf"
-    outpath = os.path.join(dir, basename)
+    # Apply the shared torch configuration so allow_tf32 is honored here too
+    # (this path previously ignored it).
+    configure_torch(TorchConfig(allow_tf32=allow_tf32))
 
-    if torch.cuda.is_available():
-        device = torch.device(f"cuda:{gpu_idx}")
+    # Create output path in the same directory as the input file (unless
+    # overridden). splitext (not split(".")) so an input like 'batch.v2.sdf'
+    # keeps 'batch.v2' instead of collapsing to 'batch' and risking collisions.
+    if out_path is not None:
+        outpath = out_path
     else:
-        device = torch.device("cpu")
+        dir = os.path.dirname(path)
+        stem = os.path.splitext(os.path.basename(path))[0]
+        if os.path.exists(model_name):  # custom NNP passed as a file path
+            basename = stem + "_userNNP_opt.sdf"
+        else:
+            basename = stem + f"_{model_name}_opt.sdf"
+        outpath = os.path.join(dir, basename)
+
+    device = get_device(gpu_idx, use_gpu=use_gpu)
 
     opt_config = OptimizationConfig(
         opt_steps=opt_steps,

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -21,7 +21,8 @@ from tqdm import tqdm
 
 from Auto3D.batch_opt.ANI2xt_no_rep import ANI2xt
 from Auto3D.batch_opt.batchopt import EnForce_ANI
-from Auto3D.model_factory import create_model
+from Auto3D.model_factory import create_model, get_device
+from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
 from Auto3D.utils.logging_config import get_logger
 
@@ -381,7 +382,9 @@ def aimnet_hessian_helper(
         return e  # energy unit: eV
 
 def calc_thermo(path: str, model_name: str, mol_info_func=None,
-                gpu_idx=0, opt_tol=0.0002, opt_steps=2000):
+                gpu_idx=0, opt_tol=0.0002, opt_steps=2000,
+                use_gpu: bool = True, allow_tf32: bool = False,
+                out_path: str | None = None):
     """ASE interface for calculating thermo properties using ANI2x, ANI2xt or AIMNET.
 
     Args:
@@ -393,6 +396,10 @@ def calc_thermo(path: str, model_name: str, mol_info_func=None,
         gpu_idx: GPU cuda index. Defaults to 0.
         opt_tol: Convergence threshold for geometry optimization. Defaults to 0.0002.
         opt_steps: Maximum geometry optimization steps. Defaults to 2000.
+        use_gpu: Use the GPU when available. Defaults to True.
+        allow_tf32: Enable TF32 matmul precision on Ampere+ GPUs. Defaults to False.
+        out_path: Output SDF path. Defaults to ``<input_stem>_<model>_G.sdf`` next
+            to the input file.
 
     Notes:
         Gibbs energies are reported at the 1 atm standard state (matching
@@ -408,18 +415,21 @@ def calc_thermo(path: str, model_name: str, mol_info_func=None,
         "molecule property is set; set it for symmetric species to avoid "
         "over-counting rotational entropy."
     )
-    # Prepare output name
+    # Apply the shared torch configuration so allow_tf32 is honored here too
+    # (this path previously ignored it).
+    configure_torch(TorchConfig(allow_tf32=allow_tf32))
+
+    # Prepare output name (unless overridden)
     out_mols, mols_failed = [], []
     path_obj = Path(path)
-    if Path(model_name).exists():
+    if out_path is not None:
+        outpath = Path(out_path)
+    elif Path(model_name).exists():
         outpath = path_obj.parent / f"{path_obj.stem}_userNNP_G.sdf"
     else:
         outpath = path_obj.parent / f"{path_obj.stem}_{model_name}_G.sdf"
 
-    if torch.cuda.is_available():
-        device = torch.device(f"cuda:{gpu_idx}")
-    else:
-        device = torch.device("cpu")
+    device = get_device(gpu_idx, use_gpu=use_gpu)
 
     hessian_model = _load_hessian_model(model_name, device)
     model, calculator = model_name2model_calculator(model_name, device)

--- a/src/Auto3D/SPE.py
+++ b/src/Auto3D/SPE.py
@@ -9,38 +9,55 @@ from rdkit import Chem
 from Auto3D.batch_opt.batchopt import EnForce_ANI
 from Auto3D.batch_opt.padding import pad_from_mols
 from Auto3D.model_factory import create_model, get_device
+from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
 from Auto3D.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-# TF32 settings are now configurable via Auto3DOptions.allow_tf32
-# and applied in workflow.py/auto3D.py entry points
 ev2hatree = 1/hartree2ev
 
 
-def calc_spe(path: str, model_name: str, gpu_idx: int = 0) -> str:
+def calc_spe(
+    path: str,
+    model_name: str,
+    gpu_idx: int = 0,
+    use_gpu: bool = True,
+    allow_tf32: bool = False,
+    out_path: str | None = None,
+) -> str:
     """Calculates single point energy.
 
     Args:
         path: Input sdf file.
         model_name: AIMNET, ANI2x, userNNP, or ANI2xt.
         gpu_idx: GPU cuda index. Defaults to 0.
+        use_gpu: Use the GPU when available. Defaults to True.
+        allow_tf32: Enable TF32 matmul precision on Ampere+ GPUs. Defaults to False.
+        out_path: Output SDF path. Defaults to ``<input_stem>_<model>_E.sdf`` next
+            to the input file.
 
     Returns:
         Path to output SDF file with energies.
     """
-    # Create output path in the same directory as the input
-    dir_path = Path(path).parent
-    stem = Path(path).stem
-    if Path(model_name).exists():
-        basename = f"{stem}_userNNP_E.sdf"
-    else:
-        basename = f"{stem}_{model_name}_E.sdf"
-    outpath = dir_path / basename
+    # Apply the shared torch configuration so allow_tf32 is honored here too
+    # (this path previously ignored it).
+    configure_torch(TorchConfig(allow_tf32=allow_tf32))
 
-    # Use get_device from model_factory
-    device = get_device(gpu_idx)
+    # Create output path in the same directory as the input (unless overridden)
+    if out_path is not None:
+        outpath = Path(out_path)
+    else:
+        dir_path = Path(path).parent
+        stem = Path(path).stem
+        if Path(model_name).exists():
+            basename = f"{stem}_userNNP_E.sdf"
+        else:
+            basename = f"{stem}_{model_name}_E.sdf"
+        outpath = dir_path / basename
+
+    # Use get_device from model_factory (honors use_gpu)
+    device = get_device(gpu_idx, use_gpu=use_gpu)
 
     # Use ModelFactory to create model adapter
     model_adapter = create_model(model_name, device)

--- a/src/Auto3D/auto3Dcli.py
+++ b/src/Auto3D/auto3Dcli.py
@@ -49,51 +49,65 @@ def _run_legacy_yaml(yaml_path: str) -> None:
     Args:
         yaml_path: Path to YAML configuration file.
     """
-    from Auto3D.cli.console import console, print_banner
+    import warnings
 
-    # Show deprecation hint
-    console.print(
-        "[dim]Hint: New syntax is 'auto3d run input.smi -c config.yaml'[/dim]\n"
+    from Auto3D.cli.console import console, print_banner, print_warning
+    from Auto3D.cli.errors import handle_error
+
+    # Real, visible deprecation notice steering users to the modern CLI.
+    warnings.warn(
+        "The 'auto3d <config.yaml>' invocation is deprecated; use "
+        "'auto3d run INPUT -c config.yaml' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    print_warning(
+        "The 'auto3d <config.yaml>' form is deprecated and will be removed in a "
+        "future release. Use 'auto3d run INPUT -c config.yaml' instead."
     )
 
-    # Load and run with legacy logic
-    import yaml
-
-    from Auto3D.auto3D import main
-    from Auto3D.config import Auto3DOptions
-    from Auto3D.exceptions import Auto3DError
-    from Auto3D.utils.logging_config import configure_logging
-
-    with open(yaml_path) as f:
-        parameters = yaml.safe_load(f)
-
-    # Convert 'None' strings to None
-    for key, val in list(parameters.items()):
-        if val == "None":
-            parameters[key] = None
-
-    configure_logging(verbose=parameters.get("verbose", False))
-
-    # Print banner
-    gpu_info = f"CUDA:{parameters.get('gpu_idx', 0)}" if parameters.get("use_gpu", True) else "CPU"
-    k = parameters.get("k")
-    window = parameters.get("window")
-    output_info = f"k={k}" if k else f"window={window}" if window else "k=1"
-
-    print_banner(
-        input_path=parameters.get("path", "?"),
-        engine=parameters.get("optimizing_engine", "AIMNET"),
-        gpu_info=gpu_info,
-        output_info=output_info,
-    )
-    console.print()
-
+    # Everything below funnels through handle_error so a bad path, malformed YAML,
+    # or a runtime failure produces a clean error panel + exit code, never a
+    # raw traceback (parity with the modern `run` command).
     try:
+        import yaml
+
+        from Auto3D.auto3D import main
+        from Auto3D.config import Auto3DOptions
+        from Auto3D.exceptions import InputValidationError
+        from Auto3D.utils.logging_config import configure_logging
+
+        if not Path(yaml_path).is_file():
+            raise InputValidationError(f"Config file not found: {yaml_path}")
+
+        with open(yaml_path) as f:
+            parameters = yaml.safe_load(f)
+
+        # Convert 'None' strings to None
+        for key, val in list(parameters.items()):
+            if val == "None":
+                parameters[key] = None
+
+        configure_logging(verbose=parameters.get("verbose", False))
+
+        # Print banner
+        gpu_info = f"CUDA:{parameters.get('gpu_idx', 0)}" if parameters.get("use_gpu", True) else "CPU"
+        k = parameters.get("k")
+        window = parameters.get("window")
+        output_info = f"k={k}" if k else f"window={window}" if window else "k=1"
+
+        print_banner(
+            input_path=parameters.get("path", "?"),
+            engine=parameters.get("optimizing_engine", "AIMNET"),
+            gpu_info=gpu_info,
+            output_info=output_info,
+        )
+        console.print()
+
         options = Auto3DOptions(**parameters)
         result = main(options)
         console.print(f"\n[green]✓[/green] Output: [cyan]{result}[/cyan]")
-    except Auto3DError as e:
-        from Auto3D.cli.errors import handle_error
+    except Exception as e:  # noqa: BLE001 - present every failure as a clean panel
         handle_error(e)
 
 

--- a/src/Auto3D/cli/app.py
+++ b/src/Auto3D/cli/app.py
@@ -3,13 +3,34 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
 import Auto3D
+from Auto3D.cli.commands.properties import engine_autocomplete
 from Auto3D.cli.console import console
+
+
+class Preset(StrEnum):
+    """Configuration presets for `auto3d config init`."""
+
+    quick = "quick"
+    balanced = "balanced"
+    thorough = "thorough"
+
+
+# Reusable input-file argument with Typer-level existence/readability validation,
+# so a missing/unreadable path fails fast and cleanly before heavy imports load.
+InputFile = Annotated[
+    Path,
+    typer.Argument(
+        exists=True, dir_okay=False, readable=True,
+        help="Input file (must exist).",
+    ),
+]
 
 # Create main app
 app = typer.Typer(
@@ -64,6 +85,7 @@ def run(
     input_file: Annotated[
         Path,
         typer.Argument(
+            exists=True, dir_okay=False, readable=True,
             help="Input .smi or .sdf file containing molecules.",
         ),
     ],
@@ -101,9 +123,20 @@ def run(
         str | None,
         typer.Option(help="GPU index(es), e.g., '0' or '0,1,2'."),
     ] = None,
+    job_name: Annotated[
+        str | None,
+        typer.Option("--job-name", help="Name for the output folder/run."),
+    ] = None,
+    save_intermediate: Annotated[
+        bool,
+        typer.Option(
+            "--save-intermediate",
+            help="Keep all intermediate metadata files (Auto3DOptions.verbose).",
+        ),
+    ] = False,
     verbose: Annotated[
         int,
-        typer.Option("-v", "--verbose", count=True, help="Increase verbosity."),
+        typer.Option("-v", "--verbose", count=True, help="Increase logging verbosity."),
     ] = 0,
     quiet: Annotated[
         bool,
@@ -124,6 +157,8 @@ def run(
         engine=engine,
         gpu=gpu,
         gpu_idx=gpu_idx,
+        job_name=job_name,
+        save_intermediate=save_intermediate,
         verbose=verbose,
         quiet=quiet,
         json_output=json_output,
@@ -137,13 +172,21 @@ def config_init(
         typer.Option("-o", "--output", help="Output file path."),
     ] = Path("auto3d.yaml"),
     preset: Annotated[
-        str | None,
-        typer.Option("-p", "--preset", help="Configuration preset: quick, balanced, thorough."),
+        Preset | None,
+        typer.Option("-p", "--preset", help="Configuration preset."),
     ] = None,
+    force: Annotated[
+        bool,
+        typer.Option("-f", "--force", help="Overwrite an existing config file."),
+    ] = False,
 ) -> None:
     """Generate a configuration file with sensible defaults."""
     from Auto3D.cli.commands.config import execute_config_init
-    execute_config_init(output=output, preset=preset)
+    execute_config_init(
+        output=output,
+        preset=preset.value if preset else None,
+        force=force,
+    )
 
 
 @config_app.command("show")
@@ -162,7 +205,10 @@ def config_show(
 def config_validate(
     config_file: Annotated[
         Path,
-        typer.Argument(help="Config file to validate."),
+        typer.Argument(
+            exists=True, dir_okay=False, readable=True,
+            help="Config file to validate.",
+        ),
     ],
 ) -> None:
     """Validate a configuration file without running."""
@@ -191,11 +237,107 @@ def models_info(
 
 @app.command()
 def validate(
-    input_file: Annotated[
-        Path,
-        typer.Argument(help="Input file to validate."),
-    ],
+    input_file: InputFile,
 ) -> None:
     """Validate input SMILES/SDF file without running optimization."""
     from Auto3D.cli.commands.validate import execute_validate
     execute_validate(input_file=input_file)
+
+
+# Shared option annotations for the property commands ------------------------
+
+EngineOption = Annotated[
+    str,
+    typer.Option(
+        "--engine",
+        autocompletion=engine_autocomplete,
+        help=(
+            "Engine: AIMNET, ANI2x, ANI2xt, an aimnet registry name "
+            "(aimnet2, aimnet2-2025, ...), or a path to a custom model file."
+        ),
+    ),
+]
+GpuFlag = Annotated[bool, typer.Option("--gpu/--no-gpu", help="Use GPU when available.")]
+GpuIdxOption = Annotated[int, typer.Option("--gpu-idx", help="CUDA device index.")]
+OutputOption = Annotated[
+    Path | None,
+    typer.Option("-o", "--output", help="Output SDF path (default: next to input)."),
+]
+Tf32Flag = Annotated[bool, typer.Option("--tf32/--no-tf32", help="Allow TF32 matmul on Ampere+ GPUs.")]
+JsonFlag = Annotated[bool, typer.Option("--json", help="Emit the result as JSON.")]
+
+
+@app.command()
+def energy(
+    input_file: InputFile,
+    engine: EngineOption = "AIMNET",
+    gpu: GpuFlag = True,
+    gpu_idx: GpuIdxOption = 0,
+    output: OutputOption = None,
+    tf32: Tf32Flag = False,
+    json_output: JsonFlag = False,
+) -> None:
+    """Single-point energy for an SDF (writes an SDF with E_hartree)."""
+    from Auto3D.cli.commands.properties import execute_energy
+    execute_energy(input_file, engine, gpu, gpu_idx, output, tf32, json_output)
+
+
+@app.command()
+def optimize(
+    input_file: InputFile,
+    engine: EngineOption = "AIMNET",
+    gpu: GpuFlag = True,
+    gpu_idx: GpuIdxOption = 0,
+    output: OutputOption = None,
+    opt_tol: Annotated[float, typer.Option("--opt-tol", help="Max-force convergence (eV/A).")] = 0.01,
+    opt_steps: Annotated[int, typer.Option("--opt-steps", help="Max optimization steps.")] = 2000,
+    patience: Annotated[int | None, typer.Option("--patience", help="Drop a conformer after this many non-improving steps.")] = None,
+    batchsize_atoms: Annotated[int, typer.Option("--batchsize-atoms", help="Atoms per optimization batch.")] = 1024,
+    tf32: Tf32Flag = False,
+    json_output: JsonFlag = False,
+) -> None:
+    """Geometry-optimize the structures in an SDF (no enumeration)."""
+    from Auto3D.cli.commands.properties import execute_optimize
+    execute_optimize(
+        input_file, engine, gpu, gpu_idx, output, opt_tol, opt_steps,
+        patience, batchsize_atoms, tf32, json_output,
+    )
+
+
+@app.command()
+def thermo(
+    input_file: InputFile,
+    engine: EngineOption = "AIMNET",
+    gpu: GpuFlag = True,
+    gpu_idx: GpuIdxOption = 0,
+    output: OutputOption = None,
+    temperature: Annotated[float, typer.Option("--temperature", "-T", help="Temperature in Kelvin.")] = 298.15,
+    opt_tol: Annotated[float, typer.Option("--opt-tol", help="Pre-optimization max-force convergence (eV/A).")] = 0.0002,
+    opt_steps: Annotated[int, typer.Option("--opt-steps", help="Max pre-optimization steps.")] = 2000,
+    tf32: Tf32Flag = False,
+    json_output: JsonFlag = False,
+) -> None:
+    """Thermochemistry (enthalpy/entropy/Gibbs) for an SDF. Requires the ase extra."""
+    from Auto3D.cli.commands.properties import execute_thermo
+    execute_thermo(
+        input_file, engine, gpu, gpu_idx, output, temperature,
+        opt_tol, opt_steps, tf32, json_output,
+    )
+
+
+@app.command()
+def tautomers(
+    input_file: InputFile,
+    engine: EngineOption = "AIMNET",
+    gpu: GpuFlag = True,
+    gpu_idx: Annotated[str | None, typer.Option("--gpu-idx", help="GPU index(es), e.g. '0' or '0,1'.")] = None,
+    tauto_k: Annotated[int | None, typer.Option("--tauto-k", help="Keep the top-k stable tautomers.")] = None,
+    tauto_window: Annotated[float | None, typer.Option("--tauto-window", help="Keep tautomers within this kcal/mol window.")] = None,
+    output: OutputOption = None,
+    json_output: JsonFlag = False,
+) -> None:
+    """Enumerate tautomers and rank/select the most stable ones."""
+    from Auto3D.cli.commands.properties import execute_tautomers
+    execute_tautomers(
+        input_file, engine, gpu, gpu_idx, tauto_k, tauto_window, output, json_output,
+    )

--- a/src/Auto3D/cli/commands/config.py
+++ b/src/Auto3D/cli/commands/config.py
@@ -89,8 +89,18 @@ def generate_commented_yaml(config: dict) -> str:
     return "\n".join(lines)
 
 
-def execute_config_init(output: Path, preset: str | None = None) -> None:
+def execute_config_init(
+    output: Path, preset: str | None = None, force: bool = False
+) -> None:
     """Generate a configuration file."""
+    # Don't clobber an existing config without explicit consent.
+    if output.exists() and not force:
+        print_error(
+            f"{output} already exists.",
+            hint="Pass --force/-f to overwrite, or choose a different -o path.",
+        )
+        raise SystemExit(1)
+
     config = DEFAULT_CONFIG.copy()
 
     if preset:

--- a/src/Auto3D/cli/commands/properties.py
+++ b/src/Auto3D/cli/commands/properties.py
@@ -1,0 +1,140 @@
+# src/Auto3D/cli/commands/properties.py
+"""CLI commands for the property calculators that wrap the Python API:
+
+- ``auto3d energy``    -> Auto3D.SPE.calc_spe
+- ``auto3d optimize``  -> Auto3D.ASE.geometry.opt_geometry
+- ``auto3d thermo``    -> Auto3D.ASE.thermo.calc_thermo
+- ``auto3d tautomers`` -> Auto3D.tautomer.get_stable_tautomers
+
+These are thin wrappers: they call the API function, report the output path (or
+emit JSON), and route every failure through ``handle_error`` so the user gets a
+clean message and a differentiated exit code instead of a traceback.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from Auto3D.cli.console import console, print_success
+from Auto3D.cli.errors import handle_error
+from Auto3D.exceptions import ConfigurationError, DependencyError
+
+# Engine names offered for shell completion. Free-form registry names and custom
+# model paths are still accepted (validated downstream); this only seeds tab
+# completion and discoverability.
+KNOWN_ENGINES = [
+    "AIMNET", "ANI2x", "ANI2xt",
+    "aimnet2", "aimnet2-2025", "aimnet2-nse", "aimnet2-pd",
+]
+
+
+def engine_autocomplete(incomplete: str) -> list[str]:
+    """Shell-completion callback for the --engine option."""
+    return [e for e in KNOWN_ENGINES if e.startswith(incomplete)]
+
+
+def _report(output_path: str, command: str, json_output: bool) -> None:
+    """Report the produced output file (JSON or human-readable)."""
+    if json_output:
+        console.print_json(json.dumps({"command": command, "output_file": output_path}))
+    else:
+        print_success(f"Wrote {output_path}")
+
+
+def execute_energy(
+    input_file: Path, engine: str, gpu: bool, gpu_idx: int,
+    output: Path | None, allow_tf32: bool, json_output: bool,
+) -> None:
+    """Single-point energy: wraps calc_spe."""
+    try:
+        from Auto3D.SPE import calc_spe
+        out = calc_spe(
+            str(input_file), engine, gpu_idx=gpu_idx, use_gpu=gpu,
+            allow_tf32=allow_tf32, out_path=str(output) if output else None,
+        )
+        _report(out, "energy", json_output)
+    except Exception as e:  # noqa: BLE001 - funnel everything to the error panel
+        handle_error(e)
+
+
+def execute_optimize(
+    input_file: Path, engine: str, gpu: bool, gpu_idx: int, output: Path | None,
+    opt_tol: float, opt_steps: int, patience: int | None, batchsize_atoms: int,
+    allow_tf32: bool, json_output: bool,
+) -> None:
+    """Geometry-only optimization of an existing SDF: wraps opt_geometry."""
+    try:
+        from Auto3D.ASE.geometry import opt_geometry
+        out = opt_geometry(
+            str(input_file), engine, gpu_idx=gpu_idx, opt_tol=opt_tol,
+            opt_steps=opt_steps, patience=patience, batchsize_atoms=batchsize_atoms,
+            use_gpu=gpu, allow_tf32=allow_tf32,
+            out_path=str(output) if output else None,
+        )
+        _report(out, "optimize", json_output)
+    except Exception as e:  # noqa: BLE001
+        handle_error(e)
+
+
+def execute_thermo(
+    input_file: Path, engine: str, gpu: bool, gpu_idx: int, output: Path | None,
+    temperature: float, opt_tol: float, opt_steps: int,
+    allow_tf32: bool, json_output: bool,
+) -> None:
+    """Thermochemistry (H/S/G): wraps calc_thermo. Requires the `ase` extra."""
+    try:
+        try:
+            from Auto3D.ASE.thermo import calc_thermo
+        except ImportError as e:
+            raise DependencyError(
+                "Thermochemistry requires ASE, which is not installed.",
+            ) from e
+
+        # Scalar --temperature -> the per-mol (id, T) callback calc_thermo expects.
+        def mol_info_func(mol):
+            name = mol.GetProp("_Name").strip() if mol.HasProp("_Name") else "molecule"
+            return (name, temperature)
+
+        out = calc_thermo(
+            str(input_file), engine, mol_info_func=mol_info_func, gpu_idx=gpu_idx,
+            opt_tol=opt_tol, opt_steps=opt_steps, use_gpu=gpu, allow_tf32=allow_tf32,
+            out_path=str(output) if output else None,
+        )
+        _report(out, "thermo", json_output)
+    except Exception as e:  # noqa: BLE001
+        handle_error(e)
+
+
+def execute_tautomers(
+    input_file: Path, engine: str, gpu: bool, gpu_idx: str | None,
+    tauto_k: int | None, tauto_window: float | None,
+    output: Path | None, json_output: bool,
+) -> None:
+    """Tautomer enumeration + stable-tautomer ranking: wraps get_stable_tautomers."""
+    try:
+        if tauto_k is not None and tauto_window is not None:
+            raise ConfigurationError(
+                "Specify only one of --tauto-k or --tauto-window, not both."
+            )
+        if tauto_k is None and tauto_window is None:
+            tauto_k = 1  # sensible default: keep the single most stable tautomer
+
+        from Auto3D.cli.config_schema import CLIConfig
+        from Auto3D.tautomer import get_stable_tautomers
+
+        cfg = CLIConfig(
+            path=input_file, k=1, optimizing_engine=engine, use_gpu=gpu,
+            gpu_idx=gpu_idx if gpu_idx is not None else 0,
+            enumerate_tautomer=True,
+        )
+        out = get_stable_tautomers(
+            cfg.to_auto3d_options(), tauto_k=tauto_k, tauto_window=tauto_window,
+        )
+        # The tautomer pipeline derives its own output name; honor -o by moving.
+        if output is not None and Path(out) != output:
+            import shutil
+            shutil.move(out, str(output))
+            out = str(output)
+        _report(out, "tautomers", json_output)
+    except Exception as e:  # noqa: BLE001
+        handle_error(e)

--- a/src/Auto3D/cli/commands/run.py
+++ b/src/Auto3D/cli/commands/run.py
@@ -12,7 +12,6 @@ from Auto3D.cli.errors import handle_error
 from Auto3D.cli.results import (
     WorkflowResults,
     output_json,
-    print_failures,
     print_results_summary,
 )
 from Auto3D.exceptions import Auto3DError
@@ -27,6 +26,8 @@ def execute_run(
     engine: str | None = None,
     gpu: bool | None = None,
     gpu_idx: str | None = None,
+    job_name: str | None = None,
+    save_intermediate: bool = False,
     verbose: int = 0,
     quiet: bool = False,
     json_output: bool = False,
@@ -41,13 +42,16 @@ def execute_run(
         engine: Optimization engine override.
         gpu: GPU enable/disable override.
         gpu_idx: GPU index override.
-        verbose: Verbosity level (0-2).
+        job_name: Output folder/run name override.
+        save_intermediate: Keep all intermediate metadata (Auto3DOptions.verbose).
+        verbose: Logging verbosity level (0-2).
         quiet: Suppress non-error output.
         json_output: Output results as JSON.
     """
     start_time = time.time()
 
-    # Configure logging based on verbosity
+    # Configure logging based on verbosity. Diagnostics already go to stderr (see
+    # configure_logging), so --json stdout stays a clean, parseable document.
     configure_logging(verbose=verbose > 0)
 
     try:
@@ -71,6 +75,10 @@ def execute_run(
             "optimizing_engine": engine,
             "use_gpu": gpu,
             "gpu_idx": gpu_idx,
+            "job_name": job_name,
+            # --save-intermediate maps to Auto3DOptions.verbose (save metadata).
+            # Only override when set, so a config-file `verbose: true` is preserved.
+            "verbose": True if save_intermediate else None,
         }
         config = merge_configs(config, {key: val for key, val in overrides.items() if val is not None})
 
@@ -126,14 +134,14 @@ def execute_run(
             failures=[],
         )
 
-        # Output results
+        # Output results. Per-molecule failure *details* are not yet wired through
+        # the workflow (results.failures is always empty), so we report the count
+        # via the summary but do not promise a detail list that cannot exist.
         if json_output:
             output_json(results)
         elif not quiet:
             console.print()
             print_results_summary(results)
-            if results.failures:
-                print_failures(results.failures, verbose=verbose > 0)
 
     except Auto3DError as e:
         handle_error(e)

--- a/src/Auto3D/cli/errors.py
+++ b/src/Auto3D/cli/errors.py
@@ -12,8 +12,28 @@ from Auto3D.exceptions import (
     DependencyError,
     GPUError,
     InputValidationError,
+    ModelError,
     ModelNotFoundError,
 )
+
+# Differentiated exit codes for scripting/CI. 1 = generic; the rest let callers
+# branch on error class. (Click reserves 2 for usage errors, which aligns with
+# our configuration/input errors below.)
+EXIT_CODES: dict[type, int] = {
+    ConfigurationError: 2,
+    InputValidationError: 2,
+    DependencyError: 3,
+    GPUError: 4,
+    ModelError: 5,  # includes ModelNotFoundError / ModelLoadError / NumericalError
+}
+
+
+def exit_code_for(error: Exception) -> int:
+    """Return the differentiated exit code for an exception (1 if unmapped)."""
+    for exc_type, code in EXIT_CODES.items():
+        if isinstance(error, exc_type):
+            return code
+    return 1
 
 
 def get_error_hint(error: Auto3DError) -> str | None:
@@ -75,4 +95,4 @@ def handle_error(error: Exception) -> None:
             border_style="red",
         ))
 
-    raise SystemExit(1)
+    raise SystemExit(exit_code_for(error))

--- a/tests/test_ase_geometry.py
+++ b/tests/test_ase_geometry.py
@@ -10,7 +10,9 @@ def test_opt_geometry_names_output_by_model(monkeypatch, tmp_path):
         def run(self): pass
     monkeypatch.setattr(geo, "optimizing", _Stub)
     monkeypatch.setattr(geo.Chem, "SDMolSupplier", lambda *a, **k: [])
-    monkeypatch.setattr(geo.torch.cuda, "is_available", lambda: False)
+    import torch
+    monkeypatch.setattr(geo, "get_device", lambda *a, **k: torch.device("cpu"))
+    monkeypatch.setattr(geo, "configure_torch", lambda *a, **k: None)
 
     out = geo.opt_geometry(str(sdf), "AIMNET")
     assert out.endswith("mols_AIMNET_opt.sdf")
@@ -48,7 +50,9 @@ def test_opt_geometry_skips_none_and_missing_etot(monkeypatch, tmp_path):
     monkeypatch.setattr(
         geo.Chem, "SDMolSupplier", lambda *a, **k: [None, no_etot, good]
     )
-    monkeypatch.setattr(geo.torch.cuda, "is_available", lambda: False)
+    import torch
+    monkeypatch.setattr(geo, "get_device", lambda *a, **k: torch.device("cpu"))
+    monkeypatch.setattr(geo, "configure_torch", lambda *a, **k: None)
 
     out = geo.opt_geometry(str(sdf), "AIMNET")  # must not raise
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,117 +198,42 @@ def test_cli_module_console_is_rich():
 class TestCLIExceptionHandling:
     """Test that CLI wraps exceptions properly."""
 
-    def test_cli_catches_auto3d_error_and_exits_with_code_1(self):
-        """CLI should catch Auto3DError and exit with code 1 (legacy YAML mode)."""
-        # Mock main() to raise Auto3DError - main is imported inside _run_legacy_yaml
-        with patch('Auto3D.auto3D.main') as mock_main:
-            mock_main.side_effect = ConfigurationError("Test configuration error")
+    # Legacy YAML path now (a) checks the file exists and (b) maps exception
+    # types to differentiated exit codes (see Auto3D.cli.errors.EXIT_CODES):
+    # ConfigurationError -> 2, GPUError -> 4, generic Auto3DError/Optimization -> 1.
+    _LEGACY_YAML = {
+        'path': '/fake/path.smi', 'k': 1, 'window': None, 'memory': None,
+        'capacity': 40, 'enumerate_tautomer': False, 'tauto_engine': 'rdkit',
+        'pKaNorm': True, 'isomer_engine': 'rdkit', 'max_confs': None,
+        'enumerate_isomer': True, 'mode_oe': 'classic', 'mpi_np': 4,
+        'optimizing_engine': 'AIMNET', 'use_gpu': False, 'gpu_idx': 0,
+        'opt_steps': 2000, 'convergence_threshold': 0.01, 'patience': 250,
+        'threshold': 0.3, 'verbose': False, 'job_name': '',
+    }
 
-            # Mock sys.argv to provide minimal arguments (legacy YAML mode)
+    def _run_legacy_with_error(self, error):
+        """Drive the legacy YAML path with main() raising `error`; return exit code."""
+        with patch('Auto3D.auto3D.main') as mock_main:
+            mock_main.side_effect = error
             with patch.object(sys, 'argv', ['auto3d', 'config.yaml']):
-                # Mock yaml.safe_load to return valid config
-                with patch('yaml.safe_load', return_value={
-                    'path': '/fake/path.smi',
-                    'k': 1,
-                    'window': None,
-                    'memory': None,
-                    'capacity': 40,
-                    'enumerate_tautomer': False,
-                    'tauto_engine': 'rdkit',
-                    'pKaNorm': True,
-                    'isomer_engine': 'rdkit',
-                    'max_confs': None,
-                    'enumerate_isomer': True,
-                    'mode_oe': 'classic',
-                    'mpi_np': 4,
-                    'optimizing_engine': 'AIMNET',
-                    'use_gpu': False,
-                    'gpu_idx': 0,
-                    'opt_steps': 2000,
-                    'convergence_threshold': 0.01,
-                    'patience': 250,
-                    'threshold': 0.3,
-                    'verbose': False,
-                    'job_name': '',
-                }):
-                    with patch('builtins.open', MagicMock()):
+                with patch('yaml.safe_load', return_value=dict(self._LEGACY_YAML)):
+                    with patch('builtins.open', MagicMock()), \
+                         patch('pathlib.Path.is_file', return_value=True):
                         with pytest.raises(SystemExit) as exc_info:
                             cli()
+                        return exc_info.value.code
 
-                        # Should exit with code 1
-                        assert exc_info.value.code == 1
+    def test_cli_configuration_error_exits_2(self):
+        """ConfigurationError -> exit code 2 (legacy YAML mode)."""
+        assert self._run_legacy_with_error(ConfigurationError("bad config")) == 2
 
-    def test_cli_catches_gpu_error_and_exits_with_code_1(self):
-        """CLI should catch GPUError and exit with code 1 (legacy YAML mode)."""
-        with patch('Auto3D.auto3D.main') as mock_main:
-            mock_main.side_effect = GPUError("No CUDA device available")
+    def test_cli_gpu_error_exits_4(self):
+        """GPUError -> exit code 4 (legacy YAML mode)."""
+        assert self._run_legacy_with_error(GPUError("No CUDA device available")) == 4
 
-            with patch.object(sys, 'argv', ['auto3d', 'config.yaml']):
-                with patch('yaml.safe_load', return_value={
-                    'path': '/fake/path.smi',
-                    'k': 1,
-                    'window': None,
-                    'memory': None,
-                    'capacity': 40,
-                    'enumerate_tautomer': False,
-                    'tauto_engine': 'rdkit',
-                    'pKaNorm': True,
-                    'isomer_engine': 'rdkit',
-                    'max_confs': None,
-                    'enumerate_isomer': True,
-                    'mode_oe': 'classic',
-                    'mpi_np': 4,
-                    'optimizing_engine': 'AIMNET',
-                    'use_gpu': True,
-                    'gpu_idx': 0,
-                    'opt_steps': 2000,
-                    'convergence_threshold': 0.01,
-                    'patience': 250,
-                    'threshold': 0.3,
-                    'verbose': False,
-                    'job_name': '',
-                }):
-                    with patch('builtins.open', MagicMock()):
-                        with pytest.raises(SystemExit) as exc_info:
-                            cli()
-
-                        assert exc_info.value.code == 1
-
-    def test_cli_catches_optimization_error_and_exits_with_code_1(self):
-        """CLI should catch OptimizationError and exit with code 1 (legacy YAML mode)."""
-        with patch('Auto3D.auto3D.main') as mock_main:
-            mock_main.side_effect = OptimizationError("No structures converged")
-
-            with patch.object(sys, 'argv', ['auto3d', 'config.yaml']):
-                with patch('yaml.safe_load', return_value={
-                    'path': '/fake/path.smi',
-                    'k': 1,
-                    'window': None,
-                    'memory': None,
-                    'capacity': 40,
-                    'enumerate_tautomer': False,
-                    'tauto_engine': 'rdkit',
-                    'pKaNorm': True,
-                    'isomer_engine': 'rdkit',
-                    'max_confs': None,
-                    'enumerate_isomer': True,
-                    'mode_oe': 'classic',
-                    'mpi_np': 4,
-                    'optimizing_engine': 'AIMNET',
-                    'use_gpu': False,
-                    'gpu_idx': 0,
-                    'opt_steps': 2000,
-                    'convergence_threshold': 0.01,
-                    'patience': 250,
-                    'threshold': 0.3,
-                    'verbose': False,
-                    'job_name': '',
-                }):
-                    with patch('builtins.open', MagicMock()):
-                        with pytest.raises(SystemExit) as exc_info:
-                            cli()
-
-                        assert exc_info.value.code == 1
+    def test_cli_optimization_error_exits_1(self):
+        """OptimizationError -> generic exit code 1 (legacy YAML mode)."""
+        assert self._run_legacy_with_error(OptimizationError("No structures converged")) == 1
 
 
 class TestSmiles2MolsExceptionHandling:

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -177,13 +177,14 @@ def test_config_init_default_path(runner, tmp_path_cwd):
 
 
 def test_config_init_invalid_preset(runner, tmp_path_cwd):
-    """config init with invalid preset should fail."""
+    """config init with an invalid preset is now a Typer enum usage error (exit 2)."""
     from Auto3D.cli.app import app
 
     result = runner.invoke(app, ["config", "init", "-p", "invalid"])
 
-    assert result.exit_code == 1
-    assert "Unknown preset" in result.stderr
+    assert result.exit_code == 2
+    # Click reports the valid choices for the enum option.
+    assert "quick" in result.output
 
 
 def test_config_show_displays_file(runner, tmp_path_cwd):
@@ -359,8 +360,8 @@ def test_models_info_unkeyed_aimnet2_variant_resolves(runner):
 
 
 def test_config_validate_missing_file(runner, tmp_path_cwd):
-    """config validate on a missing file should fail with a not-found hint."""
+    """config validate on a missing file is now a Typer path-existence error (exit 2)."""
     from Auto3D.cli.app import app
     result = runner.invoke(app, ["config", "validate", "nonexistent.yaml"])
-    assert result.exit_code == 1
-    assert "not found" in result.stderr
+    assert result.exit_code == 2
+    assert "does not exist" in result.output

--- a/tests/test_cli_property_commands.py
+++ b/tests/test_cli_property_commands.py
@@ -1,0 +1,176 @@
+# tests/test_cli_property_commands.py
+"""Fast CLI tests for the new first-class property subcommands and the
+modernization changes (exit codes, enums, path validation, --save-intermediate,
+config init --force). The heavy API functions are mocked, so no NNP runs here.
+"""
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from Auto3D.cli.app import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def sdf(tmp_path):
+    p = tmp_path / "mols.sdf"
+    p.write_text("")  # existence is all that matters; calc_* is mocked
+    return p
+
+
+@pytest.fixture
+def smi(tmp_path):
+    p = tmp_path / "mols.smi"
+    p.write_text("CCO ethanol\n")
+    return p
+
+
+# --- parity: each new command reaches its API function ----------------------
+
+def test_energy_invokes_calc_spe(sdf):
+    with patch("Auto3D.SPE.calc_spe", return_value="out_E.sdf") as m:
+        res = runner.invoke(app, ["energy", str(sdf), "--no-gpu", "--engine", "ANI2x"])
+    assert res.exit_code == 0, res.output
+    _, kwargs = m.call_args
+    assert kwargs["use_gpu"] is False
+    assert kwargs["allow_tf32"] is False
+    assert kwargs["out_path"] is None
+
+
+def test_energy_output_flag(sdf, tmp_path):
+    out = tmp_path / "custom.sdf"
+    with patch("Auto3D.SPE.calc_spe", return_value=str(out)) as m:
+        res = runner.invoke(app, ["energy", str(sdf), "--no-gpu", "-o", str(out)])
+    assert res.exit_code == 0, res.output
+    assert m.call_args.kwargs["out_path"] == str(out)
+
+
+def test_optimize_invokes_opt_geometry(sdf):
+    with patch("Auto3D.ASE.geometry.opt_geometry", return_value="out_opt.sdf") as m:
+        res = runner.invoke(app, ["optimize", str(sdf), "--no-gpu", "--opt-steps", "5"])
+    assert res.exit_code == 0, res.output
+    assert m.call_args.kwargs["opt_steps"] == 5
+
+
+def test_tautomers_invokes_get_stable_tautomers(smi):
+    with patch("Auto3D.tautomer.get_stable_tautomers", return_value="out_taut.sdf") as m:
+        res = runner.invoke(app, ["tautomers", str(smi), "--no-gpu", "--tauto-k", "3"])
+    assert res.exit_code == 0, res.output
+    assert m.call_args.kwargs["tauto_k"] == 3
+
+
+# --- error handling / exit codes --------------------------------------------
+
+def test_missing_input_path_exits_2(tmp_path):
+    res = runner.invoke(app, ["energy", str(tmp_path / "nope.sdf")])
+    assert res.exit_code == 2  # Typer exists=True usage error
+    assert "Traceback" not in res.output
+
+
+def test_tautomers_k_and_window_mutually_exclusive(smi):
+    res = runner.invoke(app, ["tautomers", str(smi), "--tauto-k", "1", "--tauto-window", "2"])
+    assert res.exit_code == 2  # ConfigurationError -> exit 2
+    assert "Traceback" not in res.output
+
+
+def test_thermo_without_ase_raises_dependency_error(sdf, monkeypatch):
+    # Make `from Auto3D.ASE.thermo import calc_thermo` fail like a missing extra.
+    monkeypatch.setitem(sys.modules, "Auto3D.ASE.thermo", None)
+    res = runner.invoke(app, ["thermo", str(sdf), "--no-gpu"])
+    assert res.exit_code == 3  # DependencyError -> exit 3
+    assert "Traceback" not in res.output
+
+
+def test_exit_code_mapping():
+    from Auto3D.cli.errors import exit_code_for
+    from Auto3D.exceptions import (
+        ConfigurationError,
+        DependencyError,
+        GPUError,
+        InputValidationError,
+        ModelNotFoundError,
+        OptimizationError,
+    )
+    assert exit_code_for(ConfigurationError("x")) == 2
+    assert exit_code_for(InputValidationError("x")) == 2
+    assert exit_code_for(DependencyError("x")) == 3
+    assert exit_code_for(GPUError("x")) == 4
+    assert exit_code_for(ModelNotFoundError("x")) == 5
+    assert exit_code_for(OptimizationError("x")) == 1  # generic
+    assert exit_code_for(RuntimeError("x")) == 1
+
+
+# --- modernization ----------------------------------------------------------
+
+def test_engine_autocomplete():
+    from Auto3D.cli.commands.properties import engine_autocomplete
+    assert "aimnet2-2025" in engine_autocomplete("aimnet2")
+    assert "ANI2x" in engine_autocomplete("ANI")
+    assert engine_autocomplete("ZZZ") == []
+
+
+def test_run_save_intermediate_sets_verbose(smi):
+    """--save-intermediate must propagate to Auto3DOptions.verbose."""
+    captured = {}
+
+    def fake_main(options):
+        captured["verbose"] = options.verbose
+        return "nonexistent_out.sdf"  # count_from_output skips a missing file
+
+    with patch("Auto3D.auto3D.main", side_effect=fake_main):
+        res = runner.invoke(app, ["run", str(smi), "--k", "1", "--no-gpu", "--save-intermediate"])
+    assert res.exit_code == 0, res.output
+    assert captured.get("verbose") is True
+
+
+def test_run_without_save_intermediate_keeps_verbose_false(smi):
+    captured = {}
+
+    def fake_main(options):
+        captured["verbose"] = options.verbose
+        return "nonexistent_out.sdf"
+
+    with patch("Auto3D.auto3D.main", side_effect=fake_main):
+        res = runner.invoke(app, ["run", str(smi), "--k", "1", "--no-gpu"])
+    assert res.exit_code == 0, res.output
+    assert captured.get("verbose") is False
+
+
+def test_config_init_force(tmp_path):
+    target = tmp_path / "cfg.yaml"
+    sentinel = "path: x.smi\n"
+    target.write_text(sentinel)
+    # Without --force: refuse to clobber (exit 1, file left untouched).
+    res = runner.invoke(app, ["config", "init", "-o", str(target)])
+    assert res.exit_code == 1
+    assert target.read_text() == sentinel  # not overwritten
+    # With --force: overwrite.
+    res2 = runner.invoke(app, ["config", "init", "-o", str(target), "--force"])
+    assert res2.exit_code == 0, res2.output
+    assert target.read_text() != sentinel  # regenerated
+
+
+def test_config_init_preset_enum_valid(tmp_path):
+    target = tmp_path / "cfg.yaml"
+    res = runner.invoke(app, ["config", "init", "-o", str(target), "-p", "thorough"])
+    assert res.exit_code == 0, res.output
+    assert target.exists()
+
+
+def test_api_functions_expose_new_params():
+    """calc_spe/opt_geometry/calc_thermo must accept out_path/use_gpu/allow_tf32
+    so the CLI can drive output location, GPU choice, and TF32 uniformly."""
+    import inspect
+
+    from Auto3D.ASE.geometry import opt_geometry
+    from Auto3D.ASE.thermo import calc_thermo
+    from Auto3D.SPE import calc_spe
+
+    for fn in (calc_spe, opt_geometry, calc_thermo):
+        params = inspect.signature(fn).parameters
+        assert {"out_path", "use_gpu", "allow_tf32"} <= set(params), fn.__name__


### PR DESCRIPTION
A three-agent review (CLI↔API parity, CLI UX, public-API architecture) found the CLI was first-class only for conformer generation; single-point energy, geometry optimization, thermochemistry, and tautomer ranking were Python-only. This closes that gap and modernizes the CLI.

### New first-class subcommands
- `auto3d energy <in.sdf>` → `calc_spe`
- `auto3d optimize <in.sdf>` → `opt_geometry`
- `auto3d thermo <in.sdf>` → `calc_thermo` (clear DependencyError if the `ase` extra is missing)
- `auto3d tautomers <in.smi>` → `get_stable_tautomers`

Each validates its input path, shares `--engine`/`--gpu`/`--gpu-idx`/`-o`/`--json`, and routes failures through `handle_error`.

### Bug fixes (CLI divergences)
- `auto3d run` `--save-intermediate` now maps to `Auto3DOptions.verbose` (previously unreachable except via YAML); `--job-name` added.
- Legacy `auto3d <config.yaml>` no longer leaks tracebacks (checks existence, funnels all errors through `handle_error`, real deprecation warning).
- `allow_tf32` was a silent no-op for the energy/optimize/thermo paths — they now route through the shared device + torch config so it applies (small numerical change when enabled).
- Removed the dead failure-detail branch in `run`.

### Modernization
- Differentiated exit codes (config/input 2, dependency 3, GPU 4, model 5, generic 1).
- `--preset` enum + `--engine` shell completion; Typer-level input-path existence validation; `config init --force`.
- Minimal backwards-compatible API additions: `out_path`/`use_gpu`/`allow_tf32` on `calc_spe`/`opt_geometry`/`calc_thermo`.

Docs (README, `docs/source/cli.rst`, CHANGELOG) updated. Fast gate: 663 passed (+14 new CLI tests); ruff clean on `src/`.

Deferred (from the API review): deeper API coherence (push `WorkflowResults` down, de-duplicate config field declarations + sync test, promote tautomer functions to `__all__`, `generate_conformers` alias, registry-aware `models`).