### PR TITLE
test: Phase 0 verification harness for the 4.0.0 audit remediation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,11 +83,16 @@ jobs:
           PY
       - name: Run slow NNP + pipeline tests
         # Previously limited to three files because the heavy end-to-end modules
-        # were flaky under combined/randomized ordering. Task 1's job_dir/isolated_input
-        # fixtures remove the shared output directories that caused it, so the
-        # full slow tier now runs (audit M31).
+        # were flaky under combined ordering. None of the five newly un-skipped
+        # modules (test_auto3D.py, test_SPE.py, test_thermo.py,
+        # test_isomer_engine.py, test_tauto.py) actually use Task 1's
+        # job_dir/isolated_input fixtures, so those fixtures are not what
+        # protects this run. What actually protects it: main()'s
+        # microsecond-resolution job naming, strictly serial CI execution, and
+        # the autouse GPU-teardown fixture applied via the `slow` marker --
+        # assessed at 70-80% confidence, not guaranteed (audit M31).
         run: >
-          pytest tests/ -m slow -q -p no:randomly
+          pytest tests/ -m slow -q
 
   lint:
     name: ruff + mypy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Install ani extra
         if: matrix.ani
         run: pip install -e ".[ani]"
+      - name: Verify every test module imports
+        # --continue-on-collection-errors on the fast run hides a module that
+        # fails to import, so assert collection cleanliness separately.
+        run: pytest tests/ --collect-only -q
       - name: Run fast tests
         run: pytest tests/ -q -m "not slow" --continue-on-collection-errors
 
@@ -60,17 +64,30 @@ jobs:
           python -m pip install --upgrade pip
           # ase for thermo, ani for the torchani-gated slow tests, dev for pytest
           pip install -e ".[ase,ani,dev]"
-      - name: Run NNP integration tests (moved out of the fast gate)
-        # These slow tests load a real AIMNet2 model -- energy/forces
-        # correctness, adapter/factory return types, and the Hessian-model load.
-        # This is exactly the real-NNP coverage moved out of the fast gate, so it
-        # still runs on every push/PR. The broader `-m slow` suite (full-pipeline
-        # test_auto3D / test_SPE / test_thermo) is intentionally NOT run here:
-        # those heavy end-to-end tests are flaky under combined/randomized
-        # ordering (they pass individually) and need separate isolation work.
+      - name: Warm the AIMNet2 model cache (hard failure if unreachable)
+        # An unavailable gate must never be reportable as a passing gate. If the
+        # registry or network is down, fail here loudly rather than letting the
+        # suite skip or silently pass (audit: the remediation gate depends on
+        # this model being present).
+        run: |
+          python - <<'PY'
+          import sys
+          import torch
+          from Auto3D.model_factory import create_model
+          try:
+              create_model("AIMNET", torch.device("cpu"))
+          except Exception as exc:
+              print(f"::error::AIMNet2 model unavailable, gate cannot run: {exc}")
+              sys.exit(1)
+          print("AIMNet2 model cache warm")
+          PY
+      - name: Run slow NNP + pipeline tests
+        # Previously limited to three files because the heavy end-to-end modules
+        # were flaky under combined/randomized ordering. Task 1's job_dir/isolated_input
+        # fixtures remove the shared output directories that caused it, so the
+        # full slow tier now runs (audit M31).
         run: >
-          pytest tests/test_model_adapter.py tests/test_model_factory.py
-          tests/test_thermo_helpers.py -m slow -q
+          pytest tests/ -m slow -q -p no:randomly
 
   lint:
     name: ruff + mypy
@@ -83,6 +100,6 @@ jobs:
       - name: Install tooling
         run: pip install ruff mypy
       - name: ruff
-        run: ruff check src/Auto3D/
+        run: ruff check src/Auto3D/ tests/
       - name: mypy (non-blocking until type debt is cleared)
         run: mypy src/Auto3D/ --ignore-missing-imports || true

--- a/docs/superpowers/plans/2026-07-30-phase0-red-list.md
+++ b/docs/superpowers/plans/2026-07-30-phase0-red-list.md
@@ -2,12 +2,20 @@
 
 Every entry below is an `xfail` test that fails on `a426cf4` and is mapped to
 the phase that owns its fix. When the owning phase lands its fix the test
-XPASSes; for the 27 entries marked `strict=True`, that XPASS is a hard pytest
-failure, and the implementer must delete the marker in the same PR. **One
-entry — the `test_utils_stereochemistry.py` C1 row — is `xfail(strict=False)`
-by design** (it is being kept, not deleted, to preserve the record that the
-buggy behavior was once asserted as correct; see "Known deviations" below).
-That row's tripwire is not self-enforcing and needs a manual check.
+XPASSes; for all 28 entries, now all marked `strict=True`, that XPASS is a
+hard pytest failure, and the implementer must delete the marker in the same
+PR.
+
+**Update (fix wave following the final whole-branch review):** the
+`test_utils_stereochemistry.py` C1 row was originally shipped as
+`xfail(strict=False)`, on the reasoning that it was "kept, not deleted, to
+preserve the record that it was once intended" and that its body would be
+rewritten later. That reasoning justified keeping the test, not leaving it
+non-strict — its body already asserts the correct behavior (structurally
+identical to the strict `test_stereo_identity.py:37` row above), so the
+non-strict marker was tightened to `strict=True`. Confirmed it still reports
+`xfailed`, not `xpassed`. See "Discrepancies against the brief's draft table"
+item 5 below for the historical context this closes out.
 
 **A phase is complete when every marker in its row is gone and no other test
 turned red.**
@@ -27,7 +35,7 @@ draft" for everywhere the two disagree.
 | C1 | `test_stereo_identity.py::TestEnantiomerPredicate::test_two_achiral_molecules_are_not_enantiomers` | 2 |
 | C1 | `test_stereo_identity.py::TestEZIsomersSurvive::test_but_2_ene_keeps_both_geometric_isomers` | 2 |
 | C1 | `test_stereo_identity.py::TestEZIsomersSurvive::test_fumaric_and_maleic_acid_both_survive` | 2 |
-| C1 | `test_utils_stereochemistry.py::TestEnantiomerHelper::test_enantiomer_helper_keeps_non_chiral` (`strict=False` — see note above) | 2 |
+| C1 | `test_utils_stereochemistry.py::TestEnantiomerHelper::test_enantiomer_helper_keeps_non_chiral` | 2 |
 | C2 | `test_stereo_identity.py::TestTautomerStereoPreservation::test_specified_center_survives_tautomer_enumeration` | 2 |
 | M19 | `test_stereo_identity.py::TestSdfInputStereo::test_unspecified_center_is_enumerated_or_refused` | 2 |
 | C5 | `test_thermo_reference.py::TestHessianGeometry::test_hessian_geometry_matches_relaxed_atoms` | 3 |
@@ -118,10 +126,18 @@ These are not red — they are gaps that had no test at all, now closed:
 - `test_pipeline_e2e.py::TestEnergyAndRankingSanity` (2 tests) — the first end-to-end assertions on actual numbers
 - `test_model_adapter.py` / `test_custom_nnp_eager.py` — analytic force values, catching a sign flip that previously passed (M32)
 - `test_batchopt.py::TestConvergenceFlagDerivation` — replaces two tests that asserted production logic against a copy of itself (M32)
+- `tests/test_batchopt.py::TestGPUCleanup::test_run_method_includes_gpu_cleanup`
+  was **deleted outright, not replaced.** It asserted on `inspect.getsource`
+  output — a source-text grep, not behavior — so unlike the two convergence
+  tests above there was no behavioral property to replace it with; the
+  whole `TestGPUCleanup` class (`tests/test_batchopt.py:145-188` at the time
+  of deletion) is gone.
 
 Beyond those, and beyond the three self-referential `test_batchopt.py`
-assertions Task 2 replaced, this phase found and fixed **three more tests
-that could never have failed regardless of the code under test**:
+assertions Task 2 removed (the two convergence tests, replaced by
+`TestConvergenceFlagDerivation` above, and the deleted GPU-cleanup test),
+this phase found and fixed **three more tests that could never have failed
+regardless of the code under test**:
 
 - A duplicate `class TestCombineSmi` in `tests/test_utils_file_ops.py` shadowed
   an earlier class of the same name, so pytest collected only the later
@@ -179,27 +195,49 @@ reality differs from it in the following ways:
    spy on the module-global `vib_hessian`, so a fix landing inside
    `do_mol_thermo` itself — not just in `vib_hessian`'s signature — is
    observed.
-5. **One marker is `xfail(strict=False)`, not `strict=True`.** The brief's
-   mechanic assumes every red-list entry is `strict=True` so that an XPASS is
-   a hard failure forcing marker deletion.
+5. **One marker shipped as `xfail(strict=False)`, not `strict=True`.**
+   (**Resolved by the post-review fix wave — see the "Update" note at the
+   top of this document.**) The brief's mechanic assumes every red-list
+   entry is `strict=True` so that an XPASS is a hard failure forcing marker
+   deletion.
    `test_utils_stereochemistry.py::TestEnantiomerHelper::test_enantiomer_helper_keeps_non_chiral`
-   is the one exception (introduced in commit `de81699`, not adjusted in any
-   later fix round, and not called out anywhere in the task ledger). Its
-   `reason` text says it is "kept (not deleted) to preserve the record that it
-   was once intended" and that "Phase 2 rewrites it" — consistent with the
-   design doc's own instruction for this specific test
-   (`2026-07-30-audit-remediation-design.md:137`) — but because it is
-   non-strict, an XPASS here will **not** turn CI red. Phase 2 must delete or
-   rewrite this marker as a manual step; the gate will not force it. Flagged
-   here explicitly so it is not lost.
+   was the one exception (introduced in commit `de81699`, not adjusted in
+   any later fix round, and not called out anywhere in the task ledger). Its
+   `reason` text said it was "kept (not deleted) to preserve the record that
+   it was once intended" and that "Phase 2 rewrites it" — consistent with
+   the design doc's own instruction for this specific test
+   (`2026-07-30-audit-remediation-design.md:137`) — but because it was
+   non-strict, an XPASS there would **not** have turned CI red on its own. A
+   final whole-branch review caught that the test's body had, in fact,
+   already been rewritten to assert correct behavior, so the non-strict
+   marker was tightened to `strict=True` rather than left for Phase 2 to
+   catch manually. All 28 red-list entries are now `strict=True`.
 6. All other findings, node IDs, and phase assignments in the brief's draft
    table were verified correct against the measured inventory and the design
    doc, with no further discrepancy.
 
 ## Handoff notes for later phases
 
-- **Phase 1:** no additional handoff beyond the red list above; note the
-  local-box `torchani` collection caveat when re-verifying C3/C4 in CI.
+- **Phase 1:** note the local-box `torchani` collection caveat when
+  re-verifying C3/C4 in CI. Additionally: spec break B1 changes
+  `pad_from_mols` to return a 4-tuple, and that silently affects four
+  tripwires outside Phase 1's own three:
+  - `test_species_conversion.py:71` (C3) and `:133` (C4) unpack 3 values
+    from `pad_from_mols`; after B1 that call raises `ValueError`, which
+    satisfies each test's `xfail(strict=True)` for the wrong reason — both
+    stay XFAIL even after a correct C3/C4 fix.
+  - `test_config_parity.py:123`'s `fake_pad` stub (used by the C11 test,
+    `TestAuxiliaryEntryPointGuards::test_calc_spe_rejects_charged_input_for_ani`)
+    returns 3 values; `SPE.py:96` will unpack 4 and raise `ValueError`,
+    which is not an `Auto3DError` — the C11 tripwire goes dark.
+  - `test_durability.py:262` uses the same 3-value `fake_pad` stub, but its
+    `pytest.raises((Auto3DError, ValueError))` at `:271` accepts the
+    `ValueError` — so C14's `test_output_equal_to_input_is_rejected` would
+    falsely XPASS during Phase 1, and because it is `strict=True`, that
+    turns CI red for a reason unrelated to C14 itself.
+  Phase 1 must update all four stubs (the two `pad_from_mols` call sites and
+  the two `fake_pad` stubs) to the new 4-tuple shape in the same PR as the
+  B1 change.
 
 - **Phase 2:** the M19 fix must land **inside `RDKitSdfIsomer` /
   `RDKitSdfIsomerAdapter`**, not behind a new or alternate registry key. Both
@@ -221,7 +259,9 @@ reality differs from it in the following ways:
   because the bug persists but because the test is looking at the wrong
   name. Phase 3 must either adopt `Thermo_converged`/`Thermo_warning` as the
   property names or update the test to whatever name it chooses — in the
-  same PR as the fix, not as an afterthought.
+  same PR as the fix, not as an afterthought. Whatever name is chosen,
+  pick one consistent with `Thermo_failed`, which spec break B7 already
+  commits to for M14 in this same phase.
 
 - **Phase 4:** the C8 and M22 tests in `TestColdCacheDiagnosis` each try
   `WorkflowOrchestrator._validate_input()` first and only fall through to the
@@ -249,6 +289,16 @@ reality differs from it in the following ways:
   unaddressed reason, because `remove_enantiomers` runs first in the
   pipeline and can independently merge the two inputs before ranking ever
   sees them. Both sites must be fixed for this test to XPASS correctly.
+
+  Additionally: `test_config_parity.py:29,39,49,66` (`C10` x2, `M27`,
+  `M28`) all use `pytest.raises(Auto3DError)`, but `Auto3DOptions.__post_init__`
+  (`src/Auto3D/config.py:151,153`) currently raises bare `ValueError` for
+  both the negative-k and negative-window checks, which is not an
+  `Auto3DError`. Extending `__post_init__` in its existing style (more bare
+  `ValueError`s) leaves all four tripwires dark. Phase 5 must raise
+  `ConfigurationError` per spec break B9/M29 instead. Collateral: `tests/test_config.py:168-176`
+  (`test_negative_k_rejected`, `test_negative_window_rejected`) currently
+  expects `ValueError` and will need updating in the same PR once M29 lands.
 
 - **Phase 6:** no additional handoff beyond the red list above.
 
@@ -284,5 +334,29 @@ a regression:
   these five files actually use. A same-second job-directory collision in
   `test_isomer_engine.py` was already found and fixed during this phase
   (timestamp-only naming with unprotected `os.mkdir`); further collisions
-  under combined/randomized ordering remain possible and are the reason for
-  the confidence estimate rather than a guarantee.
+  under combined ordering remain possible and are the reason for the
+  confidence estimate rather than a guarantee.
+- **`PytestUnraisableExceptionWarning` is untested on the slow tier.**
+  `error::pytest.PytestUnraisableExceptionWarning` (added to `pyproject.toml`
+  `filterwarnings`) has never been exercised against the slow tier, which
+  opens many `SDWriter`/`SDMolSupplier` objects and does CUDA teardown —
+  either can plausibly emit an unraisable-exception warning during garbage
+  collection. This is an independent source of first-run red, unrelated to
+  the un-skip itself. Keep the filter, but do not misdiagnose a red here as
+  a regression in the un-skipped modules.
+- **`test_thermo_reference.py:157-161` imports private `Auto3D.ASE.thermo`
+  symbols.** It imports `_load_hessian_model` and `model_name2model_calculator`
+  directly (both private/module-level, not part of the public API). Phase
+  3's M40 reroutes `_load_hessian_model` through `ModelFactory`; if that
+  change renames or removes the symbol rather than keeping it as a thin
+  wrapper, the C5 tripwire (`TestHessianGeometry::test_hessian_geometry_matches_relaxed_atoms`)
+  goes dark with an `ImportError` instead of exercising the geometry-sync
+  bug.
+
+## Notes on this checkout
+
+- `docs/superpowers/specs/` and `.claude/review-manifests/` are untracked
+  working documents in this checkout (excluded via `.git/info/exclude`, not
+  `.gitignore`). Cross-references to files under either path — including
+  `docs/superpowers/specs/2026-07-30-audit-remediation-design.md`, cited
+  throughout this document — will dangle on a fresh clone of the repository.

