### PR TITLE
Fix Read the Docs build: use Python 3.11

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: "2"
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.11"
 
 python:
   install:


### PR DESCRIPTION
The package requires Python >=3.11 (pyproject `requires-python`), but `.readthedocs.yaml` pinned the RTD build to Python 3.10, so RTD's `pip install .` failed instantly — the `docs/readthedocs.org` check has been red on every PR this cycle. One-line bump to 3.11 to match. (Extracted from the stale `docs/v3.5-refresh` branch, whose other changes are superseded by the merged docs work.)