### PR TITLE
chore: ignore local coding-assistant instruction file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Local coding-assistant instructions (developer-specific, not part of the package)
+/CLAUDE.md


### PR DESCRIPTION
The root-level assistant instruction file is developer-specific and was stripped from history in the recent scrub of internal-only docs. Without a `.gitignore` entry, a local copy shows up as untracked in every working tree and can be re-committed by accident.

Adds a root-anchored `/CLAUDE.md` entry to `.gitignore`. Docs-only change; no effect on the package or its build.