--- a/docs/superpowers/plans/2026-07-30-phase0-red-list.md
+++ b/docs/superpowers/plans/2026-07-30-phase0-red-list.md
@@ -1,0 +1,288 @@
+# Phase 0 red list — Auto3D 4.0.0 remediation gate
+
+Every entry below is an `xfail` test that fails on `a426cf4` and is mapped to
+the phase that owns its fix. When the owning phase lands its fix the test
+XPASSes; for the 27 entries marked `strict=True`, that XPASS is a hard pytest
+failure, and the implementer must delete the marker in the same PR. **One
+entry — the `test_utils_stereochemistry.py` C1 row — is `xfail(strict=False)`
+by design** (it is being kept, not deleted, to preserve the record that the
+buggy behavior was once asserted as correct; see "Known deviations" below).
+That row's tripwire is not self-enforcing and needs a manual check.
+
+**A phase is complete when every marker in its row is gone and no other test
+turned red.**
+
+This document reflects the inventory actually present in the repository at
+`3b17e86` (Task 11 complete, branch `phase0/verification-harness`), not the
+task-12 brief's pre-drafted estimate. See "Discrepancies against the brief's
+draft" for everywhere the two disagree.
+
+## Red list
+
+| Finding | Test | Owning phase |
+|---|---|---|
+| C3 | `test_species_conversion.py::TestThermoPathConverts::test_thermo_and_batch_paths_agree_on_methane` | 1 |
+| C3 | `test_species_conversion.py::TestThermoPathConverts::test_heteroatom_molecule_does_not_crash_thermo_path` | 1 |
+| C4 | `test_species_conversion.py::TestHealthCheckIsHonest::test_health_check_energy_matches_real_methane` | 1 |
+| C1 | `test_stereo_identity.py::TestEnantiomerPredicate::test_two_achiral_molecules_are_not_enantiomers` | 2 |
+| C1 | `test_stereo_identity.py::TestEZIsomersSurvive::test_but_2_ene_keeps_both_geometric_isomers` | 2 |
+| C1 | `test_stereo_identity.py::TestEZIsomersSurvive::test_fumaric_and_maleic_acid_both_survive` | 2 |
+| C1 | `test_utils_stereochemistry.py::TestEnantiomerHelper::test_enantiomer_helper_keeps_non_chiral` (`strict=False` — see note above) | 2 |
+| C2 | `test_stereo_identity.py::TestTautomerStereoPreservation::test_specified_center_survives_tautomer_enumeration` | 2 |
+| M19 | `test_stereo_identity.py::TestSdfInputStereo::test_unspecified_center_is_enumerated_or_refused` | 2 |
+| C5 | `test_thermo_reference.py::TestHessianGeometry::test_hessian_geometry_matches_relaxed_atoms` | 3 |
+| M8 | `test_thermo_reference.py::TestStationaryPointGating::test_unconverged_geometry_is_flagged_or_refused` | 3 |
+| M13 | `test_thermo_reference.py::TestBatchRobustness::test_malformed_record_does_not_abort_the_batch` | 3 |
+| C6 | `test_pipeline_e2e.py::TestInputOutputAccounting::test_one_bad_molecule_does_not_remove_the_others` | 4 |
+| C6 | `test_pipeline_e2e.py::TestExitStatus::test_cli_exits_nonzero_when_molecules_are_missing` | 4 |
+| C7 | `test_pipeline_e2e.py::TestInputOutputAccounting::test_every_input_is_present_or_reported` | 4 |
+| C8 | `test_model_preflight.py::TestColdCacheDiagnosis::test_network_failure_names_the_network` | 4 |
+| M21 | `test_model_preflight.py::TestRegistryNameValidation::test_unknown_registry_name_is_rejected_up_front` | 4 |
+| M22 | `test_model_preflight.py::TestColdCacheDiagnosis::test_checksum_mismatch_says_to_delete_the_file` | 4 |
+| C10 | `test_config_parity.py::TestAuto3DOptionsBounds::test_negative_threshold_is_rejected` | 5 |
+| C10 | `test_config_parity.py::TestAuto3DOptionsBounds::test_zero_convergence_threshold_is_rejected` | 5 |
+| C11 | `test_config_parity.py::TestAuxiliaryEntryPointGuards::test_calc_spe_rejects_charged_input_for_ani` | 5 |
+| M15 | `test_config_parity.py::TestSmiles2MolsHonesty::test_unsupported_option_raises` | 5 |
+| M15 | `test_config_parity.py::TestSmiles2MolsHonesty::test_caller_config_is_not_mutated` | 5 |
+| M17 | `test_config_parity.py::TestDuplicateInchikeyInputs::test_duplicate_smiles_both_survive` | 5 |
+| M27 | `test_config_parity.py::TestAuto3DOptionsBounds::test_zero_max_confs_is_rejected` | 5 |
+| M28 | `test_config_parity.py::TestMutuallyExclusiveSelectors::test_k_and_window_together_raise` | 5 |
+| C14 | `test_durability.py::TestOptGeometryDurability::test_input_survives_a_failed_rewrite` | 6 |
+| C14 | `test_durability.py::TestSameFileGuard::test_output_equal_to_input_is_rejected` | 6 |
+
+**28 markers total** (4 C1, 2 M15, 2 C6, 2 C3, 2 C14, 2 C10, and 1 each of C2,
+C4, C5, C7, C8, C11, M8, M13, M17, M19, M21, M22, M27, M28), extracted with:
+
+```bash
+grep -rn 'reason="[CM][0-9]' tests/
+```
+
+and resolved to full pytest node IDs and phases by reading each file and
+cross-referencing `docs/superpowers/specs/2026-07-30-audit-remediation-design.md`
+§§4-9 (Phases 1-6), not the brief's draft table.
+
+Phase totals: Phase 1 — 3 · Phase 2 — 6 · Phase 3 — 3 · Phase 4 — 6 ·
+Phase 5 — 8 · Phase 6 — 2. (3+6+3+6+8+2 = 28.)
+
+**Local-box caveat:** the three Phase-1 markers (C3 x2, C4 x1) live in
+`test_species_conversion.py`, which opens with `pytest.importorskip("torchani")`.
+`torchani` is not installed on this development box, so that entire module is
+skipped at collection time — it produces **zero** collected items under
+either `-m "not slow"` or `-m slow` here, not even a "skipped" line. These
+three markers were confirmed to exist by direct source inspection (`grep`)
+and, per Task 8's ledger note, by an independent read-only inspection of the
+pinned `torchani==2.8.4` wheel (`AEVComputer`'s `triu_index` buffer sized
+`num_species x num_species = 7x7`, confirming the heteroatom test's expected
+`IndexError`). Their first real execution — and the first chance to observe
+an `xpassed` there — will be in CI, where `torchani` is installed.
+
+## Verification
+
+Fast tier, run on this box (`3b17e86`):
+
+```
+$ pytest tests/ -q -rxX -m "not slow"
+...
+680 passed, 9 skipped, 66 deselected, 19 xfailed, 26 warnings in 19.05s
+```
+
+**0 xpassed** — all 19 fast-tier xfail markers reproduced their defect. The
+19 comprises every marker above except the 9 that live in modules carrying a
+module-level `pytestmark = pytest.mark.slow` or a per-test `@pytest.mark.slow`
+(`test_thermo_reference.py`: C5, M8, M13; `test_pipeline_e2e.py`: C6 x2, C7;
+`test_species_conversion.py`: C3 x2, C4 — the last three invisible locally per
+the caveat above). 19 + 9 = 28.
+
+Slow-tier inventory (cannot be executed on this box — 8 shared CUDA devices,
+~2 GB RAM; collection only):
+
+```
+$ pytest tests/ --collect-only -qq -m slow
+...
+66/773 tests collected (707 deselected) in 1.82s
+```
+
+Of those 66 slow-tier items, 6 carry a red-list marker (C5, M8, M13 in
+`test_thermo_reference.py`; C6 x2, C7 in `test_pipeline_e2e.py`). The
+remaining 3 slow-tier markers (C3 x2, C4) do not appear in this count at all,
+per the `torchani` caveat above — 6 + 3 = 9, matching the fast/slow split
+above. Fast + slow collection together: 707 + 66 = 773, the full suite.
+
+## New passing coverage added by Phase 0
+
+These are not red — they are gaps that had no test at all, now closed:
+
+- `test_durability.py::TestReorderSdfDurability` (2 tests) — the atomic rewrite path and temp-file cleanup, previously untested despite being the fix for the most recent bug (M33)
+- `test_padding_invariance.py` (2 tests, one per engine) — the only guard on torchani's `-1` masked-atom convention (M32)
+- `test_species_conversion.py::TestBatchPathIsCorrect` — regression guard on the one path that converts correctly (not verifiable locally; see the `torchani` caveat above)
+- `test_pipeline_e2e.py::TestEnergyAndRankingSanity` (2 tests) — the first end-to-end assertions on actual numbers
+- `test_model_adapter.py` / `test_custom_nnp_eager.py` — analytic force values, catching a sign flip that previously passed (M32)
+- `test_batchopt.py::TestConvergenceFlagDerivation` — replaces two tests that asserted production logic against a copy of itself (M32)
+
+Beyond those, and beyond the three self-referential `test_batchopt.py`
+assertions Task 2 replaced, this phase found and fixed **three more tests
+that could never have failed regardless of the code under test**:
+
+- A duplicate `class TestCombineSmi` in `tests/test_utils_file_ops.py` shadowed
+  an earlier class of the same name, so pytest collected only the later
+  definition and the earlier class's tests silently never ran. Renamed to
+  `TestCombineSmiOrderPreservingDedup` to un-shadow it.
+- `assert "Test passed" in captured.out or True` in `tests/test_cli_console.py`
+  — the `or True` made the assertion unconditionally true. Removed, after
+  confirming the condition genuinely holds without it.
+- (Together with the two above) Task 11's ruff pass initially proposed
+  silencing `F811` and `SIM222` via per-file ignores for the un-skipped slow
+  modules — exactly the two rules that had flagged these two defects. Both
+  codes were kept enabled for `tests/*` instead, with the real bugs fixed at
+  source, so a future regression of this kind is caught by lint again.
+
+## Findings not in the red list
+
+- **C9** (no post-optimization stereo validation) — Phase 2 wires `stereo_changed` in; its test is written with the fix, since asserting "a check exists" before the check exists is not a useful red test.
+- **C12** (contradictory NNP Protocols) — Phase 6; `config.NNPModel` is simply unused today, so there is no wrong behavior to reproduce.
+- **C13** (species_pad sentinel collision) — Phase 1 replaces the sentinel with an explicit mask. `test_padding_invariance.py` guards the shipped engines; the custom-NNP collision requires a deliberately hostile model and is asserted in Phase 1 alongside the fix.
+- **M2** (fp32 tolerance) — unobservable while M1 makes the criterion inert. Testable only if Phase 6 keeps and decouples the criterion.
+- **M9-M12, M14, M16, M23, M25, M26, M29-M35, M40, M46, M47** — reporting quality, API surface, or bias magnitude rather than a discrete wrong answer; verified within their own phase.
+
+## Discrepancies against the brief's draft table
+
+The task-12 brief (`.superpowers/sdd/2026-07-30-phase0-verification-harness/task-12-brief.md`)
+was written before Tasks 1-11 ran, and its Step 1 table is an estimate. Measured
+reality differs from it in the following ways:
+
+1. **Count: 28 markers, not 27 (and not the 24 the brief's own Step 2 also
+   claims).** The brief is internally inconsistent — its Step 1 table has 27
+   rows, its Step 2 expected-totals line says 24, and its Step 3 commit
+   message template says 27. None of the three matches the measured 28.
+2. **M17 is entirely absent from the brief's draft table**, despite being
+   named in the brief's own "Findings" line for `test_stereo_identity.py`
+   list and in the phase plan. Task 7's implementer discovered the omission —
+   the brief specified 7 tests targeting 5 findings but named 8 total — and
+   wrote the missing test itself:
+   `test_config_parity.py::TestDuplicateInchikeyInputs::test_duplicate_smiles_both_survive`.
+3. **M17's owning phase is 5, not 2.** An earlier report (the Task 7
+   implementer's own summary prose) mislabeled M17 as a Phase-2 fix; the
+   design doc (`2026-07-30-audit-remediation-design.md` line 263, item 13,
+   under "## 8. Phase 5 — Validation unification") is unambiguous, and this
+   document follows the design doc, not the mislabeled report.
+4. **The C5 test in the brief's table does not exist under that name.** The
+   brief predicted `test_thermo_reference.py::TestHessianGeometry::test_result_is_independent_of_input_relaxation`.
+   The actual, shipped test is `test_hessian_geometry_matches_relaxed_atoms`.
+   Task 10's implementer reformulated the assertion entirely: rather than
+   comparing two independently-computed `G` values within an arbitrary
+   tolerance (a luck-dependent comparison, the same trap Task 9 hit for C7),
+   it asserts `np.allclose(vib.atoms.get_positions(), atoms.get_positions(),
+   atol=1e-8)` — bit-for-bit identical if the Hessian and the energy share a
+   geometry, differing by the full BFGS displacement (~0.1 Å, ~1e7x the
+   tolerance) if the bug is present. A later fix-round rebound the test to
+   drive `do_mol_thermo` (the sole production caller) through a pass-through
+   spy on the module-global `vib_hessian`, so a fix landing inside
+   `do_mol_thermo` itself — not just in `vib_hessian`'s signature — is
+   observed.
+5. **One marker is `xfail(strict=False)`, not `strict=True`.** The brief's
+   mechanic assumes every red-list entry is `strict=True` so that an XPASS is
+   a hard failure forcing marker deletion.
+   `test_utils_stereochemistry.py::TestEnantiomerHelper::test_enantiomer_helper_keeps_non_chiral`
+   is the one exception (introduced in commit `de81699`, not adjusted in any
+   later fix round, and not called out anywhere in the task ledger). Its
+   `reason` text says it is "kept (not deleted) to preserve the record that it
+   was once intended" and that "Phase 2 rewrites it" — consistent with the
+   design doc's own instruction for this specific test
+   (`2026-07-30-audit-remediation-design.md:137`) — but because it is
+   non-strict, an XPASS here will **not** turn CI red. Phase 2 must delete or
+   rewrite this marker as a manual step; the gate will not force it. Flagged
+   here explicitly so it is not lost.
+6. All other findings, node IDs, and phase assignments in the brief's draft
+   table were verified correct against the measured inventory and the design
+   doc, with no further discrepancy.
+
+## Handoff notes for later phases
+
+- **Phase 1:** no additional handoff beyond the red list above; note the
+  local-box `torchani` collection caveat when re-verifying C3/C4 in CI.
+
+- **Phase 2:** the M19 fix must land **inside `RDKitSdfIsomer` /
+  `RDKitSdfIsomerAdapter`**, not behind a new or alternate registry key. Both
+  `create_isomer_engine` (a zero-logic passthrough) and any direct
+  `IsomerEngineFactory.create` call resolve through the same class-level
+  `_adapters` dict, so a fix inside the existing class is seen by both
+  routes — but a fix that instead routes ambiguous-stereo SDF input to a
+  *new* adapter key while leaving `"rdkit_sdf"` bound to the old class would
+  leave the M19 test permanently dark. Separately, `RDKitSdfIsomer`'s own
+  docstring (`isomer_engine.py:322-325`) currently reads "Preserves specified
+  stereo centers and enumerates unspecified ones" — that claim is false today
+  (M19's whole premise) and must be corrected as part of the same fix, not
+  left as a stale claim once the behavior changes.
+
+- **Phase 3:** M8's test asserts `mol.HasProp("Thermo_converged") or
+  mol.HasProp("Thermo_warning")`. Neither property exists anywhere in `src/`
+  or `tests/` today (confirmed by grep). A fix that flags non-convergence
+  under different property names will leave this test `xfail` forever, not
+  because the bug persists but because the test is looking at the wrong
+  name. Phase 3 must either adopt `Thermo_converged`/`Thermo_warning` as the
+  property names or update the test to whatever name it chooses — in the
+  same PR as the fix, not as an afterthought.
+
+- **Phase 4:** the C8 and M22 tests in `TestColdCacheDiagnosis` each try
+  `WorkflowOrchestrator._validate_input()` first and only fall through to the
+  `optim_rank_wrapper` / `_finalize_output` worker chain if that passes
+  through harmlessly (today's behavior). This means either of two fixes makes
+  them XPASS:
+  - a parent-side pre-flight added to `_validate_input` that raises
+    `Auto3DError` naming one of "network", "download", "cache", or "model",
+    and never says "patience"; **or**
+  - narrowing `optim_rank_wrapper`'s blanket `except Exception: continue`
+    plus fixing `_finalize_output`'s message to name the real cause instead
+    of the three-wrong-reasons text.
+
+  M22 additionally requires the message to mention "checksum" or "corrupt",
+  and to give delete/remove guidance naming the cache file or
+  `AIMNET_CACHE_DIR` — matching diagnostic quality is not enough on its own
+  for that one test.
+
+- **Phase 5:** M17 has **two independent sites**, not one. `ranking.py:186`
+  (`_Name.split("_")[0]` inside `ranking.run`'s grouping) and
+  `utils/stereochemistry.py:131` (the same pattern inside
+  `remove_enantiomers`) both re-collapse a disambiguated `KEY_2` id back onto
+  `KEY`. The design doc's item 13 (§8) names only the `ranking.run` site.
+  Fixing only that one leaves `test_duplicate_smiles_both_survive` red for an
+  unaddressed reason, because `remove_enantiomers` runs first in the
+  pipeline and can independently merge the two inputs before ranking ever
+  sees them. Both sites must be fixed for this test to XPASS correctly.
+
+- **Phase 6:** no additional handoff beyond the red list above.
+
+## Watch items for the first CI slow run
+
+None of these are red-list defects; they are risk notes about the harness
+itself, carried forward so the first full slow-tier CI run isn't mistaken for
+a regression:
+
+- **ANI2xt padding tolerance.** `test_padding_invariance.py`'s ANI2xt case
+  uses `atol=1e-3` eV, which is *tighter* than the ~4e-3 eV float32 ULP floor
+  documented in the very source cited to justify it (`ANI2xt_no_rep.py:148-155`).
+  If it flakes in CI, loosen it to `4e-3` rather than investigating a phantom
+  regression — a leaked padded atom still contributes eV-scale error, orders
+  of magnitude above either tolerance, so the loosened value still catches
+  the real bug.
+- **Oscillation fixture non-vacuity unconfirmed.** Task 2's oscillation test
+  (`patience=1`, `opttol=1e-9`, ethanol seed 42) has never been run against
+  the real optimizer to confirm it actually drives the oscillation code path
+  rather than converging trivially or hitting some other branch. First CI
+  slow run is the first real confirmation either way.
+- **Health-check regex reasoned, not executed.** Task 8's
+  `r"E\s*=\s*(-?\d+\.?\d*)"` match against `cli/commands/models.py:252-255`'s
+  f-string output was verified by reading the source, not by running it
+  under `CliRunner` capture (torchani unavailable locally). Confirm it
+  actually matches on first CI run.
+- **Five newly un-skipped slow modules are ~70-80% confidence, not
+  guaranteed.** Task 11 un-skipped `test_pipeline_e2e.py`, `test_thermo_reference.py`,
+  `test_auto3D.py`, `test_SPE.py`, `test_thermo.py` (plus `test_isomer_engine.py`,
+  `test_tauto.py` already slow-marked) based on the pipeline's microsecond
+  job-dir naming, serial CI execution, and the autouse GPU-teardown fixture —
+  not on the `job_dir`/`isolated_input` fixtures from Task 1, which none of
+  these five files actually use. A same-second job-directory collision in
+  `test_isomer_engine.py` was already found and fixed during this phase
+  (timestamp-only naming with unprotected `os.mkdir`); further collisions
+  under combined/randomized ordering remain possible and are the reason for
+  the confidence estimate rather than a guarantee.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,32 @@ ignore = [
     "UP031",  # format specifiers (% format is fine for simple cases)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# Task 11 (CI wiring) put `tests/` under `ruff check` for the first time. Bare
+# `except:` blocks (E722) were fixed directly -- a narrow, mechanical swap to
+# `except OSError:`/`except ImportError:` at each site. Everything below is
+# pre-existing style debt spread across most test files (not specific to the
+# newly-gated modules); fixing it is a wholesale test-suite reformat out of
+# scope for a CI-wiring change, so it is narrowed here instead of edited.
+"tests/*" = [
+    "I001",   # unsorted imports -- reordering would touch most test files
+    "F401",   # unused imports (legacy test scaffolding, e.g. optional-dep guards)
+    "E712",   # `== True`/`== False` comparisons (common in older tests)
+    "E702",   # multiple statements on one line (semicolons in legacy tests)
+    "B017",   # assertRaises(Exception) -- broad but intentional in smoke tests
+    "F841",   # unused local variables (e.g. captured-for-inspection results)
+    "N816",   # mixedCase globals (e.g. `test_userNNP1` availability flags)
+    "UP008",  # super() with parameters (legacy style, harmless)
+    "SIM117", # nested `with` statements (sometimes clearer split out)
+    "N811",   # constant imported as non-constant (legacy aliasing)
+    "B905",   # zip() without strict= (pre-3.10-style call sites)
+    "E401",   # multiple imports on one line
+    "F811",   # redefinition of unused name (legacy fixture shadowing)
+    "N813",   # camelCase import aliased to lowercase
+    "SIM222", # `... or True` (test scaffolding for short-circuit checks)
+    "SIM300", # yoda conditions
+]
+
 [tool.ruff.lint.isort]
 known-first-party = ["Auto3D"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,8 +164,17 @@ markers = [
     "openeye: marks tests requiring OpenEye license",
 ]
 filterwarnings = [
-    "ignore::DeprecationWarning",
-    "ignore::UserWarning",
+    "error::pytest.PytestUnraisableExceptionWarning",
+    # Auto3D's own deprecation and chemistry warnings are public contract and
+    # must stay visible so tests can assert them (audit M34).
+    "default::DeprecationWarning:Auto3D.*",
+    "default::UserWarning:Auto3D.*",
+    # Third-party noise we do not control.
+    "ignore:.*pkg_resources is deprecated.*:DeprecationWarning",
+    "ignore:.*Importing 'parser.split_arg_string' is deprecated.*:DeprecationWarning",
+    "ignore::DeprecationWarning:torch.*",
+    "ignore::DeprecationWarning:ase.*",
+    "ignore::UserWarning:torch.*",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,14 @@ ignore = [
 # pre-existing style debt spread across most test files (not specific to the
 # newly-gated modules); fixing it is a wholesale test-suite reformat out of
 # scope for a CI-wiring change, so it is narrowed here instead of edited.
+#
+# F811 (redefined-while-unused) and SIM222 (`... or True`) were deliberately
+# NOT added here, even though both fired in tests/. A fix-round review found
+# each one was flagging a real, currently-active bug rather than a style
+# nit -- a duplicate `TestCombineSmi` class silently shadowing another
+# class's test, and a vacuous `assert ... or True` that could never fail.
+# Both were fixed at the source instead (see git history), and both codes
+# stay enabled for tests/ so a regression here is caught by lint again.
 "tests/*" = [
     "I001",   # unsorted imports -- reordering would touch most test files
     "F401",   # unused imports (legacy test scaffolding, e.g. optional-dep guards)
@@ -157,9 +165,7 @@ ignore = [
     "N811",   # constant imported as non-constant (legacy aliasing)
     "B905",   # zip() without strict= (pre-3.10-style call sites)
     "E401",   # multiple imports on one line
-    "F811",   # redefinition of unused name (legacy fixture shadowing)
     "N813",   # camelCase import aliased to lowercase
-    "SIM222", # `... or True` (test scaffolding for short-circuit checks)
     "SIM300", # yoda conditions
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,14 +16,6 @@ TEST_DIR = Path(__file__).parent
 FILES_DIR = TEST_DIR / "files"
 
 
-def pytest_configure(config):
-    """Register custom markers."""
-    config.addinivalue_line("markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')")
-    config.addinivalue_line("markers", "integration: marks tests as integration tests")
-    config.addinivalue_line("markers", "gpu: marks tests requiring GPU")
-    config.addinivalue_line("markers", "openeye: marks tests requiring OpenEye license")
-
-
 # Session-scoped device fixture
 @pytest.fixture(scope="session")
 def device():
@@ -115,3 +107,33 @@ def _release_gpu_memory_after_slow_tests(request):
     gc.collect()
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
+
+
+@pytest.fixture
+def job_dir(tmp_path):
+    """Give each test its own pipeline output directory.
+
+    The pipeline writes job folders next to its input file. Tests that share an
+    input directory therefore collide under combined or randomized ordering,
+    which is why the heavy end-to-end modules were excluded from CI. Copying the
+    input into a per-test directory removes the shared state (audit M31).
+    """
+    d = tmp_path / "job"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def isolated_input(job_dir):
+    """Copy a file from tests/files into this test's own directory.
+
+    Returns a callable: ``isolated_input("smiles2.smi") -> str`` (absolute path).
+    """
+    import shutil
+
+    def _copy(name: str) -> str:
+        dest = job_dir / name
+        shutil.copy(FILES_DIR / name, dest)
+        return str(dest)
+
+    return _copy

--- a/tests/test_SPE.py
+++ b/tests/test_SPE.py
@@ -57,7 +57,7 @@ try:
             energies = self.model((species, coords)).energies * 27.211386245988
             return energies
     test_userNNP1 = True
-except:
+except ImportError:
     test_userNNP1 = False
 
 class userNNP2(torch.nn.Module):

--- a/tests/test_auto3D.py
+++ b/tests/test_auto3D.py
@@ -66,7 +66,7 @@ try:
             energies = self.model((species, coords)).energies * 27.211386245988
             return energies
     test_userNNP1 = True
-except:
+except ImportError:
     test_userNNP1 = False
 
 class userNNP2(torch.nn.Module):
@@ -141,7 +141,7 @@ def test_auto3D_rdkit_aimnet():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 # @pytest.mark.skipif(skip_ani2xt_test, reason="ANI2xt model is not  installed.")
@@ -153,7 +153,7 @@ def test_auto3D_rdkit_ani2xt():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 def test_auto3D_rdkit_ani2x():
@@ -164,7 +164,7 @@ def test_auto3D_rdkit_ani2x():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
@@ -176,7 +176,7 @@ def test_auto3D_omega_aimnet():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 
@@ -190,7 +190,7 @@ def test_auto3D_omega_ani2xt():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
@@ -202,7 +202,7 @@ def test_auto3D_omega_ani2x():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
@@ -214,7 +214,7 @@ def test_auto3D_config1():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 @pytest.mark.skipif(torch.cuda.is_available() == False, reason="No GPU")
@@ -226,7 +226,7 @@ def test_auto3D_config2():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
     
@@ -238,7 +238,7 @@ def test_auto3D_config3():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
@@ -250,7 +250,7 @@ def test_auto3D_config4():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 @pytest.mark.skipif(torch.cuda.is_available() == False, reason="No GPU")
@@ -263,7 +263,7 @@ def test_auto3D_config5():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 @pytest.mark.skipif(torch.cuda.is_available() == False, reason="No GPU")
@@ -276,7 +276,7 @@ def test_auto3D_config6():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
@@ -288,7 +288,7 @@ def test_auto3D_sdf_omega_aimnet():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 def test_auto3D_sdf_rdkit_aimnet():
@@ -299,7 +299,7 @@ def test_auto3D_sdf_rdkit_aimnet():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 def test_auto3D_sdf_rdkit_ani2x():
@@ -310,7 +310,7 @@ def test_auto3D_sdf_rdkit_ani2x():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 def test_auto3D_sdf_rdkit_ani2xt():
@@ -321,7 +321,7 @@ def test_auto3D_sdf_rdkit_ani2xt():
     out_folder = os.path.dirname(os.path.abspath(out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 def test_auto3D_smiles2mols():

--- a/tests/test_batchopt.py
+++ b/tests/test_batchopt.py
@@ -182,11 +182,28 @@ class TestConvergenceFlagDerivation:
 
         out = [m for m in Chem.SDMolSupplier(str(job_dir / "out.sdf"), removeHs=False) if m]
         assert out, "optimizer produced no output"
+
+        # Invariant: this must hold for every molecule regardless of which path
+        # its trajectory took, so it can never no-op. It fails if a regression
+        # decouples Converged/Dropped_Oscillating (e.g. dropping the
+        # `osc_count_i < patience` guard from `convergence_i`).
         for m in out:
             if m.HasProp("Dropped_Oscillating") and m.GetProp("Dropped_Oscillating") == "True":
                 assert m.GetProp("Converged") != "True", (
                     "a structure dropped for oscillation was reported as converged"
                 )
+
+        # Non-vacuity check: the invariant above is only meaningful if the
+        # oscillation path was actually taken. If this fails, the fixture
+        # (patience=1, opttol=1e-9, ethanol's FIRE trajectory) has stopped
+        # reproducing the oscillating condition on this platform/torch
+        # version -- it does not mean the Converged/Dropped_Oscillating
+        # invariant itself is broken.
+        assert any(m.HasProp("Dropped_Oscillating") and m.GetProp("Dropped_Oscillating") == "True" for m in out), (
+            "fixture did not reproduce an oscillating structure (patience=1 "
+            "should force this on the very first non-converging step); the "
+            "invariant above was never exercised"
+        )
 
 
 def test_make_buckets_groups_by_size(tmp_path, monkeypatch):

--- a/tests/test_batchopt.py
+++ b/tests/test_batchopt.py
@@ -142,50 +142,51 @@ class TestConvergenceStatus:
         assert len(result['converged_mask']) == 2
         assert len(result['oscillating_count']) == 2
 
-    def test_convergence_mask_excludes_oscillating(self):
-        """Convergence mask should exclude oscillating structures (Issue #90)."""
-        # Simulate a case where structure converged but is oscillating
-        converged_mask = [True, True, False]
-        oscillating_count = [10, 2, 1]  # First one is oscillating (count >= patience)
-        patience = 5
 
-        # This is the logic from batchopt.py
-        final_convergence = [
-            converged and osc_count < patience
-            for converged, osc_count in zip(converged_mask, oscillating_count)
-        ]
+@pytest.mark.slow
+class TestConvergenceFlagDerivation:
+    """The Converged/Dropped_Oscillating flags must come from production code.
 
-        # First structure: converged=True but oscillating_count >= patience → False
-        # Second structure: converged=True and oscillating_count < patience → True
-        # Third structure: converged=False → False
-        assert final_convergence == [False, True, False]
+    The previous tests in this class re-implemented the derivation inside the
+    test body and asserted it against itself, so no production code executed
+    (audit M32).
+    """
 
-    def test_convergence_with_energy_stability(self):
-        """Structures converged via energy stability should be marked converged."""
-        # This tests the scenario from issue #90 where energy convergence
-        # is used but the force is between opttol and 10*opttol
-        converged_mask = [True, True]  # Both converged (one via force, one via energy)
-        oscillating_count = [2, 3]     # Neither oscillating
-        patience = 5
+    def test_oscillating_structure_is_not_reported_converged(self, job_dir):
+        """A structure at/over the patience limit must not be Converged=True."""
+        pytest.importorskip("torchani")
 
-        final_convergence = [
-            converged and osc_count < patience
-            for converged, osc_count in zip(converged_mask, oscillating_count)
-        ]
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
 
-        # Both should be marked as converged
-        assert final_convergence == [True, True]
+        from Auto3D.batch_opt.batchopt import optimizing
 
+        mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        mol.SetProp("_Name", "osc_test")
 
-class TestGPUCleanup:
-    """Tests for GPU memory cleanup in batchopt."""
+        sdf = job_dir / "in.sdf"
+        with Chem.SDWriter(str(sdf)) as w:
+            w.write(mol)
 
-    def test_run_method_includes_gpu_cleanup(self):
-        """Verify run() method includes GPU memory cleanup code."""
-        import inspect
-        source = inspect.getsource(optimizing.run)
-        assert 'empty_cache' in source, "GPU cleanup missing from run() method"
-        assert 'cuda.is_available' in source, "CUDA availability check missing"
+        # patience=1 guarantees the oscillation path is taken on any structure
+        # that does not reduce fmax on its very first step.
+        opt = optimizing(
+            in_f=str(sdf),
+            out_f=str(job_dir / "out.sdf"),
+            name="ANI2xt",
+            device=torch.device("cpu"),
+            config={"opt_steps": 5, "opttol": 1e-9, "patience": 1, "batchsize_atoms": 1024},
+        )
+        opt.run()
+
+        out = [m for m in Chem.SDMolSupplier(str(job_dir / "out.sdf"), removeHs=False) if m]
+        assert out, "optimizer produced no output"
+        for m in out:
+            if m.HasProp("Dropped_Oscillating") and m.GetProp("Dropped_Oscillating") == "True":
+                assert m.GetProp("Converged") != "True", (
+                    "a structure dropped for oscillation was reported as converged"
+                )
 
 
 def test_make_buckets_groups_by_size(tmp_path, monkeypatch):

--- a/tests/test_cli_console.py
+++ b/tests/test_cli_console.py
@@ -31,7 +31,7 @@ def test_print_success(capsys):
     print_success("Test passed")
     # Rich strips markup in non-terminal mode
     captured = capsys.readouterr()
-    assert "Test passed" in captured.out or True  # Rich output varies
+    assert "Test passed" in captured.out
 
 
 def test_print_error():

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -1,0 +1,301 @@
+"""The same configuration must be validated identically through every door.
+
+auto3d run -c goes through CLIConfig and gets extra="forbid", Literal engine
+validation, and every Field bound. Auto3DOptions validates only k and window,
+and the legacy `auto3d config.yaml` path constructs Auto3DOptions directly --
+so the Python API that scientific users script against is the least protected
+(C10, M27), and three auxiliary entry points skip the element/charge guard
+entirely (C11).
+"""
+from __future__ import annotations
+
+import pytest
+
+from Auto3D.config import Auto3DOptions
+from Auto3D.exceptions import Auto3DError
+
+
+class TestAuto3DOptionsBounds:
+    """Auto3DOptions must enforce what CLIConfig enforces."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C10: threshold=-1 is accepted, which sets pruneRmsThresh=-1 and "
+        "makes `rmsd < -1` never true, silently disabling duplicate-conformer "
+        "removal while presenting the output as deduplicated",
+    )
+    def test_negative_threshold_is_rejected(self, isolated_input):
+        """A non-positive RMSD threshold must raise, not silently disable dedup."""
+        with pytest.raises(Auto3DError):
+            Auto3DOptions(path=isolated_input("smiles2.smi"), k=1, threshold=-1)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M27: max_confs has no Field(ge=1) in any path, so max_confs=0 "
+        "reaches EmbedMultipleConfs(numConfs=0) and every molecule yields nothing",
+    )
+    def test_zero_max_confs_is_rejected(self, isolated_input):
+        """max_confs must be at least 1."""
+        with pytest.raises(Auto3DError):
+            Auto3DOptions(path=isolated_input("smiles2.smi"), k=1, max_confs=0)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C10: convergence_threshold=0 makes `fmax > opttol` permanently "
+        "true, so every structure burns the full 2000-step budget",
+    )
+    def test_zero_convergence_threshold_is_rejected(self, isolated_input):
+        """A zero force threshold is unsatisfiable and must be refused."""
+        with pytest.raises(Auto3DError):
+            Auto3DOptions(
+                path=isolated_input("smiles2.smi"), k=1, convergence_threshold=0
+            )
+
+
+class TestMutuallyExclusiveSelectors:
+    """k and window are documented as mutually exclusive; passing both must raise."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M28: ConformerRanker.run tests `if self.k:` before "
+        "`elif self.window:`, so window is silently ignored -- which is why the "
+        "shipped 'thorough' preset's window: 5.0 has no effect",
+    )
+    def test_k_and_window_together_raise(self, isolated_input):
+        """select_tautomers raises for this; the conformer ranker must too."""
+        with pytest.raises(Auto3DError):
+            Auto3DOptions(path=isolated_input("smiles2.smi"), k=10, window=5.0)
+
+
+class TestAuxiliaryEntryPointGuards:
+    """calc_spe / opt_geometry / calc_thermo must run the same guard as main()."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C11: check_input's charge/element guard runs only in main() and "
+        "smiles2mols, so a charged species handed to ANI2x is evaluated as the "
+        "neutral molecule -- tens of kcal/mol wrong, with wrong forces",
+    )
+    def test_calc_spe_rejects_charged_input_for_ani(self, job_dir, monkeypatch):
+        """A carboxylate must be refused by ANI2x, not silently neutralized.
+
+        calc_spe would otherwise load a real ANI2x model to reach the point
+        being tested. To stay within the box's "never load an NNP" constraint,
+        the model machinery (get_device/create_model/EnForce_ANI/pad_from_mols)
+        is stubbed out the same way tests/test_isomer_engine_hardening.py and
+        tests/test_durability.py::TestSameFileGuard already do for calc_spe;
+        the guard being tested for (or its absence) sits earlier in the real
+        function, so calc_spe itself still runs for real here.
+        """
+        import torch
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        import Auto3D.SPE as spe_mod
+        from Auto3D.SPE import calc_spe
+
+        mol = Chem.AddHs(Chem.MolFromSmiles("CC(=O)[O-]"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        mol.SetProp("_Name", "acetate")
+
+        sdf = job_dir / "charged.sdf"
+        with Chem.SDWriter(str(sdf)) as w:
+            w.write(mol)
+
+        monkeypatch.setattr(spe_mod, "get_device", lambda *a, **k: torch.device("cpu"))
+
+        class FakeAdapter:
+            coord_pad = 0.0
+            species_pad = 0
+
+        monkeypatch.setattr(spe_mod, "create_model", lambda *a, **k: FakeAdapter())
+
+        class FakeEnForce:
+            def __init__(self, adapter):
+                pass
+
+            def forward_batched(self, coords, numbers, charges):
+                n = coords.shape[0]
+                return torch.ones(n, dtype=torch.float64), torch.zeros_like(coords)
+
+        monkeypatch.setattr(spe_mod, "EnForce_ANI", FakeEnForce)
+
+        def fake_pad(mols, model_name, device, coord_pad, species_pad):
+            n = len(mols)
+            coords = torch.zeros(n, 1, 3)
+            numbers = torch.zeros(n, 1, dtype=torch.long)
+            charges = torch.zeros(n, dtype=torch.long)
+            return coords, numbers, charges
+
+        monkeypatch.setattr(spe_mod, "pad_from_mols", fake_pad)
+
+        with pytest.raises(Auto3DError):
+            calc_spe(str(sdf), "ANI2x", out_path=str(job_dir / "out.sdf"))
+
+
+class TestSmiles2MolsHonesty:
+    """smiles2mols must not silently ignore options it cannot honor."""
+
+    @staticmethod
+    def _stub_pipeline(monkeypatch):
+        """Stub the isomer/optimize/rank/reorder stages of smiles2mols so the
+        function runs to completion without embedding real conformers or
+        loading a real NNP (box constraint: no NNP loads, no downloads, no
+        network). Same pattern as
+        tests/test_workflow.py::test_smiles2mols_uses_args_threshold, which
+        stubs the same four seams for the same reason.
+        """
+        import Auto3D.auto3D as auto3D_mod
+
+        class _StubIsomerEngine:
+            def run(self):
+                return None
+
+        class _StubOpt:
+            def __init__(self, *a, **k):
+                pass
+
+            def run(self):
+                return None
+
+        class _StubRank:
+            def __init__(self, *a, **k):
+                pass
+
+            def run(self):
+                return []
+
+        monkeypatch.setattr(
+            auto3D_mod.IsomerEngineFactory,
+            "create",
+            staticmethod(lambda **kwargs: _StubIsomerEngine()),
+        )
+        monkeypatch.setattr(auto3D_mod, "optimizing", _StubOpt)
+        monkeypatch.setattr(auto3D_mod, "ranking", _StubRank)
+        monkeypatch.setattr(auto3D_mod, "reorder_sdf", lambda *a, **k: [])
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M15: enumerate_tautomer, isomer_engine and mode_oe have no effect "
+        "-- there is no TautomerProcessor in the function and the RDKit engine is "
+        "hardcoded at auto3D.py:131",
+    )
+    def test_unsupported_option_raises(self, isolated_input, monkeypatch):
+        """Requesting tautomer enumeration must raise rather than be ignored.
+
+        The isomer/optimize/rank/reorder stages are stubbed (see
+        _stub_pipeline) so this stays hermetic and exercises only whether
+        enumerate_tautomer is honored, not the full pipeline.
+        """
+        from Auto3D.auto3D import smiles2mols
+
+        self._stub_pipeline(monkeypatch)
+
+        args = Auto3DOptions(
+            path=isolated_input("smiles2.smi"), k=1, use_gpu=False
+        )
+        args.enumerate_tautomer = True
+
+        with pytest.raises((Auto3DError, NotImplementedError)):
+            smiles2mols(["CCO"], args)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M15: auto3D.py:117 sets args['path'] = path0 and :125 sets "
+        "args.input_format on the caller's object, leaving path pointing into a "
+        "deleted TemporaryDirectory",
+    )
+    def test_caller_config_is_not_mutated(self, isolated_input, monkeypatch):
+        """smiles2mols must not modify the config object it was given.
+
+        The isomer/optimize/rank/reorder stages are stubbed (see
+        _stub_pipeline) so this stays hermetic; only the mutation of the
+        caller's config is under test here.
+        """
+        from Auto3D.auto3D import smiles2mols
+
+        self._stub_pipeline(monkeypatch)
+
+        args = Auto3DOptions(
+            path=isolated_input("smiles2.smi"), k=1, use_gpu=False
+        )
+        before = args.path
+
+        try:
+            smiles2mols(["CCO"], args)
+        except Exception:
+            pass  # only the mutation matters here, not whether the run succeeded
+
+        assert args.path == before, (
+            f"caller's config was mutated: {before!r} -> {args.path!r}"
+        )
+
+
+class TestDuplicateInchikeyInputs:
+    """Two inputs that collide on InChIKey must both survive, not merge.
+
+    Note: this test's class was omitted from the task brief's Step 1 code
+    block even though M17 is named in the brief's own "Findings" line and in
+    the phase plan (docs/superpowers/plans/2026-07-30-phase0-verification-harness.md:898)
+    -- added here to close that gap so the file actually covers every
+    finding it claims to.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M17: smiles2smi disambiguates a repeated InChIKey as 'KEY_2' "
+        "specifically so the input is not dropped (utils/file_ops.py:117-127), "
+        "but the pipeline's grouping steps (remove_enantiomers and "
+        "ranking.run) key on _Name.split('_')[0], mapping the disambiguated "
+        "id back onto the first input -- the two merge into one ranking "
+        "group and, with k=1, reorder_sdf finds no molecule for the "
+        "disambiguated id and the second input silently vanishes",
+    )
+    def test_duplicate_smiles_both_survive(self, isolated_input, monkeypatch):
+        """Two identical SMILES (same InChIKey) must each yield a structure
+        in the output -- not collapse into a single winner.
+
+        Only the NNP-loading `optimizing` stage is stubbed (real RDKit
+        embedding of two ethanol molecules is trivial and hermetic, and the
+        defect lives downstream of it, in the real grouping/ranking code);
+        ranking and reorder_sdf run for real since they are what is under
+        test.
+        """
+        from rdkit import Chem
+
+        import Auto3D.auto3D as auto3D_mod
+        from Auto3D.auto3D import smiles2mols
+
+        class _FakeOptimizing:
+            """Marks every real embedded conformer 'Converged' with a
+            distinct energy, so ranking.run's real grouping/top-k logic
+            executes exactly as it would after a genuine optimization --
+            without loading an NNP."""
+
+            def __init__(self, in_f, out_f, name, device, config, *a, **k):
+                self.in_f = in_f
+                self.out_f = out_f
+
+            def run(self):
+                mols = [
+                    m
+                    for m in Chem.SDMolSupplier(self.in_f, removeHs=False)
+                    if m is not None
+                ]
+                with Chem.SDWriter(self.out_f) as w:
+                    for i, m in enumerate(mols):
+                        m.SetProp("Converged", "True")
+                        m.SetProp("E_tot", str(float(i)))
+                        w.write(m)
+
+        monkeypatch.setattr(auto3D_mod, "optimizing", _FakeOptimizing)
+
+        args = Auto3DOptions(
+            path=isolated_input("smiles2.smi"), k=1, use_gpu=False, mpi_np=1
+        )
+        mols = smiles2mols(["CCO", "CCO"], args)
+
+        assert len(mols) == 2, (
+            f"expected one output structure per input (2), got {len(mols)}: "
+            f"{[m.GetProp('_Name') for m in mols]}"
+        )

--- a/tests/test_custom_nnp_eager.py
+++ b/tests/test_custom_nnp_eager.py
@@ -43,8 +43,17 @@ def test_custom_eager_module_loads_and_runs(tmp_path):
     species = torch.tensor([[1, 6, -1]])  # last atom is padding
     charges = torch.zeros(1)
     e, f = adapter.forward(coords, species, charges)
-    assert e.shape == (1,) and torch.isfinite(e).all()
-    assert f.shape == coords.shape and torch.isfinite(f).all()
+    assert e.shape == (1,)
+    assert f.shape == coords.shape
+    # _TinyNNP masks padding: E = sum(coords^2) over real atoms only, so
+    # dE/dx = 2*coords for real atoms and 0 for the padded slot => F = -dE/dx.
+    # Asserting the value, not just finiteness, is what catches a sign flip in
+    # the adapter's force path (audit M32).
+    mask = (species != _TinyNNP.species_pad).unsqueeze(-1)
+    expected_forces = -2.0 * coords * mask
+    torch.testing.assert_close(f, expected_forces, rtol=1e-5, atol=1e-6)
+    expected_energy = (coords * mask).pow(2).sum(dim=(1, 2))
+    torch.testing.assert_close(e, expected_energy, rtol=1e-5, atol=1e-6)
 
 
 def test_load_custom_nnp_eager_and_double(tmp_path):

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -1,0 +1,251 @@
+"""Rewriting a file in place must never be able to destroy it.
+
+reorder_sdf writes to a temp file and os.replace()s it, and cleans the temp up
+on failure -- but nothing tested that path (M33). opt_geometry does the
+opposite: it truncates the file it just read, so a failure mid-write destroys
+a completed optimization whose only copy lives there (C14).
+
+TestReorderSdfDurability closes the M33 coverage gap and must PASS: the
+tmp+os.replace pattern in reorder_sdf already works. TestOptGeometryDurability
+and TestSameFileGuard are tripwires for the still-open C14 defect and must
+XFAIL(strict=True) -- if a future fix makes either XPASS, strict mode turns
+that into a hard failure so the xfail marker has to be removed deliberately.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from Auto3D.utils.file_ops import reorder_sdf
+
+# Captured once, at import time, before any test monkeypatches Chem.SDWriter.
+# Constructing a real Chem.SDWriter on an existing path truncates it
+# immediately (verified empirically: size drops to 0 before any write() call),
+# so stand-ins below that need the *real* truncate-on-open behavior go through
+# this reference instead of the (possibly patched) `Chem.SDWriter` attribute.
+_real_sdwriter = Chem.SDWriter
+
+
+def _write_sdf(path, names):
+    """Write one embedded ethanol conformer per name."""
+    with Chem.SDWriter(str(path)) as w:
+        for name in names:
+            mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+            AllChem.EmbedMolecule(mol, randomSeed=42)
+            mol.SetProp("_Name", name)
+            mol.SetProp("ID", name)
+            w.write(mol)
+
+
+class TestReorderSdfDurability:
+    """A failed reorder must leave the original file intact."""
+
+    def test_original_survives_a_writer_failure(self, job_dir, monkeypatch):
+        """If SDWriter raises mid-rewrite, the input SDF must be unchanged."""
+        sdf = job_dir / "out.sdf"
+        smi = job_dir / "in.smi"
+        _write_sdf(sdf, ["a", "b"])
+        smi.write_text("CCO a\nCCO b\n")
+
+        original = sdf.read_bytes()
+
+        class ExplodingWriter:
+            def __init__(self, *a, **k):
+                pass
+
+            def write(self, *a, **k):
+                raise RuntimeError("disk full")
+
+            def close(self):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(Chem, "SDWriter", ExplodingWriter)
+
+        with pytest.raises(Exception):
+            reorder_sdf(str(sdf), str(smi))
+
+        assert sdf.read_bytes() == original, "the original SDF was corrupted"
+
+    def test_no_temp_file_is_left_behind(self, job_dir, monkeypatch):
+        """A failed reorder must not leave a .tmp artifact next to the output."""
+        sdf = job_dir / "out.sdf"
+        smi = job_dir / "in.smi"
+        _write_sdf(sdf, ["a"])
+        smi.write_text("CCO a\n")
+
+        def boom(*a, **k):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(Chem, "SDWriter", boom)
+        with pytest.raises(Exception):
+            reorder_sdf(str(sdf), str(smi))
+
+        leftovers = [p.name for p in job_dir.iterdir() if ".tmp" in p.name]
+        assert not leftovers, f"temp files left behind: {leftovers}"
+
+
+class TestOptGeometryDurability:
+    """opt_geometry must not truncate the file it is rewriting."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C14: ASE/geometry.py:106-116 opens SDWriter on the same path it "
+        "just read with SDMolSupplier, so a failure between those lines destroys "
+        "the completed optimization -- optimizing.run() wrote its only copy there",
+    )
+    def test_input_survives_a_failed_rewrite(self, job_dir, monkeypatch):
+        """A write failure partway through the unit-conversion rewrite pass must
+        not lose the completed optimization.
+
+        Fork resolution (see task-5 brief, Step 2): `geometry._annotate_and_rewrite`
+        does not exist -- ASE/geometry.py:106-116 inlines the read-then-rewrite
+        with no importable helper, and Phase 6 (not this task) owns extracting
+        one. Chosen option: "Preferred" -- drive the real `opt_geometry` with
+        the batch optimizer (Auto3D.batch_opt.batchopt.optimizing) monkeypatched
+        so no NNP loads. This keeps the test hermetic and in the fast tier while
+        leaving the vulnerable geometry.py:106-116 pass running unmodified.
+
+        Opening Chem.SDWriter on an existing path truncates it immediately (see
+        `_real_sdwriter` note above), so FlakyWriter below wraps the *real*
+        writer -- letting that real truncation happen exactly as it would in
+        production -- and only injects the write() failure after one record,
+        reproducing an interrupted rewrite against an already-truncated file.
+        """
+        import Auto3D.ASE.geometry as geometry
+
+        sdf = job_dir / "in.sdf"
+        _write_sdf(sdf, ["m1", "m2"])
+        outpath = job_dir / "opt_out.sdf"
+
+        completed = {}
+
+        class FakeOptimizing:
+            """Stand-in for batch_opt.optimizing: skips NNP inference entirely.
+
+            Simulates a completed optimization by writing E_tot-bearing records
+            straight to outpath with the real SDWriter -- this is "the only
+            copy" referenced in the xfail reason above.
+            """
+
+            def __init__(self, path, outpath, model_name, device, opt_config):
+                self._path = path
+                self._outpath = outpath
+
+            def run(self):
+                mols = list(Chem.SDMolSupplier(str(self._path), removeHs=False))
+                with _real_sdwriter(str(self._outpath)) as w:
+                    for i, mol in enumerate(mols):
+                        mol.SetProp("E_tot", str(1.0 + i))
+                        w.write(mol)
+                completed["bytes"] = Path(self._outpath).read_bytes()
+
+        monkeypatch.setattr(geometry, "optimizing", FakeOptimizing)
+
+        class FlakyWriter:
+            """Wraps the real SDWriter so opening it truncates `outpath` exactly
+            like production, then fails after one successful write -- leaving
+            the file truncated/partial, the same way a real disk-full crash
+            would.
+            """
+
+            def __init__(self, path, *a, **k):
+                self._real = _real_sdwriter(path, *a, **k)
+                self._n = 0
+
+            def write(self, mol):
+                self._n += 1
+                if self._n >= 2:
+                    raise RuntimeError("disk full")
+                self._real.write(mol)
+
+            def close(self):
+                self._real.close()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                self._real.close()
+                return False
+
+        monkeypatch.setattr(geometry.Chem, "SDWriter", FlakyWriter)
+
+        with pytest.raises(Exception):
+            geometry.opt_geometry(
+                str(sdf), "fake-model", out_path=str(outpath), use_gpu=False
+            )
+
+        assert "bytes" in completed, "the fake optimizer never ran"
+        assert outpath.read_bytes() == completed["bytes"], (
+            "opt_geometry truncated its own output; a completed optimization was lost"
+        )
+
+
+class TestSameFileGuard:
+    """Writing output over the input must be refused or staged atomically."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C14: calc_spe / opt_geometry / calc_thermo do not guard "
+        "out_path == input path, so `auto3d energy mols.sdf -o mols.sdf` "
+        "overwrites the user's input with no atomic staging",
+    )
+    def test_output_equal_to_input_is_rejected(self, job_dir, monkeypatch):
+        """Passing out_path == path must raise rather than silently clobber input.
+
+        calc_spe reads every input molecule into a Python list before it ever
+        opens a writer, so exercising it with a real "AIMNET" run would not
+        even reproduce a truncation -- it would just quietly succeed and
+        overwrite the input, which is the very absence of a guard this test is
+        checking for. To stay within the box's "never load an NNP" constraint,
+        the model machinery (get_device/create_model/EnForce_ANI/pad_from_mols)
+        is stubbed out the same way tests/test_isomer_engine_hardening.py
+        already does for calc_spe; the guard being tested for (or its absence)
+        sits earlier in the real function, so calc_spe itself still runs for
+        real here.
+        """
+        import Auto3D.SPE as spe_mod
+        from Auto3D.exceptions import Auto3DError
+
+        sdf = job_dir / "mols.sdf"
+        _write_sdf(sdf, ["m1"])
+
+        monkeypatch.setattr(spe_mod, "get_device", lambda *a, **k: torch.device("cpu"))
+
+        class FakeAdapter:
+            coord_pad = 0.0
+            species_pad = 0
+
+        monkeypatch.setattr(spe_mod, "create_model", lambda *a, **k: FakeAdapter())
+
+        class FakeEnForce:
+            def __init__(self, adapter):
+                pass
+
+            def forward_batched(self, coords, numbers, charges):
+                n = coords.shape[0]
+                return torch.ones(n, dtype=torch.float64), torch.zeros_like(coords)
+
+        monkeypatch.setattr(spe_mod, "EnForce_ANI", FakeEnForce)
+
+        def fake_pad(mols, model_name, device, coord_pad, species_pad):
+            n = len(mols)
+            coords = torch.zeros(n, 1, 3)
+            numbers = torch.zeros(n, 1, dtype=torch.long)
+            charges = torch.zeros(n, dtype=torch.long)
+            return coords, numbers, charges
+
+        monkeypatch.setattr(spe_mod, "pad_from_mols", fake_pad)
+
+        with pytest.raises((Auto3DError, ValueError)):
+            spe_mod.calc_spe(str(sdf), "AIMNET", out_path=str(sdf))

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -45,7 +45,17 @@ class TestReorderSdfDurability:
     """A failed reorder must leave the original file intact."""
 
     def test_original_survives_a_writer_failure(self, job_dir, monkeypatch):
-        """If SDWriter raises mid-rewrite, the input SDF must be unchanged."""
+        """If SDWriter raises mid-rewrite, the input SDF must be unchanged.
+
+        The stand-in wraps the *real* SDWriter (via the module-level
+        ``_real_sdwriter`` captured before any monkeypatching -- same
+        technique as ``FlakyWriter`` in ``TestOptGeometryDurability`` below)
+        so opening it performs a genuine truncate-on-open against whatever
+        path ``reorder_sdf`` actually hands it. A stub that never touches
+        disk would pass identically whether ``reorder_sdf`` writes to a tmp
+        file (correct) or directly to ``sdf`` (a regression) -- this makes
+        the test sensitive to *which path* gets opened.
+        """
         sdf = job_dir / "out.sdf"
         smi = job_dir / "in.smi"
         _write_sdf(sdf, ["a", "b"])
@@ -54,19 +64,20 @@ class TestReorderSdfDurability:
         original = sdf.read_bytes()
 
         class ExplodingWriter:
-            def __init__(self, *a, **k):
-                pass
+            def __init__(self, path, *a, **k):
+                self._real = _real_sdwriter(path, *a, **k)
 
             def write(self, *a, **k):
                 raise RuntimeError("disk full")
 
             def close(self):
-                pass
+                self._real.close()
 
             def __enter__(self):
                 return self
 
             def __exit__(self, *a):
+                self._real.close()
                 return False
 
         monkeypatch.setattr(Chem, "SDWriter", ExplodingWriter)
@@ -77,13 +88,23 @@ class TestReorderSdfDurability:
         assert sdf.read_bytes() == original, "the original SDF was corrupted"
 
     def test_no_temp_file_is_left_behind(self, job_dir, monkeypatch):
-        """A failed reorder must not leave a .tmp artifact next to the output."""
+        """A failed reorder must not leave a .tmp artifact next to the output.
+
+        ``boom`` actually opens (and closes) the real writer at whatever path
+        it is given before raising, so a genuine tmp file exists on disk
+        ahead of the simulated crash -- otherwise there would be nothing for
+        the cleanup code (``file_ops.py``'s ``tmp_path.unlink()``) to ever
+        leave behind if that cleanup were removed, and this test would pass
+        vacuously.
+        """
         sdf = job_dir / "out.sdf"
         smi = job_dir / "in.smi"
         _write_sdf(sdf, ["a"])
         smi.write_text("CCO a\n")
 
-        def boom(*a, **k):
+        def boom(path, *a, **k):
+            w = _real_sdwriter(path, *a, **k)
+            w.close()
             raise RuntimeError("disk full")
 
         monkeypatch.setattr(Chem, "SDWriter", boom)

--- a/tests/test_isomer_engine.py
+++ b/tests/test_isomer_engine.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import time
+import uuid
 import pytest
 from rdkit import Chem
 from rdkit.Chem import rdMolAlign
@@ -37,7 +38,10 @@ def rmsd_greater(mols, rmsd=0.3):
     return True
             
 def test_rd_isomer_class():
-    job_name = time.strftime('%Y%m%d-%H%M%S')
+    # time.strftime is second-resolution; append a uuid4 fragment so this
+    # collides with neither a same-second run of this test nor a leftover
+    # directory from a prior failed run that skipped cleanup.
+    job_name = time.strftime('%Y%m%d-%H%M%S') + '_' + uuid.uuid4().hex[:8]
     os.mkdir(job_name)
     engine = rd_isomer(path, smiles_enumerated, smiles_reduced, smiles_hashed,
                         sdf_enumerated, job_name, max_confs, threshold, n_process)
@@ -71,7 +75,9 @@ def test_rd_isomer_conformer_func():
     smi_name = ("C#CCOOC", "1_0")
     num_conformers = []
     for threshold in [0.1, 0.2, 0.3]:
-        job_name = time.strftime('%Y%m%d-%H%M%S')
+        # Same-second collision risk across loop iterations; see
+        # test_rd_isomer_class for why a uuid4 fragment is appended.
+        job_name = time.strftime('%Y%m%d-%H%M%S') + '_' + uuid.uuid4().hex[:8]
         os.mkdir(job_name)
         engine = rd_isomer(path, smiles_enumerated, smiles_reduced, smiles_hashed,
                             sdf_enumerated, job_name, max_confs, threshold, n_process)

--- a/tests/test_isomer_engine.py
+++ b/tests/test_isomer_engine.py
@@ -47,23 +47,23 @@ def test_rd_isomer_class():
     assert(rmsd_greater(mols, threshold) == True)
     try:
         os.remove(smiles_enumerated)
-    except:
+    except OSError:
         pass
     try:
         os.remove(smiles_reduced)
-    except:
+    except OSError:
         pass
     try:
         os.remove(smiles_hashed)
-    except:
+    except OSError:
         pass
     try:
         os.remove(sdf_enumerated)
-    except:
+    except OSError:
         pass
     try:
         shutil.rmtree(job_name)
-    except:
+    except OSError:
         pass
 
 
@@ -79,7 +79,7 @@ def test_rd_isomer_conformer_func():
         num_conformers.append(num_conformers_)
         try:
             shutil.rmtree(job_name)
-        except:
+        except OSError:
             pass
     assert(num_conformers[0] >= num_conformers[1])
     assert(num_conformers[1] >= num_conformers[2])
@@ -126,11 +126,11 @@ def test_rd_isomer_with_parallel_embedding():
     for f in [smiles_enum_par, smiles_reduced_par, smiles_hashed_par, sdf_enum_par]:
         try:
             os.remove(f)
-        except:
+        except OSError:
             pass
     try:
         shutil.rmtree(job_name)
-    except:
+    except OSError:
         pass
 
 
@@ -149,7 +149,7 @@ def test_rd_isomer_parallel_embedding_default_off():
 
     try:
         shutil.rmtree(job_name)
-    except:
+    except OSError:
         pass
 
 
@@ -172,7 +172,7 @@ def test_rd_isomer_parallel_embedding_threshold():
 
     try:
         shutil.rmtree(job_name)
-    except:
+    except OSError:
         pass
 
 

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -275,7 +275,14 @@ def test_custom_model_adapter_runs(tmp_path):
     e, f = ad.forward(coords, species, charges)
     assert e.shape == (2,)
     assert f.shape == (2, 4, 3)
-    assert torch.isfinite(e).all() and torch.isfinite(f).all()
+    # _Toy does not mask padding, so E = sum(coords^2) over every slot =>
+    # dE/dx = 2*coords => F = -dE/dx = -2*coords. Asserting the value, not
+    # just finiteness, is what catches a sign flip in the adapter's force
+    # path (audit M32).
+    expected_forces = -2.0 * coords
+    torch.testing.assert_close(f, expected_forces, rtol=1e-5, atol=1e-6)
+    expected_energy = (coords ** 2).sum(dim=(1, 2))
+    torch.testing.assert_close(e, expected_energy, rtol=1e-5, atol=1e-6)
 
 
 class TestValidateOutputs:

--- a/tests/test_model_preflight.py
+++ b/tests/test_model_preflight.py
@@ -28,6 +28,18 @@ Verified against production (not assumed from the plan):
   even exist there) never intercepts construction; the fresh
   ``from ... import ...`` re-resolves the attribute on ``aimnet.calculators``
   every call, so that module attribute is the genuine interception point.
+
+The two ``TestColdCacheDiagnosis`` tests must stay sensitive to a fix landing
+at EITHER of two layers, since the natural fix for C8/M22 is a parent-side
+pre-flight in ``WorkflowOrchestrator._validate_input`` (workers run in
+separate spawned processes with no access to the parent's in-memory model or
+cache, so that is the only place a pre-flight check can usefully live) -- but
+today no such pre-flight exists, so the failure only surfaces deeper, in
+``optim_rank_wrapper`` + ``_finalize_output``. Each test therefore tries
+``_validate_input()`` first and asserts on whatever it raises; only if that
+passes through harmlessly (today's behavior) does it fall through to the
+worker chain. This keeps the tripwire falsifiable regardless of which layer a
+future fix targets.
 """
 from __future__ import annotations
 
@@ -80,7 +92,18 @@ class TestColdCacheDiagnosis:
         "WorkflowOrchestrator._finalize_output's 'no 3D structure converged'",
     )
     def test_network_failure_names_the_network(self, isolated_input, monkeypatch):
-        """An offline cold cache must produce a model/network error, not a chemistry one."""
+        """An offline cold cache must produce a model/network error, not a chemistry one.
+
+        The stated fix for C8 is to pre-flight the model in the parent
+        process before spawning workers (the only sane place, since workers
+        run in separate spawned processes with no access to the parent's
+        in-memory state). So this test must observe a fix landing EITHER
+        there (``WorkflowOrchestrator._validate_input``) OR left as today,
+        deeper in the worker (``optim_rank_wrapper`` + ``_finalize_output``).
+        It tries the parent-side path first; today that passes through
+        harmlessly (``check_input`` never constructs a model), so it falls
+        through to the worker chain, where the failure is actually swallowed.
+        """
         import aimnet.calculators as aimnet_calculators
 
         from Auto3D import workflow_workers as ww
@@ -94,7 +117,26 @@ class TestColdCacheDiagnosis:
 
         chunk_path = isolated_input("smiles2.smi")
         args = Auto3DOptions(path=chunk_path, k=1, use_gpu=False)
+        orchestrator = WorkflowOrchestrator(args)
 
+        try:
+            orchestrator._validate_input()
+        except Auto3DError as exc:
+            # A future parent-side pre-flight check caught it here instead --
+            # the same diagnostic bar applies regardless of which layer fixed it.
+            message = str(exc).lower()
+            assert any(word in message for word in ("network", "download", "cache", "model")), (
+                f"error does not mention the real cause: {exc}"
+            )
+            assert "patience" not in message, (
+                "the three-wrong-reasons message leaked into a model-load failure"
+            )
+            return
+
+        # No parent-side pre-flight exists today (C8): _validate_input()
+        # passed through harmlessly. The failure only surfaces once the
+        # worker attempts to construct the model, and even then it is
+        # swallowed by optim_rank_wrapper's blanket except.
         job_root = Path(chunk_path).parent
         job_dir = job_root / "job1"
         job_dir.mkdir()
@@ -110,7 +152,6 @@ class TestColdCacheDiagnosis:
         result = ww.optim_rank_wrapper(args, q, logq, gpu_idx=0)
         assert result == []
 
-        orchestrator = WorkflowOrchestrator(args)
         orchestrator.job_dir = job_root
         orchestrator.input_path = Path(chunk_path)
         orchestrator.logger = None
@@ -133,7 +174,14 @@ class TestColdCacheDiagnosis:
         "identically forever; Auto3D adds no hint about deleting it",
     )
     def test_checksum_mismatch_says_to_delete_the_file(self, isolated_input, monkeypatch):
-        """A corrupted cache entry must name the file and tell the user to remove it."""
+        """A corrupted cache entry must name the file and tell the user to remove it.
+
+        Same two-layer shape as ``test_network_failure_names_the_network``:
+        try the parent-side pre-flight first (``_validate_input``), which
+        passes through harmlessly today, then fall through to the worker
+        chain where the real (buggy) swallow happens. This way a fix landing
+        at either layer is observed and can legitimately XPASS.
+        """
         import aimnet.calculators as aimnet_calculators
 
         from Auto3D import workflow_workers as ww
@@ -147,7 +195,23 @@ class TestColdCacheDiagnosis:
 
         chunk_path = isolated_input("smiles2.smi")
         args = Auto3DOptions(path=chunk_path, k=1, use_gpu=False)
+        orchestrator = WorkflowOrchestrator(args)
 
+        try:
+            orchestrator._validate_input()
+        except Auto3DError as exc:
+            # A future parent-side pre-flight check caught it here instead.
+            message = str(exc).lower()
+            assert "checksum" in message or "corrupt" in message
+            assert any(w in message for w in ("delete", "remove", "aimnet_cache_dir")), (
+                f"no recovery guidance in: {exc}"
+            )
+            return
+
+        # No parent-side pre-flight exists today (M22): _validate_input()
+        # passed through harmlessly; the failure only surfaces once the
+        # worker attempts to construct the model, and even then it is
+        # swallowed by optim_rank_wrapper's blanket except.
         job_root = Path(chunk_path).parent
         job_dir = job_root / "job1"
         job_dir.mkdir()
@@ -160,7 +224,6 @@ class TestColdCacheDiagnosis:
         result = ww.optim_rank_wrapper(args, q, logq, gpu_idx=0)
         assert result == []
 
-        orchestrator = WorkflowOrchestrator(args)
         orchestrator.job_dir = job_root
         orchestrator.input_path = Path(chunk_path)
         orchestrator.logger = None

--- a/tests/test_model_preflight.py
+++ b/tests/test_model_preflight.py
@@ -1,0 +1,175 @@
+"""Model resolution failures must be diagnosed accurately, before spawning.
+
+The model is built inside the spawned optimizer worker
+(``workflow_workers.optim_rank_wrapper``), inside a blanket
+``except Exception: continue``. So every model-construction failure -- no
+network, bad checksum, typo'd registry name -- surfaces as
+``WorkflowOrchestrator._finalize_output``'s "no 3D structure converged"
+message listing three causes (memory, invalid SMILES, patience), none of
+which applies (C8, M21, M22).
+
+Verified against production (not assumed from the plan):
+
+- ``check_valid_configuration`` (utils/validation.py:267-361) takes explicit
+  keyword parameters and returns a ``list[str]`` of error messages -- it never
+  receives an ``Auto3DOptions`` instance and never raises. The raise happens
+  one layer up, in ``WorkflowOrchestrator._validate_input``
+  (workflow.py:164-179), which is what these tests exercise directly.
+- ``check_input`` (utils/validation.py:35) never constructs any model adapter
+  -- it only checks installed dependencies, opt_steps, and input-file format.
+  Patching ``AIMNet2Calculator`` and calling ``check_input`` (as an earlier
+  draft of this suite assumed) would never intercept anything; the real
+  construction site is ``optimizing.__init__`` (batch_opt/batchopt.py:175),
+  called from ``workflow_workers.optim_rank_wrapper``.
+- ``AIMNet2Adapter.__init__`` imports the calculator lazily, INSIDE the
+  method (``from aimnet.calculators import AIMNet2Calculator``,
+  models/adapter.py:226) -- not at ``Auto3D.models.adapter`` module scope.
+  Patching ``Auto3D.models.adapter.AIMNet2Calculator`` (a name that does not
+  even exist there) never intercepts construction; the fresh
+  ``from ... import ...`` re-resolves the attribute on ``aimnet.calculators``
+  every call, so that module attribute is the genuine interception point.
+"""
+from __future__ import annotations
+
+import queue as queue_mod
+from pathlib import Path
+
+import pytest
+
+from Auto3D.config import Auto3DOptions
+from Auto3D.exceptions import Auto3DError
+from Auto3D.model_factory import ModelFactory
+from Auto3D.workflow import WorkflowOrchestrator
+
+
+class TestRegistryNameValidation:
+    """A typo'd registry model name must fail during validation, not in a worker."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M21: utils/validation.py:329-333 accepts any string starting "
+        "with 'aimnet2' without consulting the registry, so "
+        "WorkflowOrchestrator._validate_input never raises for a typo'd name "
+        "-- the failure only surfaces later, inside the spawned worker",
+    )
+    def test_unknown_registry_name_is_rejected_up_front(self, isolated_input):
+        """--engine aimnet2-2025x must fail validation and name valid options."""
+        args = Auto3DOptions(
+            path=isolated_input("smiles2.smi"), k=1, use_gpu=False
+        )
+        args.optimizing_engine = "aimnet2-2025x"
+
+        orchestrator = WorkflowOrchestrator(args)
+
+        with pytest.raises(Auto3DError) as exc:
+            orchestrator._validate_input()
+
+        message = str(exc.value).lower()
+        assert "aimnet2-2025x" in message, "the error must name the bad value"
+        assert "aimnet2" in message, "the error must list valid options"
+
+
+class TestColdCacheDiagnosis:
+    """A model that cannot be fetched must say so, not blame the user's chemistry."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C8: AIMNet2Adapter.__init__ (models/adapter.py:239) has no "
+        "try/except and runs inside optim_rank_wrapper's blanket except "
+        "(workflow_workers.py), so a ConnectionError becomes "
+        "WorkflowOrchestrator._finalize_output's 'no 3D structure converged'",
+    )
+    def test_network_failure_names_the_network(self, isolated_input, monkeypatch):
+        """An offline cold cache must produce a model/network error, not a chemistry one."""
+        import aimnet.calculators as aimnet_calculators
+
+        from Auto3D import workflow_workers as ww
+
+        ModelFactory.clear_cache()
+
+        def no_network(*a, **k):
+            raise ConnectionError("Temporary failure in name resolution")
+
+        monkeypatch.setattr(aimnet_calculators, "AIMNet2Calculator", no_network)
+
+        chunk_path = isolated_input("smiles2.smi")
+        args = Auto3DOptions(path=chunk_path, k=1, use_gpu=False)
+
+        job_root = Path(chunk_path).parent
+        job_dir = job_root / "job1"
+        job_dir.mkdir()
+
+        q: queue_mod.Queue = queue_mod.Queue()
+        q.put(("enumerated.sdf", chunk_path, str(job_dir), 1))
+        q.put("Done")
+        logq: queue_mod.Queue = queue_mod.Queue()
+
+        # optim_rank_wrapper's blanket except swallows the ConnectionError
+        # today (C8) -- this must not raise, matching the current (buggy)
+        # behavior, and no *_3d.sdf is ever written for job1.
+        result = ww.optim_rank_wrapper(args, q, logq, gpu_idx=0)
+        assert result == []
+
+        orchestrator = WorkflowOrchestrator(args)
+        orchestrator.job_dir = job_root
+        orchestrator.input_path = Path(chunk_path)
+        orchestrator.logger = None
+
+        with pytest.raises(Auto3DError) as exc:
+            orchestrator._finalize_output(start_time=0.0)
+
+        message = str(exc.value).lower()
+        assert any(word in message for word in ("network", "download", "cache", "model")), (
+            f"error does not mention the real cause: {exc.value}"
+        )
+        assert "patience" not in message, (
+            "the three-wrong-reasons message leaked into a model-load failure"
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M22: aimnet's _maybe_download_asset raises on a checksum "
+        "mismatch and leaves the bad file in place, so every later run fails "
+        "identically forever; Auto3D adds no hint about deleting it",
+    )
+    def test_checksum_mismatch_says_to_delete_the_file(self, isolated_input, monkeypatch):
+        """A corrupted cache entry must name the file and tell the user to remove it."""
+        import aimnet.calculators as aimnet_calculators
+
+        from Auto3D import workflow_workers as ww
+
+        ModelFactory.clear_cache()
+
+        def bad_checksum(*a, **k):
+            raise ValueError("Checksum mismatch for aimnet2_wb97m_0.pt")
+
+        monkeypatch.setattr(aimnet_calculators, "AIMNet2Calculator", bad_checksum)
+
+        chunk_path = isolated_input("smiles2.smi")
+        args = Auto3DOptions(path=chunk_path, k=1, use_gpu=False)
+
+        job_root = Path(chunk_path).parent
+        job_dir = job_root / "job1"
+        job_dir.mkdir()
+
+        q: queue_mod.Queue = queue_mod.Queue()
+        q.put(("enumerated.sdf", chunk_path, str(job_dir), 1))
+        q.put("Done")
+        logq: queue_mod.Queue = queue_mod.Queue()
+
+        result = ww.optim_rank_wrapper(args, q, logq, gpu_idx=0)
+        assert result == []
+
+        orchestrator = WorkflowOrchestrator(args)
+        orchestrator.job_dir = job_root
+        orchestrator.input_path = Path(chunk_path)
+        orchestrator.logger = None
+
+        with pytest.raises(Auto3DError) as exc:
+            orchestrator._finalize_output(start_time=0.0)
+
+        message = str(exc.value).lower()
+        assert "checksum" in message or "corrupt" in message
+        assert any(w in message for w in ("delete", "remove", "aimnet_cache_dir")), (
+            f"no recovery guidance in: {exc.value}"
+        )

--- a/tests/test_padding_invariance.py
+++ b/tests/test_padding_invariance.py
@@ -26,8 +26,17 @@ class TestPaddingInvariance:
     """Energy of a molecule must be independent of batch padding."""
 
     @pytest.mark.slow
-    @pytest.mark.parametrize("engine", ["AIMNET", "ANI2xt"])
-    def test_energy_unchanged_when_padded(self, engine, device):
+    # Per-engine absolute tolerance, not one shared constant: this is the same
+    # padded-vs-solo AIMNet2 invariant tests/test_model_adapter.py:249-250
+    # already asserts with atol=1e-2 eV, and ANI2xt's float32 output caps
+    # usable precision at ~float32 ULP (~4e-3 eV) at typical total-energy
+    # magnitudes per src/Auto3D/batch_opt/ANI2xt_no_rep.py:148-155. 1e-6 would
+    # demand sub-ULP reproducibility and flake on a correct model.
+    @pytest.mark.parametrize(
+        "engine, atol",
+        [("AIMNET", 1e-2), ("ANI2xt", 1e-3)],
+    )
+    def test_energy_unchanged_when_padded(self, engine, atol, device):
         """Batching a small molecule alongside a large one must not shift its energy."""
         if engine == "ANI2xt":
             pytest.importorskip("torchani")
@@ -36,16 +45,28 @@ class TestPaddingInvariance:
         model = create_model(engine, device)
         small, large = _mol("CCO"), _mol("c1ccccc1CCCCO")
 
+        # Drive the padding convention from the adapter under test, not a
+        # hardcoded per-engine constant, so the two can never drift apart:
+        # AIMNet2Adapter uses coord_pad=0.0/species_pad=0 while
+        # ANI2xtAdapter uses coord_pad=0.0/species_pad=-1
+        # (src/Auto3D/models/adapter.py:240, :302).
+        coord_pad, species_pad = model.coord_pad, model.species_pad
+
         # Alone: no padding at all.
-        c1, s1, q1 = pad_from_mols([small], engine, device)
+        c1, s1, q1 = pad_from_mols(
+            [small], engine, device, coord_pad=coord_pad, species_pad=species_pad
+        )
         e_alone = model.forward(c1, s1, q1)[0][0]
 
         # Batched with a larger molecule: `small` is now padded to `large`'s size.
-        c2, s2, q2 = pad_from_mols([small, large], engine, device)
+        c2, s2, q2 = pad_from_mols(
+            [small, large], engine, device, coord_pad=coord_pad, species_pad=species_pad
+        )
         e_padded = model.forward(c2, s2, q2)[0][0]
 
-        assert abs(float(e_alone) - float(e_padded)) < 1e-6, (
-            f"{engine}: padding shifted the energy by "
-            f"{abs(float(e_alone) - float(e_padded)):.3e} eV -- padded slots are "
-            f"reaching the model"
+        delta = abs(float(e_alone) - float(e_padded))
+        assert delta < atol, (
+            f"{engine}: padding shifted the energy by {delta:.3e} eV (allowed "
+            f"{atol:.0e} eV of float32 noise) -- padded slots are reaching the "
+            f"model"
         )

--- a/tests/test_padding_invariance.py
+++ b/tests/test_padding_invariance.py
@@ -1,0 +1,51 @@
+"""Padding must not change a molecule's energy.
+
+Every engine masks padded slots differently: AIMNet2 pads species with 0 and
+relies on Z=0 being unused, while ANI2x/ANI2xt pad with -1 and rely on that
+being torchani's masked-atom sentinel. batch_opt/ANI2xt_no_rep.py:167-172
+documents that second assumption as unverified. These tests verify it (audit
+M32, C13).
+"""
+from __future__ import annotations
+
+import pytest
+
+from Auto3D.batch_opt.padding import pad_from_mols
+
+
+def _mol(smiles: str):
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    m = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    AllChem.EmbedMolecule(m, randomSeed=42)
+    return m
+
+
+class TestPaddingInvariance:
+    """Energy of a molecule must be independent of batch padding."""
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("engine", ["AIMNET", "ANI2xt"])
+    def test_energy_unchanged_when_padded(self, engine, device):
+        """Batching a small molecule alongside a large one must not shift its energy."""
+        if engine == "ANI2xt":
+            pytest.importorskip("torchani")
+        from Auto3D.model_factory import create_model
+
+        model = create_model(engine, device)
+        small, large = _mol("CCO"), _mol("c1ccccc1CCCCO")
+
+        # Alone: no padding at all.
+        c1, s1, q1 = pad_from_mols([small], engine, device)
+        e_alone = model.forward(c1, s1, q1)[0][0]
+
+        # Batched with a larger molecule: `small` is now padded to `large`'s size.
+        c2, s2, q2 = pad_from_mols([small, large], engine, device)
+        e_padded = model.forward(c2, s2, q2)[0][0]
+
+        assert abs(float(e_alone) - float(e_padded)) < 1e-6, (
+            f"{engine}: padding shifted the energy by "
+            f"{abs(float(e_alone) - float(e_padded)):.3e} eV -- padded slots are "
+            f"reaching the model"
+        )

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -19,10 +19,6 @@ from Auto3D.config import Auto3DOptions
 pytestmark = pytest.mark.slow
 
 
-def _count_records(sdf_path: str) -> int:
-    return sum(1 for m in Chem.SDMolSupplier(sdf_path, removeHs=False) if m is not None)
-
-
 def _input_ids(smi_path: str) -> set[str]:
     ids = set()
     with open(smi_path) as fh:
@@ -41,12 +37,37 @@ class TestInputOutputAccounting:
         reason="C7: neither _finalize_output nor smiles2mols reconciles inputs "
         "against outputs; find_smiles_not_in_sdf has zero production callers",
     )
-    def test_every_input_is_present_or_reported(self, isolated_input):
-        """Each input ID must appear in the output or in a reported failure list."""
+    def test_every_input_is_present_or_reported(self, job_dir):
+        """Each input ID must appear in the output or in a reported failure list.
+
+        A run of only valid molecules has no *structural* reason to lose any
+        of them, so their absence would depend on non-deterministic
+        convergence luck rather than the C7 defect itself. Instead, mix in the
+        same guaranteed-unconvertible sodium counterion used by
+        ``test_one_bad_molecule_does_not_remove_the_others`` below, and force
+        one molecule per job (the same capacity/memory=1 technique used in
+        ``TestExitStatus``) so sodium's job fails alone -- deterministically,
+        via optim_rank_wrapper's bare except/continue -- while the other jobs
+        succeed independently. Total output is nonzero (no OptimizationError),
+        but the failing ID vanishes with no report anywhere reachable from
+        main()'s return value. That is the reconciliation gap C7 describes,
+        exercised without relying on any molecule's numerical luck.
+        """
         from Auto3D.auto3D import main
 
-        smi = isolated_input("smiles10.smi")
-        args = Auto3DOptions(path=smi, k=1, use_gpu=False, max_confs=2)
+        smi = job_dir / "mixed10.smi"
+        # Na is outside AIMNet2's 14-element set and guaranteed to fail; the
+        # other three are simple, well-behaved organics guaranteed to succeed.
+        smi.write_text(
+            "CCO ethanol\n"
+            "CCCO propanol\n"
+            "c1ccccc1 benzene\n"
+            "[Na+].CC(=O)[O-] sodium_acetate\n"
+        )
+
+        args = Auto3DOptions(
+            path=str(smi), k=1, use_gpu=False, max_confs=2, capacity=1, memory=1
+        )
         out = main(args)
 
         produced = set()
@@ -54,10 +75,17 @@ class TestInputOutputAccounting:
             if mol is not None:
                 produced.add(mol.GetProp("_Name").split("_")[0])
 
-        expected = _input_ids(smi)
-        missing = expected - produced
+        # No public interface reports failed inputs today (that is exactly
+        # C7), so this is always empty -- but written this way, a later fix
+        # that starts populating a failure list on the result would make this
+        # test XPASS without any edits here.
+        reported_failures = set(getattr(out, "failures", None) or [])
+
+        expected = _input_ids(str(smi))
+        missing = expected - produced - reported_failures
         assert not missing, (
-            f"{len(missing)} of {len(expected)} inputs vanished with no report: "
+            f"{len(missing)} of {len(expected)} inputs vanished with no report "
+            f"(absent from the output SDF and from any reported failure list): "
             f"{sorted(missing)}"
         )
 

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -1,0 +1,182 @@
+"""Every input molecule must be accounted for, and success must mean success.
+
+The pipeline isolates failure per chunk, per molecule, with sentinel-guaranteed
+queue drains -- but has no compensating reporting layer, so failure is reliably
+contained and just as reliably invisible. _finalize_output raises only when zero
+outputs exist, so 9 of 10 failed chunks exits 0 (C6). find_smiles_not_in_sdf,
+the reconciliation function, exists and is exported and tested with zero
+production callers (C7).
+
+Slow tier: uses the real aimnet2 registry model on CPU.
+"""
+from __future__ import annotations
+
+import pytest
+from rdkit import Chem
+
+from Auto3D.config import Auto3DOptions
+
+pytestmark = pytest.mark.slow
+
+
+def _count_records(sdf_path: str) -> int:
+    return sum(1 for m in Chem.SDMolSupplier(sdf_path, removeHs=False) if m is not None)
+
+
+def _input_ids(smi_path: str) -> set[str]:
+    ids = set()
+    with open(smi_path) as fh:
+        for line in fh:
+            parts = line.split()
+            if len(parts) >= 2:
+                ids.add(parts[1])
+    return ids
+
+
+class TestInputOutputAccounting:
+    """No input may vanish without being reported."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C7: neither _finalize_output nor smiles2mols reconciles inputs "
+        "against outputs; find_smiles_not_in_sdf has zero production callers",
+    )
+    def test_every_input_is_present_or_reported(self, isolated_input):
+        """Each input ID must appear in the output or in a reported failure list."""
+        from Auto3D.auto3D import main
+
+        smi = isolated_input("smiles10.smi")
+        args = Auto3DOptions(path=smi, k=1, use_gpu=False, max_confs=2)
+        out = main(args)
+
+        produced = set()
+        for mol in Chem.SDMolSupplier(out, removeHs=False):
+            if mol is not None:
+                produced.add(mol.GetProp("_Name").split("_")[0])
+
+        expected = _input_ids(smi)
+        missing = expected - produced
+        assert not missing, (
+            f"{len(missing)} of {len(expected)} inputs vanished with no report: "
+            f"{sorted(missing)}"
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C6: one unsupported element raises inside ensemble_opt, and "
+        "optim_rank_wrapper's bare `except Exception: continue` discards every "
+        "molecule in that chunk",
+    )
+    def test_one_bad_molecule_does_not_remove_the_others(self, job_dir):
+        """A sodium counterion must not take the rest of the file down with it."""
+        from Auto3D.auto3D import main
+
+        smi = job_dir / "mixed.smi"
+        # Na is outside AIMNet2's 14-element set; the other three are fine.
+        smi.write_text(
+            "CCO ethanol\n"
+            "CCCO propanol\n"
+            "[Na+].CC(=O)[O-] sodium_acetate\n"
+            "c1ccccc1 benzene\n"
+        )
+
+        args = Auto3DOptions(path=str(smi), k=1, use_gpu=False, max_confs=2)
+        out = main(args)
+
+        produced = {
+            m.GetProp("_Name").split("_")[0]
+            for m in Chem.SDMolSupplier(out, removeHs=False)
+            if m is not None
+        }
+        for good in ("ethanol", "propanol", "benzene"):
+            assert good in produced, (
+                f"{good} was lost because an unrelated molecule failed; produced "
+                f"{sorted(produced)}"
+            )
+
+
+class TestExitStatus:
+    """Losing molecules must not exit 0."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C6: execute_run ends its try block with print_results_summary and "
+        "never raises SystemExit on failed_count > 0, so `auto3d run --json && "
+        "next_step` proceeds on a partial run",
+    )
+    def test_cli_exits_nonzero_when_molecules_are_missing(self, job_dir):
+        """auto3d run must signal partial failure through its exit code."""
+        from typer.testing import CliRunner
+
+        from Auto3D.cli.app import app
+
+        smi = job_dir / "mixed.smi"
+        smi.write_text("CCO ethanol\n[Na+].CC(=O)[O-] sodium_acetate\n")
+
+        # `auto3d run` has no --capacity/--memory/--max-confs flags (verified via
+        # `auto3d run --help`), so a plain two-molecule file lands both rows in a
+        # single default-sized chunk (capacity=42/GB memory). One unsupported
+        # element in a *shared* chunk currently takes the whole chunk down (C6),
+        # which would leave zero total output and make _finalize_output raise
+        # OptimizationError on its own -- a *correct* nonzero exit for an
+        # unrelated reason, not the silent partial-failure this test targets.
+        # A tiny capacity/memory (via --config) forces one molecule per chunk,
+        # so ethanol's chunk succeeds independently of sodium_acetate's chunk
+        # failing: a genuine partial run that should exit 0 today.
+        config = job_dir / "config.yaml"
+        config.write_text(f"path: {smi}\ncapacity: 1\nmemory: 1\n")
+
+        result = CliRunner().invoke(
+            app,
+            ["run", str(smi), "--config", str(config), "--k", "1", "--no-gpu"],
+        )
+        assert result.exit_code != 0, (
+            f"exited 0 despite losing a molecule; output:\n{result.output}"
+        )
+
+
+class TestEnergyAndRankingSanity:
+    """Assert on the numbers, not merely that the program ran."""
+
+    def test_energies_are_negative_and_ordered(self, isolated_input):
+        """E_tot must be negative and ascending within a conformer group."""
+        from Auto3D.auto3D import main
+
+        args = Auto3DOptions(
+            path=isolated_input("smiles2.smi"), k=3, use_gpu=False, max_confs=4
+        )
+        out = main(args)
+
+        groups: dict[str, list[float]] = {}
+        for mol in Chem.SDMolSupplier(out, removeHs=False):
+            if mol is None:
+                continue
+            base = mol.GetProp("_Name").split("_")[0]
+            groups.setdefault(base, []).append(float(mol.GetProp("E_tot")))
+
+        assert groups, "no molecules in the output"
+        for base, energies in groups.items():
+            assert all(e < 0 for e in energies), f"{base}: non-negative energy {energies}"
+            assert energies == sorted(energies), (
+                f"{base}: conformers are not energy-ordered: {energies}"
+            )
+
+    def test_top_k_returns_distinct_conformers(self, isolated_input):
+        """k=3 must yield at most 3 per molecule, and the first is the minimum."""
+        from Auto3D.auto3D import main
+
+        args = Auto3DOptions(
+            path=isolated_input("smiles2.smi"), k=3, use_gpu=False, max_confs=6
+        )
+        out = main(args)
+
+        groups: dict[str, list[float]] = {}
+        for mol in Chem.SDMolSupplier(out, removeHs=False):
+            if mol is None:
+                continue
+            base = mol.GetProp("_Name").split("_")[0]
+            groups.setdefault(base, []).append(float(mol.GetProp("E_tot")))
+
+        for base, energies in groups.items():
+            assert len(energies) <= 3, f"{base}: k=3 but got {len(energies)}"
+            assert energies[0] == min(energies), f"{base}: first is not the minimum"

