### PR TITLE
Live optimization progress display in auto3d run

### DIFF
--- a/src/Auto3D/auto3D.py
+++ b/src/Auto3D/auto3D.py
@@ -13,6 +13,8 @@ import torch
 from rdkit import Chem
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from Auto3D.results import WorkflowResult
 
 from Auto3D.batch_opt.batchopt import optimizing
@@ -43,11 +45,18 @@ logger = get_logger(__name__)
 # and the allow_tf32 option in Auto3DOptions. Configuration is applied at pipeline start.
 
 
-def main(args: Auto3DOptions) -> WorkflowResult:
+def main(
+    args: Auto3DOptions,
+    progress_callback: Callable[[dict], None] | None = None,
+) -> WorkflowResult:
     """Run the Auto3D conformer generation pipeline.
 
     Args:
         args: Configuration options as an ``Auto3DOptions`` instance.
+        progress_callback: Optional callable invoked with per-step optimizer
+            progress events (dicts with ``job``/``step``/``total``/``converged``/
+            ``dropped``/``active``) for a live display. Defaults to None, which
+            leaves the pipeline behavior unchanged.
 
     Returns:
         A :class:`Auto3D.results.WorkflowResult` -- a ``str`` subclass holding
@@ -78,7 +87,7 @@ def main(args: Auto3DOptions) -> WorkflowResult:
 
     from Auto3D.results import WorkflowResult
 
-    orchestrator = WorkflowOrchestrator(args)
+    orchestrator = WorkflowOrchestrator(args, progress_callback=progress_callback)
     return WorkflowResult(orchestrator.run())
 
 def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:

--- a/src/Auto3D/batch_opt/batchopt.py
+++ b/src/Auto3D/batch_opt/batchopt.py
@@ -7,6 +7,8 @@ import torch
 from Auto3D.utils.logging_config import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from Auto3D.config import OptimizationConfig
 
 logger = get_logger(__name__)
@@ -49,6 +51,7 @@ def ensemble_opt(
     param: dict,
     device: torch.device,
     species_pad: int = -1,
+    progress_cb: "Callable[[dict], None] | None" = None,
 ) -> dict:
     """Optimize a group of molecules using batch optimization.
 
@@ -117,7 +120,7 @@ def ensemble_opt(
     energy_patience = param.get('energy_patience', 3)
     n_steps(state, param['opt_steps'], param['opttol'], param['patience'],
             energy_tol=energy_tol, energy_patience=energy_patience,
-            species_pad=species_pad)
+            species_pad=species_pad, progress_cb=progress_cb)
 
     return dict(
         coord=state['coord'].tolist(),
@@ -142,6 +145,7 @@ class optimizing:
         device: torch.device,
         config: "OptimizationConfig | dict",
         use_ensemble: bool = False,
+        progress_cb: "Callable[[dict], None] | None" = None,
     ):
         """Initialize optimization runner.
 
@@ -158,6 +162,7 @@ class optimizing:
         self.out_f = out_f
         self.name = name
         self.device = device
+        self.progress_cb = progress_cb
 
         # Support both OptimizationConfig and legacy dict
         if isinstance(config, dict):
@@ -246,7 +251,8 @@ class optimizing:
         # `with torch.jit.optimized_execution(False)` guard here was a no-op.
         optdict = ensemble_opt(model, coord_padded, numbers_padded, charges,
                                self._config_dict, self.device,
-                               species_pad=self.species_pad)  # Magic step
+                               species_pad=self.species_pad,
+                               progress_cb=self.progress_cb)  # Magic step
         return optdict
 
     def run(self):

--- a/src/Auto3D/batch_opt/optimization_engine.py
+++ b/src/Auto3D/batch_opt/optimization_engine.py
@@ -6,6 +6,7 @@ This module contains the main optimization loop (n_steps) and status reporting
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -51,6 +52,21 @@ def _validate_state(state: dict[str, Any]) -> None:
         )
 
 
+def optimization_counts(state: dict[str, Any], patience: int) -> tuple[int, int, int, int]:
+    """Return (total, converged, dropped, active) structure counts from state.
+
+    ``converged`` excludes structures dropped for oscillation; ``active`` is the
+    number still being optimized. Performs a small host-device sync (sum of two
+    boolean masks), so callers gate how often they invoke it.
+    """
+    num_total = int(state['numbers'].size()[0])
+    num_converged_dropped = int(torch.sum(state['converged_mask']).to('cpu'))
+    num_dropped = int(torch.sum(state['oscillating_count'].to('cpu') >= patience))
+    num_converged = num_converged_dropped - num_dropped
+    num_active = num_total - num_converged_dropped
+    return num_total, num_converged, num_dropped, num_active
+
+
 def print_stats(state: dict[str, Any], patience: int) -> None:
     """Print the optimization status.
 
