### PR TITLE
API coherence: WorkflowResult return type, public-surface hygiene, config de-dup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   codes (2 config/input, 3 dependency, 4 GPU, 5 model).
 - **API**: `calc_spe`, `opt_geometry`, and `calc_thermo` accept `out_path`,
   `use_gpu`, and `allow_tf32` (backwards-compatible).
+- **`generate_conformers`** - canonical, self-describing alias for `main()`
+  (`main` remains exported). `get_stable_tautomers` and `select_tautomers` are
+  now part of the public API (`Auto3D.__all__`).
+- **`main()` returns a `WorkflowResult`** - a `str` subclass holding the output
+  SDF path (drop-in for the previous return value) plus `n_molecules` /
+  `n_conformers` counts, so callers no longer need to re-read the output.
 
 ### Changed
 

--- a/src/Auto3D/ASE/geometry.py
+++ b/src/Auto3D/ASE/geometry.py
@@ -10,19 +10,26 @@ from rdkit import Chem
 
 from Auto3D.batch_opt.batchopt import optimizing
 from Auto3D.config import OptimizationConfig
+from Auto3D.constants import (
+    DEFAULT_BATCHSIZE_ATOMS,
+    DEFAULT_CONVERGENCE_THRESHOLD,
+    DEFAULT_OPT_STEPS,
+)
 from Auto3D.model_factory import get_device
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
+
+__all__ = ["opt_geometry"]
 
 
 def opt_geometry(
     path: str,
     model_name: str,
     gpu_idx: int = 0,
-    opt_tol: float = 0.01,
-    opt_steps: int = 2000,
+    opt_tol: float = DEFAULT_CONVERGENCE_THRESHOLD,
+    opt_steps: int = DEFAULT_OPT_STEPS,
     patience: int | None = None,
-    batchsize_atoms: int = 1024,
+    batchsize_atoms: int = DEFAULT_BATCHSIZE_ATOMS,
     use_gpu: bool = True,
     allow_tf32: bool = False,
     out_path: str | None = None,

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -21,10 +21,13 @@ from tqdm import tqdm
 
 from Auto3D.batch_opt.ANI2xt_no_rep import ANI2xt
 from Auto3D.batch_opt.batchopt import EnForce_ANI
+from Auto3D.constants import DEFAULT_OPT_STEPS, DEFAULT_THERMO_CONVERGENCE_THRESHOLD
 from Auto3D.model_factory import create_model, get_device
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
 from Auto3D.utils.logging_config import get_logger
+
+__all__ = ["calc_thermo"]
 
 # TF32 settings are configured centrally via Auto3D.torch_config.configure_torch()
 # and the allow_tf32 option in Auto3DOptions.
@@ -382,7 +385,8 @@ def aimnet_hessian_helper(
         return e  # energy unit: eV
 
 def calc_thermo(path: str, model_name: str, mol_info_func=None,
-                gpu_idx=0, opt_tol=0.0002, opt_steps=2000,
+                gpu_idx=0, opt_tol=DEFAULT_THERMO_CONVERGENCE_THRESHOLD,
+                opt_steps=DEFAULT_OPT_STEPS,
                 use_gpu: bool = True, allow_tf32: bool = False,
                 out_path: str | None = None):
     """ASE interface for calculating thermo properties using ANI2x, ANI2xt or AIMNET.

--- a/src/Auto3D/SPE.py
+++ b/src/Auto3D/SPE.py
@@ -15,6 +15,8 @@ from Auto3D.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+__all__ = ["calc_spe"]
+
 ev2hatree = 1/hartree2ev
 
 

--- a/src/Auto3D/__init__.py
+++ b/src/Auto3D/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     "__version__",
     # Core API
     "main",
+    "generate_conformers",  # canonical alias for main()
     "smiles2mols",
     # Configuration
     "Auto3DOptions",
@@ -44,43 +45,39 @@ __all__ = [
     # Model creation
     "create_model",
     "ModelFactory",
-    # Utilities
+    # Property calculators
     "calc_spe",
     "opt_geometry",
     "calc_thermo",
+    # Tautomers
+    "get_stable_tautomers",
+    "select_tautomers",
 ]
+
+# name -> (module, attribute) for lazy public-API imports. generate_conformers is
+# the canonical, self-describing alias for main(); main stays for back-compat.
+_LAZY_API: dict[str, tuple[str, str]] = {
+    "main": ("Auto3D.auto3D", "main"),
+    "generate_conformers": ("Auto3D.auto3D", "main"),
+    "smiles2mols": ("Auto3D.auto3D", "smiles2mols"),
+    "Auto3DOptions": ("Auto3D.config", "Auto3DOptions"),
+    "OptimizationConfig": ("Auto3D.config", "OptimizationConfig"),
+    "NNPModel": ("Auto3D.config", "NNPModel"),
+    "create_model": ("Auto3D.model_factory", "create_model"),
+    "ModelFactory": ("Auto3D.model_factory", "ModelFactory"),
+    "calc_spe": ("Auto3D.SPE", "calc_spe"),
+    "opt_geometry": ("Auto3D.ASE.geometry", "opt_geometry"),
+    "calc_thermo": ("Auto3D.ASE.thermo", "calc_thermo"),
+    "get_stable_tautomers": ("Auto3D.tautomer", "get_stable_tautomers"),
+    "select_tautomers": ("Auto3D.tautomer", "select_tautomers"),
+}
+
 
 # Lazy imports for public API
 def __getattr__(name: str):
-    """Lazy import for public API functions."""
-    if name == "main":
-        from Auto3D.auto3D import main
-        return main
-    elif name == "smiles2mols":
-        from Auto3D.auto3D import smiles2mols
-        return smiles2mols
-    elif name == "Auto3DOptions":
-        from Auto3D.config import Auto3DOptions
-        return Auto3DOptions
-    elif name == "OptimizationConfig":
-        from Auto3D.config import OptimizationConfig
-        return OptimizationConfig
-    elif name == "NNPModel":
-        from Auto3D.config import NNPModel
-        return NNPModel
-    elif name == "create_model":
-        from Auto3D.model_factory import create_model
-        return create_model
-    elif name == "ModelFactory":
-        from Auto3D.model_factory import ModelFactory
-        return ModelFactory
-    elif name == "calc_spe":
-        from Auto3D.SPE import calc_spe
-        return calc_spe
-    elif name == "opt_geometry":
-        from Auto3D.ASE.geometry import opt_geometry
-        return opt_geometry
-    elif name == "calc_thermo":
-        from Auto3D.ASE.thermo import calc_thermo
-        return calc_thermo
+    """Lazy import for public API functions (see _LAZY_API)."""
+    if name in _LAZY_API:
+        import importlib
+        module_name, attr = _LAZY_API[name]
+        return getattr(importlib.import_module(module_name), attr)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/Auto3D/auto3D.py
+++ b/src/Auto3D/auto3D.py
@@ -7,9 +7,13 @@ from __future__ import annotations
 import multiprocessing as mp
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import torch
 from rdkit import Chem
+
+if TYPE_CHECKING:
+    from Auto3D.results import WorkflowResult
 
 from Auto3D.batch_opt.batchopt import optimizing
 from Auto3D.config import Auto3DOptions
@@ -39,14 +43,16 @@ logger = get_logger(__name__)
 # and the allow_tf32 option in Auto3DOptions. Configuration is applied at pipeline start.
 
 
-def main(args: Auto3DOptions) -> str:
+def main(args: Auto3DOptions) -> WorkflowResult:
     """Run the Auto3D conformer generation pipeline.
 
     Args:
         args: Configuration options as an ``Auto3DOptions`` instance.
 
     Returns:
-        Path to the output SDF file containing generated conformers.
+        A :class:`Auto3D.results.WorkflowResult` -- a ``str`` subclass holding
+        the output SDF path (so it works anywhere the path string did) plus the
+        run's ``n_molecules`` / ``n_conformers`` counts.
 
     Raises:
         SystemExit: If input validation fails or no structures converge.
@@ -70,8 +76,10 @@ def main(args: Auto3DOptions) -> str:
     # (e.g. a prior use_gpu=True call in the same interpreter / test session).
     mp.set_start_method("spawn", force=True)
 
+    from Auto3D.results import WorkflowResult
+
     orchestrator = WorkflowOrchestrator(args)
-    return orchestrator.run()
+    return WorkflowResult(orchestrator.run())
 
 def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
     """Find low-energy conformers for a list of SMILES.

--- a/src/Auto3D/cli/commands/run.py
+++ b/src/Auto3D/cli/commands/run.py
@@ -113,12 +113,13 @@ def execute_run(
 
         elapsed = time.time() - start_time
 
-        # Build results from the real output file
-        from Auto3D.cli.results import count_from_output, count_input_molecules
-        if output_path and Path(output_path).exists():
-            molecules, conformers = count_from_output(str(output_path))
-        else:
-            molecules, conformers = 0, 0
+        # main() returns a WorkflowResult (a path str carrying the counts), so we
+        # read them off the result instead of re-opening the output SDF here.
+        # getattr keeps the old graceful (0, 0) if a caller/mocks ever hand back a
+        # plain str instead of a WorkflowResult.
+        from Auto3D.cli.results import count_input_molecules
+        molecules = getattr(output_path, "n_molecules", 0)
+        conformers = getattr(output_path, "n_conformers", 0)
         # Failures = input molecules that produced no conformer. Per-molecule
         # failure *details* are not yet wired through the workflow, but the count
         # is recoverable as inputs minus produced molecules so the summary no

--- a/src/Auto3D/cli/results.py
+++ b/src/Auto3D/cli/results.py
@@ -129,21 +129,13 @@ def count_input_molecules(input_path: str) -> int:
 def count_from_output(output_path: str) -> tuple[int, int]:
     """Return (unique_molecule_count, conformer_count) from an output SDF.
 
-    Molecule identity is the input ID - the part of the conformer name
-    before the first '@' (the tautomer separator, "id@tautN"), so all
-    tautomers of one input molecule count as a single molecule.
+    Thin back-compat wrapper around :func:`Auto3D.results.count_output` (the
+    single source of truth). ``main()`` now returns a ``WorkflowResult`` that
+    carries these counts, so the CLI reads them off the result instead.
     """
-    from rdkit import Chem
+    from Auto3D.results import count_output
 
-    suppl = Chem.SDMolSupplier(output_path, removeHs=False)
-    ids: set[str] = set()
-    conformers = 0
-    for mol in suppl:
-        if mol is None:
-            continue
-        conformers += 1
-        ids.add(mol.GetProp("_Name").split("@")[0].strip())
-    return len(ids), conformers
+    return count_output(output_path)
 
 
 def output_json(results: WorkflowResults) -> None:

--- a/src/Auto3D/constants.py
+++ b/src/Auto3D/constants.py
@@ -62,6 +62,10 @@ DEFAULT_RMSD_THRESHOLD = 0.3  # Angstrom, for duplicate conformer removal
 # (~1e-3 eV) so truly identical conformers still dedup.
 DEFAULT_DUPLICATE_ENERGY_TOL = 0.01
 DEFAULT_CONVERGENCE_THRESHOLD = 0.01  # eV/Angstrom, force convergence
+# eV/Angstrom, the deliberately tighter pre-optimization force tolerance used by
+# the thermochemistry path (calc_thermo): a true minimum is needed before a
+# Hessian/frequency calculation, unlike conformer generation where 0.01 suffices.
+DEFAULT_THERMO_CONVERGENCE_THRESHOLD = 2e-4
 DEFAULT_OPT_STEPS = 2000  # Maximum optimization steps
 DEFAULT_PATIENCE = 250  # Steps before dropping oscillating conformer
 DEFAULT_BATCHSIZE_ATOMS = 1024  # Atoms per batch for GPU optimization

--- a/src/Auto3D/results.py
+++ b/src/Auto3D/results.py
@@ -1,0 +1,59 @@
+"""Result type for the conformer-generation pipeline.
+
+``main()`` returns a :class:`WorkflowResult`, a ``str`` subclass that *is* the
+output SDF path (so every existing caller -- ``Path(out)``, ``open(out)``,
+``print(out)``, string ops -- keeps working unchanged) but also exposes the
+molecule/conformer counts of the run. The counts are computed lazily on first
+access and cached, so callers that only need the path pay nothing.
+"""
+from __future__ import annotations
+
+from functools import cached_property
+from pathlib import Path
+
+
+def count_output(output_path: str) -> tuple[int, int]:
+    """Return (unique_molecule_count, conformer_count) for an output SDF.
+
+    Molecule identity is the input id -- the part of the conformer name before
+    the first ``@`` (the tautomer separator, ``id@tautN``), so all tautomers of
+    one input molecule count as a single molecule. A missing/unreadable file
+    yields ``(0, 0)``.
+    """
+    from rdkit import Chem
+
+    if not output_path or not Path(output_path).exists():
+        return (0, 0)
+
+    ids: set[str] = set()
+    conformers = 0
+    with Chem.SDMolSupplier(str(output_path), removeHs=False) as supplier:
+        for mol in supplier:
+            if mol is None:
+                continue
+            conformers += 1
+            ids.add(mol.GetProp("_Name").split("@")[0].strip())
+    return (len(ids), conformers)
+
+
+class WorkflowResult(str):
+    """Output SDF path annotated with the run's molecule/conformer counts.
+
+    Subclasses ``str`` (value = the output path) so it is a drop-in for the path
+    string the pipeline historically returned. ``n_molecules`` / ``n_conformers``
+    are read from the output SDF lazily and cached.
+    """
+
+    @cached_property
+    def _counts(self) -> tuple[int, int]:
+        return count_output(str(self))
+
+    @property
+    def n_molecules(self) -> int:
+        """Number of distinct input molecules that produced a conformer."""
+        return self._counts[0]
+
+    @property
+    def n_conformers(self) -> int:
+        """Total number of conformers written to the output SDF."""
+        return self._counts[1]

--- a/src/Auto3D/tautomer.py
+++ b/src/Auto3D/tautomer.py
@@ -12,6 +12,8 @@ from Auto3D.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+__all__ = ["select_tautomers", "get_stable_tautomers"]
+
 
 def select_tautomers(sdf: str, k: int | None = None, window: float | None = None) -> str:
     """Select and Write the top-k or E <= window tautomers for each input SMILES

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -275,7 +275,8 @@ def test_json_output_is_pure_json(runner, tmp_path_cwd, monkeypatch):
     with Chem.SDWriter(str(out)) as w:
         m = Chem.AddHs(Chem.MolFromSmiles("CCO")); AllChem.EmbedMolecule(m, randomSeed=1)
         m.SetProp("_Name", "mol1"); w.write(m)
-    monkeypatch.setattr(a3d, "main", lambda options: str(out))
+    from Auto3D.results import WorkflowResult
+    monkeypatch.setattr(a3d, "main", lambda options: WorkflowResult(str(out)))
 
     result = runner.invoke(app, ["run", str(smi), "--json"])
     assert result.exit_code == 0

--- a/tests/test_cli_config_schema.py
+++ b/tests/test_cli_config_schema.py
@@ -139,3 +139,19 @@ def test_shipped_parameters_yaml_loads():
     assert cfg.k == 1
     assert cfg.window is None
     cfg.to_auto3d_options()  # must not raise
+
+
+def test_cliconfig_covers_all_auto3doptions_fields():
+    """Guard against config-layer drift: every user-facing Auto3DOptions field
+    must be reachable from the CLI/YAML via CLIConfig. ``input_format`` is set
+    internally by the workflow, so it is the only allowed exclusion."""
+    import dataclasses
+
+    from Auto3D.cli.config_schema import CLIConfig
+    from Auto3D.config import Auto3DOptions
+
+    excluded = {"input_format"}
+    opt_fields = {f.name for f in dataclasses.fields(Auto3DOptions)} - excluded
+    cli_fields = set(CLIConfig.model_fields)
+    missing = opt_fields - cli_fields
+    assert not missing, f"CLIConfig is missing Auto3DOptions fields: {missing}"

--- a/tests/test_cli_property_commands.py
+++ b/tests/test_cli_property_commands.py
@@ -116,11 +116,12 @@ def test_engine_autocomplete():
 
 def test_run_save_intermediate_sets_verbose(smi):
     """--save-intermediate must propagate to Auto3DOptions.verbose."""
+    from Auto3D.results import WorkflowResult
     captured = {}
 
     def fake_main(options):
         captured["verbose"] = options.verbose
-        return "nonexistent_out.sdf"  # count_from_output skips a missing file
+        return WorkflowResult("nonexistent_out.sdf")  # counts -> 0 (missing file)
 
     with patch("Auto3D.auto3D.main", side_effect=fake_main):
         res = runner.invoke(app, ["run", str(smi), "--k", "1", "--no-gpu", "--save-intermediate"])
@@ -129,11 +130,12 @@ def test_run_save_intermediate_sets_verbose(smi):
 
 
 def test_run_without_save_intermediate_keeps_verbose_false(smi):
+    from Auto3D.results import WorkflowResult
     captured = {}
 
     def fake_main(options):
         captured["verbose"] = options.verbose
-        return "nonexistent_out.sdf"
+        return WorkflowResult("nonexistent_out.sdf")
 
     with patch("Auto3D.auto3D.main", side_effect=fake_main):
         res = runner.invoke(app, ["run", str(smi), "--k", "1", "--no-gpu"])

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,37 @@
+# tests/test_public_api.py
+"""Lock the public API surface: everything in Auto3D.__all__ resolves, the
+generate_conformers alias points at main, the tautomer functions are public,
+and the property/tautomer modules declare their own __all__."""
+from __future__ import annotations
+
+import importlib
+
+
+def test_all_public_names_resolve():
+    import Auto3D
+    for name in Auto3D.__all__:
+        if name == "__version__":
+            continue
+        assert getattr(Auto3D, name) is not None, name
+
+
+def test_generate_conformers_is_main():
+    import Auto3D
+    assert Auto3D.generate_conformers is Auto3D.main
+
+
+def test_tautomer_functions_public():
+    import Auto3D
+    assert callable(Auto3D.get_stable_tautomers)
+    assert callable(Auto3D.select_tautomers)
+
+
+def test_module_all_declared():
+    for mod_name, expected in (
+        ("Auto3D.SPE", {"calc_spe"}),
+        ("Auto3D.ASE.geometry", {"opt_geometry"}),
+        ("Auto3D.ASE.thermo", {"calc_thermo"}),
+        ("Auto3D.tautomer", {"select_tautomers", "get_stable_tautomers"}),
+    ):
+        mod = importlib.import_module(mod_name)
+        assert set(mod.__all__) == expected, mod_name

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,44 @@
+# tests/test_results.py
+"""WorkflowResult is a backwards-compatible str carrying lazy run counts."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from Auto3D.results import WorkflowResult, count_output
+
+
+def _write_sdf(path, names):
+    with Chem.SDWriter(str(path)) as w:
+        for name in names:
+            m = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+            AllChem.EmbedMolecule(m, randomSeed=1)
+            m.SetProp("_Name", name)
+            w.write(m)
+
+
+def test_workflow_result_is_str_compatible(tmp_path):
+    p = tmp_path / "out.sdf"
+    r = WorkflowResult(str(p))
+    assert isinstance(r, str)
+    assert os.fspath(r) == str(p)
+    assert Path(r) == p
+    assert r == str(p)
+
+
+def test_workflow_result_counts(tmp_path):
+    p = tmp_path / "out.sdf"
+    # two conformers of molecule "a" (a@taut0/@taut1 collapse to one molecule)
+    # and one of molecule "b" -> 2 molecules, 3 conformers.
+    _write_sdf(p, ["a@taut0", "a@taut1", "b"])
+    r = WorkflowResult(str(p))
+    assert r.n_molecules == 2
+    assert r.n_conformers == 3
+
+
+def test_count_output_missing_file_is_zero(tmp_path):
+    assert count_output(str(tmp_path / "nope.sdf")) == (0, 0)
+    assert count_output("") == (0, 0)


### PR DESCRIPTION
The deferred API-coherence work from the CLI review. Two independent reviews (architecture + correctness) verified the change set is backwards-compatible and ship-able; the one actionable finding (defensive count read in `run.py`) was applied.

### `main()` returns a `WorkflowResult`
A `str` subclass whose value is the output SDF path — a verified drop-in for the previous return (isinstance(str), `Path()`, `open()`, `==`, hashing, pickling, `json.dumps` all behave identically) — that also exposes `n_molecules`/`n_conformers`, computed lazily and cached. The CLI reads these off the result instead of re-opening the SDF; `count_from_output` now delegates to a single-source core `count_output`.

### Public-surface hygiene
- `get_stable_tautomers`/`select_tautomers` promoted into `Auto3D.__all__`; added a self-describing `generate_conformers` alias for `main()` (`main` stays exported); lazy `__getattr__` refactored into one `name -> (module, attr)` table.
- Module-level `__all__` added to `SPE.py`, `ASE/geometry.py`, `ASE/thermo.py`, `tautomer.py`.

### Config coherence
- Replaced hardcoded `opt_tol`/`opt_steps`/`batchsize_atoms` literals in `opt_geometry`/`calc_thermo` with the `DEFAULT_*` constants (same values; thermo's 2e-4 becomes `DEFAULT_THERMO_CONVERGENCE_THRESHOLD`).
- Added a test asserting `CLIConfig` covers every public `Auto3DOptions` field, so the config layers can't silently drift.

All values preserved (no behavior change). Fast gate: 671 passed (+8 new tests); ruff clean on `src/`. CHANGELOG updated.

Still deferred (CLI/feature, not API coherence): registry-aware `models` (`models test <engine>`), wiring `progress.py`'s live display into the run loop.