--- a/tests/test_species_conversion.py
+++ b/tests/test_species_conversion.py
@@ -1,0 +1,158 @@
+"""ANI2xt species must be model indices, not atomic numbers.
+
+ANI2xt is built with periodic_table_index=False at every construction site
+(nothing passes True), so its forward expects 0-based indices H=0..Cl=6. Only
+batch_opt/padding.py:131-134 converts. ASE/thermo.py:146-147 and :170-171 pass
+raw atomic numbers, as does cli/commands/models.py:241-243 (C3, C4).
+
+The decisive asymmetry: ANI2x gets periodic_table_index=True at both of its
+sites (thermo.py:338, models/adapter.py:346), so it is correct.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torchani")
+
+
+def torch_isfinite(t) -> bool:
+    import torch
+
+    return bool(torch.isfinite(t).all())
+
+
+class TestBatchPathIsCorrect:
+    """The batch path already converts; this guards against regression."""
+
+    @pytest.mark.slow
+    def test_pad_from_mols_emits_indices_for_ani2xt(self, device):
+        """Methane must become species indices [1, 0, 0, 0, 0], not [6, 1, 1, 1, 1]."""
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        from Auto3D.batch_opt.padding import pad_from_mols
+
+        mol = Chem.AddHs(Chem.MolFromSmiles("C"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+
+        _, species, _ = pad_from_mols([mol], "ANI2xt", device)
+        values = sorted(int(v) for v in species[0])
+
+        # ANI2XT_INDEX: H=0, C=1. Methane is one carbon and four hydrogens.
+        assert values == [0, 0, 0, 0, 1], (
+            f"expected model indices, got {values} -- looks like atomic numbers"
+        )
+
+
+class TestThermoPathConverts:
+    """The thermo path must convert atomic numbers the same way the batch path does."""
+
+    @pytest.mark.slow
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C3: ASE/thermo.py:146-147 passes atoms.get_atomic_numbers() and "
+        ":170-171 passes a.GetAtomicNum() straight to ANI2xtAdapter, so H(Z=1) "
+        "hits the carbon network and C(Z=6) hits the chlorine network",
+    )
+    def test_thermo_and_batch_paths_agree_on_methane(self, device):
+        """The same molecule must get the same energy from both thermo entry points."""
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        from Auto3D.ASE.thermo import mol2aimnet_input
+        from Auto3D.batch_opt.padding import pad_from_mols
+        from Auto3D.model_factory import create_model
+
+        mol = Chem.AddHs(Chem.MolFromSmiles("C"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+
+        model = create_model("ANI2xt", device)
+
+        coords_b, species_b, charges_b = pad_from_mols([mol], "ANI2xt", device)
+        e_batch = float(model.forward(coords_b, species_b, charges_b)[0][0])
+
+        thermo_in = mol2aimnet_input(mol, device)
+        e_thermo = float(
+            model.forward(
+                thermo_in["coord"], thermo_in["numbers"], thermo_in["charge"]
+            )[0][0]
+        )
+
+        assert abs(e_batch - e_thermo) < 1e-4, (
+            f"thermo path disagrees with batch path by {abs(e_batch - e_thermo):.3f} eV "
+            f"-- the thermo path is passing atomic numbers where indices are expected"
+        )
+
+    @pytest.mark.slow
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C3: N/O/F/S/Cl have Z = 7,8,9,16,17, all >= len(self.networks) == 7, "
+        "so they index out of range instead of being converted",
+    )
+    def test_heteroatom_molecule_does_not_crash_thermo_path(self, device):
+        """Ethanol has oxygen (Z=8), which is out of range for 7 networks."""
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        from Auto3D.ASE.thermo import mol2aimnet_input
+        from Auto3D.model_factory import create_model
+
+        mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+
+        model = create_model("ANI2xt", device)
+        thermo_in = mol2aimnet_input(mol, device)
+
+        energy, _ = model.forward(
+            thermo_in["coord"], thermo_in["numbers"], thermo_in["charge"]
+        )
+        assert torch_isfinite(energy), "energy is not finite"
+
+
+class TestHealthCheckIsHonest:
+    """auto3d models test must not report success on a mis-specified molecule."""
+
+    @pytest.mark.slow
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C4: cli/commands/models.py:241-243 passes [[6, 1, 1, 1, 1]] "
+        "(atomic numbers) as species, so index 6 is Cl and index 1 is C -- the "
+        "'methane' health check evaluates a Cl+4C species and prints 'working'",
+    )
+    def test_health_check_energy_matches_real_methane(self, device):
+        """The reported health-check energy must match a correctly-built methane."""
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        from Auto3D.batch_opt.padding import pad_from_mols
+        from Auto3D.model_factory import create_model
+
+        mol = Chem.AddHs(Chem.MolFromSmiles("C"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        model = create_model("ANI2xt", device)
+        coords, species, charges = pad_from_mols([mol], "ANI2xt", device)
+        reference = float(model.forward(coords, species, charges)[0][0])
+
+        # _health_check_energy does not exist -- cli/commands/models.py builds
+        # its tensor inline inside execute_models_test. Drive the real CLI
+        # command instead and parse the reported energy out of its output.
+        # --no-gpu keeps this on the same device family as `reference` (the
+        # `device` fixture is always CPU), so the comparison isn't confounded
+        # by CPU/GPU numerical drift.
+        from typer.testing import CliRunner
+
+        from Auto3D.cli.app import app
+
+        result = CliRunner().invoke(app, ["models", "test", "ANI2xt", "--no-gpu"])
+        assert result.exit_code == 0, result.output
+
+        import re
+
+        match = re.search(r"E\s*=\s*(-?\d+\.?\d*)", result.output)
+        assert match, f"could not parse the reported energy from: {result.output}"
+        reported = float(match.group(1))
+
+        assert abs(reported - reference) < 1.0, (
+            f"health check reports {reported:.2f} eV but real methane is "
+            f"{reference:.2f} eV -- the check is validating a different molecule"
+        )

--- a/tests/test_stereo_identity.py
+++ b/tests/test_stereo_identity.py
@@ -78,8 +78,14 @@ class TestTautomerStereoPreservation:
         "so rd_taut writes stereo-stripped SMILES that are then re-enumerated "
         "as unassigned -- a 50% chance of the wrong enantiomer",
     )
-    def test_specified_center_survives_tautomer_enumeration(self):
+    def test_specified_center_survives_tautomer_enumeration(self, job_dir):
         """At least one output tautomer must retain the input's specified center.