@@ -64,13 +80,7 @@ def print_stats(state: dict[str, Any], patience: int) -> None:
             - oscillating_count: Oscillation counter tensor, shape (batch,)
         patience: Number of steps without force decrease before dropping a structure.
     """
-    numbers = state['numbers']
-    num_total = numbers.size()[0]
-    num_converged_dropped = torch.sum(state['converged_mask']).to('cpu')
-    oscillating_count = state['oscillating_count'].to('cpu') >= patience
-    num_dropped = torch.sum(oscillating_count)
-    num_converged = num_converged_dropped - num_dropped
-    num_active = num_total - num_converged_dropped
+    num_total, num_converged, num_dropped, num_active = optimization_counts(state, patience)
     logger.info("Total 3D structures: %i  Converged: %i   Dropped(Oscillating): %i    Active: %i" %
           (num_total, num_converged, num_dropped, num_active))
 
@@ -83,6 +93,7 @@ def n_steps(
     energy_tol: float = DEFAULT_ENERGY_TOL,
     energy_patience: int = 3,
     species_pad: int = -1,
+    progress_cb: Callable[[dict], None] | None = None,
 ) -> None:
     """Run n optimization steps for each input structure.
 
@@ -232,6 +243,27 @@ def n_steps(
         # Print stats every 10% of steps (avoid division by zero for small n)
         if n >= 10 and (istep % (n // 10)) == 0:
             print_stats(state, patience)
+
+        # Emit a live-progress event for the CLI display. Reuses the istep % 10
+        # sync cadence; only active when a callback was supplied (i.e. interactive
+        # `auto3d run`), so the default/library path adds nothing. Guarded so a
+        # progress hiccup can never abort the optimization.
+        if progress_cb is not None and istep % 10 == 0:
+            try:
+                total, converged, dropped, active = optimization_counts(state, patience)
+                progress_cb({"step": istep, "total": total, "converged": converged,
+                             "dropped": dropped, "active": active})
+            except Exception:
+                pass
+
+    # Final event so the display reflects the converged end state.
+    if progress_cb is not None:
+        try:
+            total, converged, dropped, active = optimization_counts(state, patience)
+            progress_cb({"step": istep, "total": total, "converged": converged,
+                         "dropped": dropped, "active": active})
+        except Exception:
+            pass
 
     # Energy and fmax stored during the loop are evaluated at the pre-step
     # geometry, while the stored coordinates are post-step (the loop always takes

--- a/src/Auto3D/cli/commands/run.py
+++ b/src/Auto3D/cli/commands/run.py
@@ -106,9 +106,23 @@ def execute_run(
         from Auto3D.auto3D import main
 
         if not quiet and not json_output:
-            with console.status("[bold]Running Auto3D workflow..."):
-                output_path = main(options)
+            # Interactive: render a live optimization panel (converged/active/
+            # dropped/step) fed by per-step events from the optimizer workers.
+            from rich.live import Live
+
+            from Auto3D.cli.progress import OptimizationDisplay
+
+            display = OptimizationDisplay(0)
+            jobs: dict = {}
+            with Live(display.make_panel(), console=console, refresh_per_second=8) as live:
+                def progress_cb(event: dict) -> None:
+                    jobs[event.get("job", 0)] = event
+                    display.update_from_jobs(jobs)
+                    live.update(display.make_panel())
+
+                output_path = main(options, progress_callback=progress_cb)
         else:
+            # Quiet / JSON: no live display, keep stdout clean for piping.
             output_path = main(options)
 
         elapsed = time.time() - start_time

--- a/src/Auto3D/cli/progress.py
+++ b/src/Auto3D/cli/progress.py
@@ -91,6 +91,23 @@ class OptimizationDisplay:
         if best_energy is not None:
             self.best_energy = best_energy
 
+    def update_from_jobs(self, jobs: dict) -> None:
+        """Aggregate the latest per-job progress events into the display.
+
+        Each value in ``jobs`` is the most recent event for one optimizer worker
+        (``{"total", "converged", "dropped", "active", "step"}``). Counts are
+        summed across jobs and the step shown is the furthest along, so a single
+        optimizer (the common case) renders exactly its own progress and a
+        multi-GPU run shows a sensible aggregate.
+        """
+        if not jobs:
+            return
+        self.total = sum(j.get("total", 0) for j in jobs.values())
+        self.converged = sum(j.get("converged", 0) for j in jobs.values())
+        self.dropped = sum(j.get("dropped", 0) for j in jobs.values())
+        self.active = sum(j.get("active", 0) for j in jobs.values())
+        self.step = max((j.get("step", 0) for j in jobs.values()), default=0)
+
     def make_panel(self) -> Panel:
         """Create a Rich panel showing current status.
 

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -26,6 +26,7 @@ from Auto3D.workflow_workers import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from logging import LogRecord
     from multiprocessing import Queue
 
@@ -44,13 +45,22 @@ class WorkflowOrchestrator:
         >>> output_path = orchestrator.run()
     """
 
-    def __init__(self, config: Auto3DOptions) -> None:
+    def __init__(
+        self,
+        config: Auto3DOptions,
+        progress_callback: Callable[[dict], None] | None = None,
+    ) -> None:
         """Initialize the orchestrator with configuration.
 
         Args:
             config: Auto3D configuration options.
+            progress_callback: Optional callable invoked (in the main process)
+                with per-step optimizer progress events for a live display. When
+                None (the default, and every library/test caller) the pipeline
+                runs exactly as before -- no progress queue, plain blocking joins.
         """
         self.config = config
+        self.progress_callback = progress_callback
         self.job_name: str = ""
         self.job_dir: Path = Path()
         self.input_path: Path = Path()
@@ -276,6 +286,14 @@ class WorkflowOrchestrator:
         """
         chunk_queue: Queue[tuple[str, str, str, int] | str] = mp.Manager().Queue()
 
+        # Process-safe channel for live progress events, created only when a
+        # progress callback was supplied (interactive `auto3d run`). When None,
+        # the optimizer workers emit nothing and the supervise loop below falls
+        # back to plain blocking joins -- the default/library path is unchanged.
+        progress_queue = (
+            mp.Manager().Queue() if self.progress_callback is not None else None
+        )
+
         # Per-run config carrying the memory-scaled batch size for optimization.
         # Built with dataclasses.replace so the caller's shared config is never
         # mutated (review findings #35/#36).
@@ -301,7 +319,8 @@ class WorkflowOrchestrator:
             p2s.append(
                 mp.Process(
                     target=optim_rank_wrapper,
-                    args=(opt_config, chunk_queue, self.logging_queue, idx),
+                    args=(opt_config, chunk_queue, self.logging_queue, idx,
+                          progress_queue),
                 )
             )
 
@@ -313,22 +332,64 @@ class WorkflowOrchestrator:
         # Wait for completion and supervise exit codes. The isomer worker emits
         # a "Done" sentinel per optimizer in a `finally`, so even if it crashed
         # the optimizers will drain and exit rather than block on queue.get().
-        p1.join()
-        if p1.exitcode not in (0, None):
+        if progress_queue is not None:
+            self._supervise_with_progress(p1, p2s, progress_queue)
+        else:
+            p1.join()
+            self._check_exit(p1, "Isomer generation")
+            for p2 in p2s:
+                p2.join()
+                self._check_exit(p2, "Optimization")
+
+    def _check_exit(self, proc: mp.Process, label: str) -> None:
+        """Log a warning if a worker process exited abnormally."""
+        if proc.exitcode not in (0, None):
             logger.error(
-                "Isomer generation process exited with code %s; "
-                "output may be incomplete.",
-                p1.exitcode,
+                "%s process exited with code %s; output may be incomplete.",
+                label, proc.exitcode,
             )
 
+    def _supervise_with_progress(
+        self, p1: mp.Process, p2s: list[mp.Process], progress_queue: Queue[dict]
+    ) -> None:
+        """Drain progress events to the callback while workers run, then join.
+
+        Used only when a progress callback is set. The progress queue is an
+        unbounded Manager queue, so workers never block on put even if draining
+        lags; after the workers exit we drain any buffered events, then join
+        (immediate) and run the same exit-code checks as the default path.
+        """
+        import queue as _queue
+
+        procs = [p1, *p2s]
+        while any(p.is_alive() for p in procs):
+            try:
+                event = progress_queue.get(timeout=0.2)
+            except _queue.Empty:
+                continue
+            self._emit_progress(event)
+        # Drain events buffered after the liveness check.
+        while True:
+            try:
+                event = progress_queue.get_nowait()
+            except _queue.Empty:
+                break
+            self._emit_progress(event)
+
+        p1.join()
+        self._check_exit(p1, "Isomer generation")
         for p2 in p2s:
             p2.join()
-            if p2.exitcode not in (0, None):
-                logger.error(
-                    "Optimization process exited with code %s; "
-                    "output may be incomplete.",
-                    p2.exitcode,
-                )
+            self._check_exit(p2, "Optimization")
+
+    def _emit_progress(self, event: dict) -> None:
+        """Forward one progress event to the callback; never raise."""
+        if self.progress_callback is None:
+            return
+        try:
+            self.progress_callback(event)
+        except Exception:
+            logger.debug("Progress callback failed for event %r", event, exc_info=True)
 
     def _finalize_output(self, start_time: float) -> str:
         """Combine outputs and finalize the pipeline.

--- a/src/Auto3D/workflow_workers.py
+++ b/src/Auto3D/workflow_workers.py
@@ -113,6 +113,7 @@ def optim_rank_wrapper(
     queue: Queue[tuple[str, str, str, int] | str],
     logging_queue: Queue[LogRecord | None],
     gpu_idx: int,
+    progress_queue: Queue[dict] | None = None,
 ) -> list[list[Chem.Mol]]:
     #prepare logging
     logger = logging.getLogger("auto3d")
@@ -141,8 +142,20 @@ def optim_rank_wrapper(
                 device = torch.device(f"cuda:{gpu_idx}")
             else:
                 device = torch.device("cpu")
+            # When a progress queue is supplied (interactive `auto3d run`), tag
+            # each event with this chunk's job id and forward it to the main
+            # process for the live display. Guarded so a full/closed queue can
+            # never break the optimization.
+            progress_cb = None
+            if progress_queue is not None:
+                def progress_cb(event, _q=progress_queue, _job=job):
+                    try:
+                        _q.put({**event, "job": _job})
+                    except Exception:
+                        pass
             optimizer = optimizing(enumerated_sdf, optimized_og,
-                                   optimizing_engine, device, opt_config)
+                                   optimizing_engine, device, opt_config,
+                                   progress_cb=progress_cb)
             optimizer.run()
 
             # optimizing.run() returns early without writing optimized_og when

--- a/tests/test_batchopt.py
+++ b/tests/test_batchopt.py
@@ -238,7 +238,7 @@ def test_optimizing_preserves_input_order(tmp_path, monkeypatch):
             m.SetProp("_Name", str(i)); w.write(m)
 
     def fake_ensemble_opt(net, coord, numbers, charges, param, device,
-                          species_pad=-1):
+                          species_pad=-1, progress_cb=None):
         n = len(coord)
         return dict(coord=coord.tolist(), ids=list(range(n)), energy=[0.0]*n,
                     fmax=[0.0]*n, he=[], close=[], timing={},

--- a/tests/test_cli_property_commands.py
+++ b/tests/test_cli_property_commands.py
@@ -119,7 +119,7 @@ def test_run_save_intermediate_sets_verbose(smi):
     from Auto3D.results import WorkflowResult
     captured = {}
 
-    def fake_main(options):
+    def fake_main(options, progress_callback=None):
         captured["verbose"] = options.verbose
         return WorkflowResult("nonexistent_out.sdf")  # counts -> 0 (missing file)
 
@@ -133,7 +133,7 @@ def test_run_without_save_intermediate_keeps_verbose_false(smi):
     from Auto3D.results import WorkflowResult
     captured = {}
 
-    def fake_main(options):
+    def fake_main(options, progress_callback=None):
         captured["verbose"] = options.verbose
         return WorkflowResult("nonexistent_out.sdf")
 
@@ -205,6 +205,39 @@ def test_models_test_non_finite_exit_code(monkeypatch):
     monkeypatch.setattr("Auto3D.model_factory.create_model", lambda *a, **k: _NanAdapter())
     res = runner.invoke(app, ["models", "test", "AIMNET", "--no-gpu"])
     assert res.exit_code == 5  # NumericalError (ModelError) -> 5
+
+
+def test_run_interactive_forwards_progress_callback(smi):
+    """Interactive `auto3d run` supplies a live-progress callback to main()."""
+    from Auto3D.results import WorkflowResult
+    captured = {}
+
+    def fake_main(options, progress_callback=None):
+        captured["cb"] = progress_callback
+        if progress_callback:  # exercise the render path with a sample event
+            progress_callback({"job": 1, "step": 10, "total": 2,
+                               "converged": 1, "dropped": 0, "active": 1})
+        return WorkflowResult("nonexistent_out.sdf")
+
+    with patch("Auto3D.auto3D.main", side_effect=fake_main):
+        res = runner.invoke(app, ["run", str(smi), "--k", "1", "--no-gpu"])
+    assert res.exit_code == 0, res.output
+    assert callable(captured["cb"])
+
+
+def test_run_quiet_passes_no_progress_callback(smi):
+    """--quiet keeps stdout clean: no live display, callback is None."""
+    from Auto3D.results import WorkflowResult
+    captured = {}
+
+    def fake_main(options, progress_callback=None):
+        captured["cb"] = progress_callback
+        return WorkflowResult("nonexistent_out.sdf")
+
+    with patch("Auto3D.auto3D.main", side_effect=fake_main):
+        res = runner.invoke(app, ["run", str(smi), "--k", "1", "--no-gpu", "--quiet"])
+    assert res.exit_code == 0
+    assert captured["cb"] is None
 
 
 def test_api_functions_expose_new_params():

--- a/tests/test_mp_start_method.py
+++ b/tests/test_mp_start_method.py
@@ -41,7 +41,7 @@ def test_main_forces_spawn_even_when_fork_is_locked(monkeypatch):
         monkeypatch.setattr(
             workflow,
             "WorkflowOrchestrator",
-            lambda args: types.SimpleNamespace(run=lambda: "out.sdf"),
+            lambda args, progress_callback=None: types.SimpleNamespace(run=lambda: "out.sdf"),
         )
 
         out = auto3D.main(Auto3DOptions(path="unused.smi", k=1))

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,55 @@
+# tests/test_progress.py
+"""Unit tests for the live-progress plumbing: the count helper that feeds events
+and the display's multi-job aggregation. No NNP/optimization runs here."""
+from __future__ import annotations
+
+import torch
+
+from Auto3D.batch_opt.optimization_engine import optimization_counts
+from Auto3D.cli.progress import OptimizationDisplay
+
+
+def test_optimization_counts():
+    # 5 structures; converged_mask marks 3 as done; one of those (osc>=patience)
+    # is a drop, so converged=2, dropped=1, active=5-3=2.
+    state = {
+        "numbers": torch.zeros(5, 3),
+        "converged_mask": torch.tensor([True, True, False, False, True]),
+        "oscillating_count": torch.tensor([0, 5, 0, 0, 1]),
+    }
+    assert optimization_counts(state, patience=3) == (5, 2, 1, 2)
+
+
+def test_optimization_counts_none_converged():
+    state = {
+        "numbers": torch.zeros(4, 3),
+        "converged_mask": torch.tensor([False, False, False, False]),
+        "oscillating_count": torch.tensor([0, 0, 0, 0]),
+    }
+    assert optimization_counts(state, patience=3) == (4, 0, 0, 4)
+
+
+def test_display_single_job():
+    d = OptimizationDisplay(0)
+    d.update_from_jobs({1: {"total": 5, "converged": 2, "dropped": 1, "active": 2, "step": 30}})
+    assert (d.total, d.converged, d.dropped, d.active, d.step) == (5, 2, 1, 2, 30)
+    d.make_panel()  # must not raise
+
+
+def test_display_multi_job_aggregates():
+    d = OptimizationDisplay(0)
+    d.update_from_jobs({
+        1: {"total": 5, "converged": 2, "dropped": 1, "active": 2, "step": 30},
+        2: {"total": 3, "converged": 3, "dropped": 0, "active": 0, "step": 50},
+    })
+    assert d.total == 8
+    assert d.converged == 5
+    assert d.dropped == 1
+    assert d.active == 2
+    assert d.step == 50  # furthest along
+
+
+def test_display_empty_jobs_is_noop():
+    d = OptimizationDisplay(0)
+    d.update_from_jobs({})
+    assert (d.total, d.converged, d.dropped, d.active, d.step) == (0, 0, 0, 0, 0)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -332,7 +332,7 @@ def test_optim_rank_wrapper_isolates_failing_chunks(tmp_path, monkeypatch):
     attempted = []
 
     class _BoomOptimizing:
-        def __init__(self, in_f, out_f, engine, device, config):
+        def __init__(self, in_f, out_f, engine, device, config, progress_cb=None):
             self._enumerated = in_f
 
         def run(self):


### PR DESCRIPTION
Wires the unused `OptimizationDisplay` into interactive `auto3d run`, replacing the static spinner with a live panel (converged/active/dropped/step). The hard part is that optimization runs in spawned worker processes while the main process blocks in `join()`; this pushes per-step counts out over a process-safe channel and renders them in the main process.

### Design — strictly opt-in, risk confined to `auto3d run`
- Optional `progress_callback` threaded `main()` → `WorkflowOrchestrator` → workers. **When `None` (every Python-API caller, tests, and `--quiet`/`--json`), the pipeline behaves byte-for-byte as before** — no progress queue, plain blocking joins, no extra GPU syncs. The spawn/CUDA isolation and "Done"-sentinel logic are untouched on the default path.
- When set: `_run_pipeline` creates an unbounded `Manager().Queue()`, the worker builds a job-tagging closure, and `n_steps` emits `{step,total,converged,dropped,active}` (via the extracted `optimization_counts`, shared with `print_stats`) on the existing `istep % 10` cadence. The main process runs a supervise-and-drain loop, forwarding events to a Rich `Live` panel, then joins with the same exit-code checks.

### Review
An independent concurrency/correctness review found **no Critical/Major issues** — deadlock-safety confirmed (liveness-driven loop, unbounded synchronous Manager queue, guarded puts, sentinels intact) and default-path invariance confirmed. Two Minor cosmetic notes on multi-chunk/multi-GPU percent aggregation are scoped by the docstrings (chunk-level totals were deferred).

Fast gate: 681 passed (+12 new: count helper, display aggregation, callback forwarding); ruff clean on `src/`. Guarded so a render error can never abort a run.

This is the last item from the CLI review backlog.