+
+        This drives Auto3D's real ``rdkit`` tautomer engine -- the same
+        ``TautomerEngine.rd_taut()`` the pipeline dispatches to, reached via
+        ``Auto3D.isomers.factory.create_tautomer_engine`` -- rather than a
+        bare RDKit ``TautomerEnumerator``, so the defect is attributed to
+        Auto3D's tautomer path and not to RDKit in isolation.
 
         This center is itself alpha to the ketone, so a tautomer genuinely
         produced by enolizing through the stereocenter's own alpha-hydrogen
@@ -92,17 +98,19 @@ class TestTautomerStereoPreservation:
         the eventual fix must not over-correct to "preserve stereo across all
         tautomers unconditionally."
         """
-        from rdkit.Chem.MolStandardize import rdMolStandardize
+        from Auto3D.isomers.factory import create_tautomer_engine
 
-        source = "C[C@H](C(=O)C)N"
-        enumerator = rdMolStandardize.TautomerEnumerator()
-        outputs = [
-            Chem.MolToSmiles(t)
-            for t in enumerator.Enumerate(Chem.MolFromSmiles(source))
-        ]
+        in_smi = job_dir / "taut_stereo.smi"
+        in_smi.write_text("C[C@H](C(=O)C)N taut_test\n")
+        out_smi = job_dir / "taut_stereo_out.smi"
 
+        create_tautomer_engine(
+            "rdkit", str(in_smi), str(out_smi), pka_norm=False
+        ).run()
+
+        outputs = out_smi.read_text().splitlines()
         assert outputs, "tautomer enumeration returned nothing"
-        assert any("@" in smi for smi in outputs), (
+        assert any("@" in line for line in outputs), (
             f"every tautomer lost the specified stereocenter: {sorted(outputs)}"
         )
 

--- a/tests/test_stereo_identity.py
+++ b/tests/test_stereo_identity.py
@@ -1,0 +1,127 @@
+"""Stereochemical identity must survive the pipeline.
+
+Auto3D's primary value proposition is stereoisomer enumeration, so a molecule
+emitted with a different configuration than it was given is a correctness
+failure, not a quality one. Every test here is hermetic: these defects occur
+during enumeration, before any neural network potential runs.
+
+Findings: C1 (E/Z collapse), C2 (tautomer stereo loss), M19 (SDF path),
+C9 (no post-optimization validation).
+"""
+from __future__ import annotations
+
+import pytest
+from rdkit import Chem
+from rdkit.Chem.EnumerateStereoisomers import (
+    EnumerateStereoisomers,
+    StereoEnumerationOptions,
+)
+
+from Auto3D.utils.stereochemistry import enantiomer, enantiomer_helper
+
+
+def _enumerate(smiles: str) -> list[str]:
+    """Enumerate unassigned stereocenters the way the pipeline does."""
+    opts = StereoEnumerationOptions(unique=True, maxIsomers=64, onlyUnassigned=True)
+    mol = Chem.MolFromSmiles(smiles)
+    return sorted(Chem.MolToSmiles(m) for m in EnumerateStereoisomers(mol, options=opts))
+
+
+class TestEnantiomerPredicate:
+    """The enantiomer predicate must not treat 'no stereocenters' as 'enantiomers'."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C1: enantiomer([], []) returns True vacuously -- the loop body "
+        "never executes and `indicator` stays True",
+    )
+    def test_two_achiral_molecules_are_not_enantiomers(self):
+        """Molecules with no stereocenters cannot be an enantiomeric pair."""
+        assert enantiomer([], []) is False
+
+
+class TestEZIsomersSurvive:
+    """E/Z configuration is invariant under reflection, so it is never enantiomeric."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C1: FindMolChiralCenters does not report double-bond stereo, so "
+        "both descriptor lists are empty and one geometric isomer is discarded",
+    )
+    def test_but_2_ene_keeps_both_geometric_isomers(self):
+        """CC=CC must yield both E and Z after enantiomer filtering."""
+        enumerated = _enumerate("CC=CC")
+        assert enumerated == ["C/C=C/C", "C/C=C\\C"], f"enumeration changed: {enumerated}"
+
+        kept = enantiomer_helper(enumerated)
+        assert len(kept) == 2, f"a geometric isomer was discarded: kept {kept}"
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C1: fumaric and maleic acid differ by ~5 kcal/mol and one is "
+        "discarded as an 'enantiomer' of the other",
+    )
+    def test_fumaric_and_maleic_acid_both_survive(self):
+        """The two diacids are distinct compounds, not an enantiomeric pair."""
+        enumerated = _enumerate("OC(=O)C=CC(=O)O")
+        assert len(enumerated) == 2, f"enumeration changed: {enumerated}"
+
+        kept = enantiomer_helper(enumerated)
+        assert len(kept) == 2, f"a geometric isomer was discarded: kept {kept}"
+
+
+class TestTautomerStereoPreservation:
+    """Tautomer enumeration must not silently erase a specified stereocenter."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C2: RDKit TautomerEnumerator defaults to SetRemoveSp3Stereo(True), "
+        "so rd_taut writes stereo-stripped SMILES that are then re-enumerated "
+        "as unassigned -- a 50% chance of the wrong enantiomer",
+    )
+    def test_specified_center_survives_tautomer_enumeration(self):
+        """At least one output tautomer must retain the input's specified center."""
+        from rdkit.Chem.MolStandardize import rdMolStandardize
+
+        source = "C[C@H](C(=O)C)N"
+        enumerator = rdMolStandardize.TautomerEnumerator()
+        outputs = [
+            Chem.MolToSmiles(t)
+            for t in enumerator.Enumerate(Chem.MolFromSmiles(source))
+        ]
+
+        assert outputs, "tautomer enumeration returned nothing"
+        assert any("@" in smi for smi in outputs), (
+            f"every tautomer lost the specified stereocenter: {sorted(outputs)}"
+        )
+
+
+class TestSdfInputStereo:
+    """A 2D SDF with an unspecified center must not be silently randomized."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M19: RDKitSdfIsomer calls only AddHs + EmbedMultipleConfs, so "
+        "ETKDG returns a mixture of configurations written as conformers of one "
+        "species; RDKitSdfIsomerAdapter does not even accept enumerate_isomers",
+    )
+    def test_unspecified_center_is_enumerated_or_refused(self, job_dir):
+        """Either both configurations appear as separate species, or it is refused."""
+        from rdkit.Chem import AllChem
+
+        # Alanine drawn flat, with no stereo specified.
+        mol = Chem.AddHs(Chem.MolFromSmiles("CC(N)C(=O)O"))
+        mol.SetProp("_Name", "alanine_flat")
+        AllChem.EmbedMultipleConfs(mol, numConfs=12, randomSeed=42)
+
+        codes = set()
+        for conf in mol.GetConformers():
+            single = Chem.Mol(mol, confId=conf.GetId())
+            Chem.AssignStereochemistryFrom3D(single)
+            found = Chem.FindMolChiralCenters(single, useLegacyImplementation=False)
+            codes.update(code for _, code in found)
+
+        assert len(codes) <= 1, (
+            f"embedding produced a stereochemical mixture {sorted(codes)} labeled as "
+            f"conformers of one species; the pipeline must enumerate or refuse instead"
+        )

--- a/tests/test_stereo_identity.py
+++ b/tests/test_stereo_identity.py
@@ -5,8 +5,7 @@ emitted with a different configuration than it was given is a correctness
 failure, not a quality one. Every test here is hermetic: these defects occur
 during enumeration, before any neural network potential runs.
 
-Findings: C1 (E/Z collapse), C2 (tautomer stereo loss), M19 (SDF path),
-C9 (no post-optimization validation).
+Findings: C1 (E/Z collapse), C2 (tautomer stereo loss), M19 (SDF path).
 """
 from __future__ import annotations
 
@@ -80,7 +79,19 @@ class TestTautomerStereoPreservation:
         "as unassigned -- a 50% chance of the wrong enantiomer",
     )
     def test_specified_center_survives_tautomer_enumeration(self):
-        """At least one output tautomer must retain the input's specified center."""
+        """At least one output tautomer must retain the input's specified center.
+
+        This center is itself alpha to the ketone, so a tautomer genuinely
+        produced by enolizing through the stereocenter's own alpha-hydrogen
+        could legitimately racemize it -- that would be real chemistry, not a
+        bug. The defect under test is that RDKit's ``SetRemoveSp3Stereo(True)``
+        strips the center indiscriminately from EVERY output tautomer,
+        including ones produced by enolizing the ketone's other,
+        non-stereogenic alpha carbon, which cannot touch this center at all.
+        That is unconditional information loss, not equilibrium modeling, and
+        the eventual fix must not over-correct to "preserve stereo across all
+        tautomers unconditionally."
+        """
         from rdkit.Chem.MolStandardize import rdMolStandardize
 
         source = "C[C@H](C(=O)C)N"
@@ -101,27 +112,74 @@ class TestSdfInputStereo:
 
     @pytest.mark.xfail(
         strict=True,
-        reason="M19: RDKitSdfIsomer calls only AddHs + EmbedMultipleConfs, so "
-        "ETKDG returns a mixture of configurations written as conformers of one "
-        "species; RDKitSdfIsomerAdapter does not even accept enumerate_isomers",
+        reason="M19: RDKitSdfIsomer.run() (driven here through the real "
+        "create_isomer_engine('rdkit_sdf', ...) / RDKitSdfIsomerAdapter factory "
+        "path) calls only AddHs + EmbedMultipleConfs on the SDF-parsed mol, so "
+        "ETKDG returns a stereochemical mixture that is written to the output "
+        "SDF as numbered conformers under a single species name",
     )
     def test_unspecified_center_is_enumerated_or_refused(self, job_dir):
-        """Either both configurations appear as separate species, or it is refused."""
+        """Drive Auto3D's real SDF isomer engine on a flat, unspecified center.
+
+        This writes a genuine flat (2D, no wedge bonds, no parity flags) SDF
+        record for alanine to disk and feeds it through the production
+        ``rdkit_sdf`` engine -- the same ``RDKitSdfIsomerAdapter`` /
+        ``RDKitSdfIsomer.run()`` the pipeline dispatches to for SDF input --
+        via ``Auto3D.isomers.factory.create_isomer_engine``. It then inspects
+        the SDF file Auto3D actually writes, grouped by species name (the
+        conformer-index suffix stripped). Either the two configurations must
+        come out as distinct, internally consistent species, or ambiguous
+        input must be explicitly refused (a ``ValueError``). Instead, both
+        configurations are written as numbered conformers under one species
+        name -- the defect this test targets.
+        """
         from rdkit.Chem import AllChem
 
-        # Alanine drawn flat, with no stereo specified.
-        mol = Chem.AddHs(Chem.MolFromSmiles("CC(N)C(=O)O"))
+        from Auto3D.isomers.factory import create_isomer_engine
+
+        # Alanine drawn flat (2D), with no stereo specified anywhere: no
+        # wedge/hash bonds, no parity flags in the mol block.
+        mol = Chem.MolFromSmiles("CC(N)C(=O)O")
         mol.SetProp("_Name", "alanine_flat")
-        AllChem.EmbedMultipleConfs(mol, numConfs=12, randomSeed=42)
+        AllChem.Compute2DCoords(mol)
 
-        codes = set()
-        for conf in mol.GetConformers():
-            single = Chem.Mol(mol, confId=conf.GetId())
-            Chem.AssignStereochemistryFrom3D(single)
-            found = Chem.FindMolChiralCenters(single, useLegacyImplementation=False)
-            codes.update(code for _, code in found)
+        input_sdf = job_dir / "alanine_flat.sdf"
+        with Chem.SDWriter(str(input_sdf)) as writer:
+            writer.write(mol)
 
-        assert len(codes) <= 1, (
-            f"embedding produced a stereochemical mixture {sorted(codes)} labeled as "
-            f"conformers of one species; the pipeline must enumerate or refuse instead"
+        output_sdf = job_dir / "alanine_enumerated.sdf"
+        engine = create_isomer_engine(
+            "rdkit_sdf",
+            input_path=str(input_sdf),
+            output_path=str(output_sdf),
+            max_confs=12,
+            threshold=0.3,
+            n_jobs=1,
+        )
+
+        try:
+            engine.run()
+        except ValueError:
+            # Explicit refusal of ambiguous stereochemistry is an acceptable
+            # resolution; there is nothing further to check.
+            return
+
+        per_species: dict[str, set[str]] = {}
+        for out_mol in Chem.SDMolSupplier(str(output_sdf), removeHs=False):
+            if out_mol is None:
+                continue
+            name = out_mol.GetProp("_Name")
+            species = name.rsplit("_", 1)[0]
+            Chem.AssignStereochemistryFrom3D(out_mol)
+            found = Chem.FindMolChiralCenters(out_mol, useLegacyImplementation=False)
+            per_species.setdefault(species, set()).update(code for _, code in found)
+
+        mixed = {
+            name: sorted(codes) for name, codes in per_species.items() if len(codes) > 1
+        }
+        assert not mixed, (
+            f"RDKitSdfIsomer wrote a stereochemical mixture under a single species "
+            f"name: {mixed}; the pipeline must enumerate distinct species or refuse "
+            f"ambiguous input instead of silently mixing configurations as "
+            f"conformers of one species"
         )

--- a/tests/test_tauto.py
+++ b/tests/test_tauto.py
@@ -42,7 +42,7 @@ def test_get_stable_tautomers1():
     out_folder = os.path.dirname(os.path.abspath(tautomer_out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 
@@ -64,7 +64,7 @@ def test_get_stable_tautomers2():
     out_folder = os.path.dirname(os.path.abspath(tautomer_out))
     try:
         send2trash(out_folder)
-    except:
+    except OSError:
         shutil.rmtree(out_folder)
 
 if __name__ == '__main__':

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -59,7 +59,7 @@ try:
             energies = self.model((species, coords)).energies * 27.211386245988
             return energies
     test_userNNP1 = True
-except:
+except ImportError:
     test_userNNP1 = False
 
 class userNNP2(torch.nn.Module):
@@ -168,7 +168,7 @@ def test_calc_thermo_aimnet():
     assert(abs(reference_H - H_out) <= 0.02)
     try:
         os.remove(out)
-    except:
+    except OSError:
         pass
 
 def test_vib_hessian_includes_external_dispersion():
@@ -248,7 +248,7 @@ def test_opt_geometry1():
     out = opt_geometry(path, 'ANI2x', gpu_idx=0, opt_tol=0.1, opt_steps=5000)
     try:
         os.remove(out)
-    except:
+    except OSError:
         pass
 
 def test_opt_geometry2():
@@ -256,7 +256,7 @@ def test_opt_geometry2():
     out = opt_geometry(path, 'ANI2xt', gpu_idx=0, opt_tol=0.1, opt_steps=5000)
     try:
         os.remove(out)
-    except:
+    except OSError:
         pass
 
 def test_opt_geometry3():
@@ -264,7 +264,7 @@ def test_opt_geometry3():
     out = opt_geometry(path, 'AIMNET', gpu_idx=0, opt_tol=0.1, opt_steps=5000)
     try:
         os.remove(out)
-    except:
+    except OSError:
         pass
 
 
@@ -283,7 +283,7 @@ def test_opt_geometry_with_patience_and_batchsize():
     assert os.path.exists(out)
     try:
         os.remove(out)
-    except:
+    except OSError:
         pass
 
 @pytest.mark.skipif(not test_userNNP1, reason="TorchANI is not  installed.")
@@ -298,7 +298,7 @@ def test_opt_geometry4():
         out = opt_geometry(path, model_path, gpu_idx=0, opt_tol=0.1, opt_steps=5000)
     try:
         os.remove(out)
-    except:
+    except OSError:
         pass
 
 def test_opt_geometry5():
@@ -312,7 +312,7 @@ def test_opt_geometry5():
         out = opt_geometry(path, model_path, gpu_idx=0, opt_tol=0.1, opt_steps=5000)
     try:
         os.remove(out)
-    except:
+    except OSError:
         pass
 
 
@@ -345,11 +345,11 @@ def test_calc_thermo_userNNP1():
     assert(abs(H_out - H_out2) <= 0.02)
     try:
         os.remove(out)
-    except:
+    except OSError:
         pass
     try:
         os.remove(out2)
-    except:
+    except OSError:
         pass
 
 
@@ -376,7 +376,7 @@ def test_calc_thermo_userNNP2():
     assert(abs(reference_H - H_out) <= 0.02)
     try:
         os.remove(out)
-    except:
+    except OSError:
         pass
 
 

--- a/tests/test_thermo_reference.py
+++ b/tests/test_thermo_reference.py
@@ -94,18 +94,28 @@ class TestStationaryPointGating:
         # guaranteed to either skip straight past the gate or fail to
         # converge in a single BFGS step, regardless of which of those two
         # code paths is taken.
-        path = _write_mol(job_dir / "raw.sdf", smiles="CCCCO", optimize=False)
+        path = _write_mol(job_dir / "raw.sdf", smiles="CCCCO", name="butanol", optimize=False)
 
         out = calc_thermo(str(path), "AIMNET", opt_steps=1, use_gpu=False)
 
-        for mol in Chem.SDMolSupplier(str(out), removeHs=False):
-            if mol is None:
-                continue
-            if mol.HasProp("G_hartree"):
-                assert mol.HasProp("Thermo_converged") or mol.HasProp("Thermo_warning"), (
-                    "G was reported for a structure that could not have converged in "
-                    "one step, with no flag distinguishing it"
-                )
+        results = [m for m in Chem.SDMolSupplier(str(out), removeHs=False) if m]
+        with_g = [m for m in results if m.HasProp("G_hartree")]
+        for mol in with_g:
+            assert mol.HasProp("Thermo_converged") or mol.HasProp("Thermo_warning"), (
+                "G was reported for a structure that could not have converged in "
+                "one step, with no flag distinguishing it"
+            )
+
+        # Non-vacuity check: the invariant above is only meaningful if at
+        # least one record actually reported G_hartree. If do_mol_thermo
+        # instead raises for this deliberately-unconverged geometry, the
+        # record lands in mols_failed with no G_hartree at all, the loop
+        # above never executes its assertion, and this test would otherwise
+        # pass for the wrong reason.
+        assert with_g, (
+            "no output record carried G_hartree -- the unconverged-geometry gate "
+            "above was never exercised; this does not confirm the bug is fixed"
+        )
 
 
 class TestHessianGeometry:

--- a/tests/test_thermo_reference.py
+++ b/tests/test_thermo_reference.py
@@ -1,0 +1,178 @@
+"""Thermochemistry must be computed at a converged stationary point.
+
+BFGS mutates the ASE atoms in place, but mol's conformer is synced only at the
+end of do_mol_thermo -- so vib_hessian re-reads pre-optimization coordinates
+while the energy and moments of inertia come from the relaxed structure (C5).
+Nothing checks opt.run()'s return value, so G is reported for structures the
+optimizer never converged (M8). And one unparseable SDF record aborts a batch
+that may already have computed hundreds of Hessians (M13).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+pytest.importorskip("ase")
+pytestmark = pytest.mark.slow
+
+
+def _write_mol(path, smiles="CCO", name="ethanol", optimize=True):
+    mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    AllChem.EmbedMolecule(mol, randomSeed=42)
+    if optimize:
+        AllChem.MMFFOptimizeMolecule(mol, maxIters=2000)
+    mol.SetProp("_Name", name)
+    with Chem.SDWriter(str(path)) as w:
+        w.write(mol)
+    return str(path)
+
+
+class TestBatchRobustness:
+    """One malformed record must not destroy a batch of Hessians."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M13: SDMolSupplier yields a None entry for an unparseable "
+        "record, and GetConformer(), GetProp('_Name') and set_calculator all "
+        "run before the try: at thermo.py:457 -- SPE.py:73-82 filters None "
+        "entries for exactly this reason, thermo.py does not",
+    )
+    def test_malformed_record_does_not_abort_the_batch(self, job_dir):
+        """A None record between two valid ones must be skipped, not crash.
+
+        The corrupt block must sit BETWEEN two valid records, not after the
+        last one: verified against this repo's RDKit (2025.09.6), a forward
+        ``SDMolSupplier`` iterator (what ``list(...)`` and ``calc_thermo``
+        itself use) only ever surfaces an explicit ``None`` for a corrupt
+        record when a further valid record follows it in the file. A corrupt
+        trailing record with nothing after it is silently dropped without
+        producing a ``None`` at all, so the code path under test (an
+        unguarded ``None.GetConformer()``) would never fire and the test
+        would pass today for the wrong reason.
+        """
+        from Auto3D.ASE.thermo import calc_thermo
+
+        good1 = job_dir / "good1.sdf"
+        good2 = job_dir / "good2.sdf"
+        _write_mol(good1, smiles="CCO", name="ethanol")
+        _write_mol(good2, smiles="CCCO", name="propanol")
+
+        # Sandwich a deliberately corrupt record between two valid ones.
+        combined = job_dir / "mixed.sdf"
+        combined.write_text(
+            good1.read_text() + "this is not a molecule\n$$$$\n" + good2.read_text()
+        )
+
+        out = calc_thermo(str(combined), "AIMNET", use_gpu=False)
+
+        results = [m for m in Chem.SDMolSupplier(str(out), removeHs=False) if m]
+        assert any(m.HasProp("G_hartree") for m in results), (
+            "the valid molecules produced no thermo result"
+        )
+
+
+class TestStationaryPointGating:
+    """G must not be reported for a structure the optimizer did not converge."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M8: opt.run()'s return value is never checked, so a geometry "
+        "that exhausts opt_steps proceeds to a Hessian and its G is reported "
+        "as if converged; opt_tol is used only in the except ValueError "
+        "fallback, and the entry gate at thermo.py:464 hardcodes 0.01",
+    )
+    def test_unconverged_geometry_is_flagged_or_refused(self, job_dir):
+        """With opt_steps=1 nothing can converge, so no G may be emitted unflagged."""
+        from Auto3D.ASE.thermo import calc_thermo
+
+        # Deliberately unoptimized (no MMFF pass): a raw ETKDG embedding has
+        # bond lengths/angles far enough from equilibrium that any reasonable
+        # potential (classical or NNP) reports a force well above both the
+        # 0.01 eV/A entry gate and the tighter opt_tol -- so this is
+        # guaranteed to either skip straight past the gate or fail to
+        # converge in a single BFGS step, regardless of which of those two
+        # code paths is taken.
+        path = _write_mol(job_dir / "raw.sdf", smiles="CCCCO", optimize=False)
+
+        out = calc_thermo(str(path), "AIMNET", opt_steps=1, use_gpu=False)
+
+        for mol in Chem.SDMolSupplier(str(out), removeHs=False):
+            if mol is None:
+                continue
+            if mol.HasProp("G_hartree"):
+                assert mol.HasProp("Thermo_converged") or mol.HasProp("Thermo_warning"), (
+                    "G was reported for a structure that could not have converged in "
+                    "one step, with no flag distinguishing it"
+                )
+
+
+class TestHessianGeometry:
+    """The Hessian and the energy must be evaluated at the same geometry."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C5: vib_hessian re-reads mol.GetConformer() at thermo.py:225 "
+        "-- the geometry as it stood before BFGS ran -- instead of the "
+        "positions actually held by the atoms object it was handed, whose "
+        "energy is read at thermo.py:272 after BFGS has moved it",
+    )
+    def test_hessian_geometry_matches_relaxed_atoms(self, job_dir):
+        """vib_hessian must evaluate the Hessian at atoms' current geometry.
+
+        A tolerance-banded comparison of two independently-computed G values
+        is a coin flip: whether they differ by more than an arbitrary
+        threshold depends on how far the input happened to sit from the
+        model's minimum. Instead, compare a quantity that is EXACTLY
+        determined by the code path, with no numerical judgment call: the
+        Cartesian geometry vib_hessian's returned VibrationsData was built
+        from vs. the geometry the same `atoms` object actually holds after
+        BFGS has moved it. If the Hessian and the energy come from the same
+        structure, these must be bit-for-bit identical (the same array
+        round-tripped through the same object); if vib_hessian re-reads a
+        stale mol conformer, they will differ by the full relaxation
+        displacement -- typically tenths of an Angstrom for a raw,
+        non-force-field-relaxed embedding, i.e. many orders of magnitude
+        above float64 noise. There is no threshold to tune and no way for
+        this to pass by numerical accident.
+        """
+        from ase.optimize import BFGS
+
+        from Auto3D.ASE.thermo import (
+            _load_hessian_model,
+            mol2atoms,
+            model_name2model_calculator,
+            vib_hessian,
+        )
+        from Auto3D.model_factory import get_device
+
+        # Raw ETKDG embedding, no MMFF relaxation: guarantees a large initial
+        # force, so BFGS is guaranteed to actually move the atoms before
+        # vib_hessian is ever called.
+        path = _write_mol(job_dir / "raw.sdf", smiles="CCO", optimize=False)
+        mol = next(m for m in Chem.SDMolSupplier(path, removeHs=False) if m)
+
+        device = get_device(0, use_gpu=False)
+        hessian_model = _load_hessian_model("AIMNET", device)
+        _, calculator = model_name2model_calculator("AIMNET", device)
+        calculator.set_charge(Chem.GetFormalCharge(mol))
+
+        # This is exactly what calc_thermo's optimize branch does: BFGS
+        # mutates `atoms` in place. mol's RDKit conformer is untouched.
+        atoms = mol2atoms(mol)
+        atoms.set_calculator(calculator)
+        opt = BFGS(atoms)
+        opt.run(fmax=3e-3, steps=100)
+
+        vib = vib_hessian(mol, atoms.get_calculator(), hessian_model, device,
+                          model_name="AIMNET")
+
+        # The geometry the Hessian was computed at must be the geometry the
+        # energy (and moments of inertia) were computed at: the same `atoms`
+        # object, post-relaxation.
+        assert np.allclose(vib.atoms.get_positions(), atoms.get_positions(), atol=1e-8), (
+            "vib_hessian's Hessian was evaluated at a different geometry than "
+            "the relaxed atoms object -- the Hessian is stale relative to the "
+            "reported energy"
+        )

--- a/tests/test_thermo_reference.py
+++ b/tests/test_thermo_reference.py
@@ -113,43 +113,57 @@ class TestHessianGeometry:
 
     @pytest.mark.xfail(
         strict=True,
-        reason="C5: vib_hessian re-reads mol.GetConformer() at thermo.py:225 "
-        "-- the geometry as it stood before BFGS ran -- instead of the "
-        "positions actually held by the atoms object it was handed, whose "
-        "energy is read at thermo.py:272 after BFGS has moved it",
+        reason="C5: do_mol_thermo calls vib_hessian at thermo.py:270 while "
+        "mol's conformer still holds the pre-BFGS geometry -- the sync back "
+        "from atoms only happens at thermo.py:318-320, after the Hessian and "
+        "the energy (:272) have already been computed from two different "
+        "geometries",
     )
-    def test_hessian_geometry_matches_relaxed_atoms(self, job_dir):
-        """vib_hessian must evaluate the Hessian at atoms' current geometry.
+    def test_hessian_geometry_matches_relaxed_atoms(self, job_dir, monkeypatch):
+        """do_mol_thermo's Hessian must come from the same geometry as its energy.
 
         A tolerance-banded comparison of two independently-computed G values
         is a coin flip: whether they differ by more than an arbitrary
         threshold depends on how far the input happened to sit from the
         model's minimum. Instead, compare a quantity that is EXACTLY
         determined by the code path, with no numerical judgment call: the
-        Cartesian geometry vib_hessian's returned VibrationsData was built
-        from vs. the geometry the same `atoms` object actually holds after
-        BFGS has moved it. If the Hessian and the energy come from the same
+        Cartesian geometry the Hessian was built from vs. the geometry the
+        same `atoms` object actually holds when the energy is read
+        (thermo.py:272). If the Hessian and the energy come from the same
         structure, these must be bit-for-bit identical (the same array
-        round-tripped through the same object); if vib_hessian re-reads a
-        stale mol conformer, they will differ by the full relaxation
-        displacement -- typically tenths of an Angstrom for a raw,
-        non-force-field-relaxed embedding, i.e. many orders of magnitude
-        above float64 noise. There is no threshold to tune and no way for
-        this to pass by numerical accident.
+        round-tripped through the same object); if the Hessian is stale, they
+        differ by the full relaxation displacement -- typically tenths of an
+        Angstrom for a raw, non-force-field-relaxed embedding, many orders of
+        magnitude above float64 noise. There is no threshold to tune and no
+        way for this to pass by numerical accident.
+
+        This drives `do_mol_thermo` itself -- the sole production caller of
+        `vib_hessian` (thermo.py:270) -- rather than calling `vib_hessian`
+        directly, and only records what the real, unmodified `vib_hessian`
+        returns (via a pass-through spy) rather than asserting on its
+        internals. That binds the test to both plausible fix locations: if
+        the fix reorders `do_mol_thermo`'s mol-conformer sync to happen
+        before it calls `vib_hessian` (the sync currently at :318-320), the
+        real `vib_hessian` it calls will see an already-synced `mol` and this
+        assertion will pass; if instead the fix changes `vib_hessian` itself
+        to source its geometry from `atoms` rather than from `mol`, the
+        spied return value reflects that directly too. Either fix location
+        makes this XPASS; only calling `vib_hessian` directly (bypassing
+        `do_mol_thermo`) would have missed a fix made by reordering the sync.
         """
         from ase.optimize import BFGS
 
+        from Auto3D.ASE import thermo as thermo_mod
         from Auto3D.ASE.thermo import (
             _load_hessian_model,
             mol2atoms,
             model_name2model_calculator,
-            vib_hessian,
         )
         from Auto3D.model_factory import get_device
 
         # Raw ETKDG embedding, no MMFF relaxation: guarantees a large initial
         # force, so BFGS is guaranteed to actually move the atoms before
-        # vib_hessian is ever called.
+        # do_mol_thermo calls vib_hessian.
         path = _write_mol(job_dir / "raw.sdf", smiles="CCO", optimize=False)
         mol = next(m for m in Chem.SDMolSupplier(path, removeHs=False) if m)
 
@@ -159,20 +173,37 @@ class TestHessianGeometry:
         calculator.set_charge(Chem.GetFormalCharge(mol))
 
         # This is exactly what calc_thermo's optimize branch does: BFGS
-        # mutates `atoms` in place. mol's RDKit conformer is untouched.
+        # mutates `atoms` in place. mol's RDKit conformer is untouched -- the
+        # only sync back into mol happens inside do_mol_thermo, at the very
+        # end (thermo.py:318-320).
         atoms = mol2atoms(mol)
         atoms.set_calculator(calculator)
         opt = BFGS(atoms)
         opt.run(fmax=3e-3, steps=100)
 
-        vib = vib_hessian(mol, atoms.get_calculator(), hessian_model, device,
-                          model_name="AIMNET")
+        # Spy on the module-level vib_hessian: call straight through to the
+        # real implementation and record the geometry it actually built the
+        # Hessian from. do_mol_thermo resolves `vib_hessian` as a bare global
+        # at call time (thermo.py:270), so patching the module attribute
+        # intercepts that specific call without altering its behavior.
+        real_vib_hessian = thermo_mod.vib_hessian
+        captured: dict[str, np.ndarray] = {}
 
+        def _spy(*args, **kwargs):
+            vib = real_vib_hessian(*args, **kwargs)
+            captured["positions"] = vib.atoms.get_positions().copy()
+            return vib
+
+        monkeypatch.setattr(thermo_mod, "vib_hessian", _spy)
+
+        thermo_mod.do_mol_thermo(mol, atoms, hessian_model, device, model_name="AIMNET")
+
+        assert "positions" in captured, "do_mol_thermo never called vib_hessian"
         # The geometry the Hessian was computed at must be the geometry the
         # energy (and moments of inertia) were computed at: the same `atoms`
         # object, post-relaxation.
-        assert np.allclose(vib.atoms.get_positions(), atoms.get_positions(), atol=1e-8), (
-            "vib_hessian's Hessian was evaluated at a different geometry than "
-            "the relaxed atoms object -- the Hessian is stale relative to the "
-            "reported energy"
+        assert np.allclose(captured["positions"], atoms.get_positions(), atol=1e-8), (
+            "do_mol_thermo's Hessian was evaluated at a different geometry "
+            "than the relaxed atoms object it read the energy from -- the "
+            "Hessian is stale relative to the reported energy"
         )

--- a/tests/test_utils_file_ops.py
+++ b/tests/test_utils_file_ops.py
@@ -122,8 +122,13 @@ class TestSmiles2Smi:
         assert all("_" not in i for i in ids)
 
 
-class TestCombineSmi:
-    """Tests for combine_smi (order-preserving dedup)."""
+class TestCombineSmiOrderPreservingDedup:
+    """Tests for combine_smi (order-preserving dedup).
+
+    Named distinctly from the ``TestCombineSmi`` class below -- both defined
+    ``TestCombineSmi`` until a lint audit found the second definition was
+    silently shadowing this one, so pytest never collected the test below.
+    """
 
     def test_preserves_order_and_dedups(self, tmp_path):
         f1 = tmp_path / "a.smi"

--- a/tests/test_utils_stereochemistry.py
+++ b/tests/test_utils_stereochemistry.py
@@ -74,10 +74,10 @@ class TestEnantiomerHelper:
         assert result[0] in smiles
 
     @pytest.mark.xfail(
-        strict=False,
-        reason="C1: this test asserts the buggy behavior is correct. Phase 2 "
-        "rewrites it to assert that two distinct achiral molecules both survive. "
-        "Kept (not deleted) to preserve the record that it was once intended.",
+        strict=True,
+        reason="C1: enantiomer([], []) returns True vacuously, so two distinct "
+        "achiral molecules are wrongly treated as an enantiomeric pair and one "
+        "is dropped by enantiomer_helper.",
     )
     def test_enantiomer_helper_keeps_non_chiral(self):
         """Two distinct achiral molecules must both survive enantiomer filtering.

--- a/tests/test_utils_stereochemistry.py
+++ b/tests/test_utils_stereochemistry.py
@@ -73,20 +73,22 @@ class TestEnantiomerHelper:
         assert len(result) == 1
         assert result[0] in smiles
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason="C1: this test asserts the buggy behavior is correct. Phase 2 "
+        "rewrites it to assert that two distinct achiral molecules both survive. "
+        "Kept (not deleted) to preserve the record that it was once intended.",
+    )
     def test_enantiomer_helper_keeps_non_chiral(self):
-        """Test that non-chiral molecules are handled.
+        """Two distinct achiral molecules must both survive enantiomer filtering.
 
-        Note: Non-chiral molecules have empty stereo center lists.
-        The enantiomer check on empty lists returns True (vacuously),
-        so subsequent non-chiral molecules are filtered as "enantiomers".
-        This is the expected behavior of the original function.
+        CCO and CCCO are different compounds. The current implementation drops
+        the second because both have empty stereo-center lists and
+        ``enantiomer([], [])`` returns True vacuously.
         """
         smiles = ["CCO", "CCCO"]
         result = enantiomer_helper(smiles)
-        # First molecule is always kept; second has same (empty) stereo info
-        # so it's considered an "enantiomer" and filtered out
-        assert len(result) == 1
-        assert result[0] == "CCO"
+        assert len(result) == 2, f"a distinct achiral molecule was dropped: {result}"
 
     def test_enantiomer_helper_empty_list(self):
         """Test handling of empty list."""


### PR DESCRIPTION
Builds the verification harness that the six audit-remediation phases will be measured against. **No production code changes** — `git diff` against the base is empty under `src/`.

## The mechanism

Each of the 28 new tests asserts the behavior the code *should* have, which today's code violates, and carries `@pytest.mark.xfail(strict=True, reason="<finding-id>: ...")`. The test fails now, so CI stays green. When the owning phase fixes the defect the test XPASSes, and `strict=True` turns that into a hard failure — forcing the marker's removal in the same PR. The markers are tripwires in the code rather than a checklist in a document.

`docs/superpowers/plans/2026-07-30-phase0-red-list.md` maps every marker to its owning phase, with handoff notes for the traps a fix could otherwise walk into.

## Coverage

28 tripwires — 19 fast-tier, 6 slow-tier, 3 requiring `torchani`. They cover the stereochemistry identity defects (E/Z isomers discarded as enantiomers; tautomer enumeration erasing specified centers), the ANI2xt atomic-number/species-index mismatch, the thermochemistry Hessian-geometry mismatch, silent molecule loss with a zero exit code, model-load failures misreported as convergence failures, and the configuration validation gaps.

## Also fixed

Six tests that could never fail: three that re-implemented production logic in the test body or grepped `inspect.getsource`, a duplicated `TestCombineSmi` class that shadowed an earlier one so its test never ran, and an `assert ... or True`. The `ruff` config now keeps F811 and SIM222 enabled for `tests/` so these cannot recur silently.

New passing coverage where there was none: analytic force values on the toy NNP (a sign flip previously passed the gate), per-engine padding invariance, and the atomic-rewrite failure path in `reorder_sdf`.

## CI

The slow job now runs the full `-m slow` tier instead of three files — five end-to-end modules previously ran in no job at all. A model-cache warm step hard-fails when the registry is unreachable, so an unavailable gate can never read as a passing one. `tests/` is now linted.

## Verification

680 passed, 9 skipped, 19 xfailed, 0 xpassed, 0 failed. `ruff check src/Auto3D/ tests/` clean.

Note: 9 of the 28 tripwires have not been executed — they need a real model or `torchani`, unavailable on the development box — and are asserted red by source-level tracing. `strict=True` fails safe there: an unexpectedly-passing test goes red rather than dark. The red list names four specific items to watch on the first CI slow run.