### PR TITLE
Phase 2: stereochemical identity (C1, C2, C9, M19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **Molecules with unspecified double-bond stereo now produce roughly twice the
+  conformer groups.** One geometric isomer of every such molecule was previously
+  discarded before embedding, because the enantiomer filter treated two empty
+  stereo-center lists as an enantiomeric pair and `FindMolChiralCenters` never
+  reports double-bond stereo. Which isomer survived was decided by SMILES sort
+  order. Fumaric and maleic acid differ by ~5 kcal/mol, and one of them silently
+  disappeared. Expect larger output and longer runs for affected inputs; this is
+  the cis/trans enumeration that was already being requested.
+
+- **Conformers whose configuration changed during optimization are excluded from
+  the results.** Optimization can invert a stereocenter or rotate through a
+  double bond, producing a molecule of different chemical identity than its
+  title. Such records are marked with a `Stereo_changed` SD property and dropped
+  by the conformer filters, with a count logged. A molecule whose every
+  conformer changed configuration now yields no output where it previously
+  yielded a mislabeled structure. Every surviving record now carries
+  `Stereo_changed` too, set to `False` - this SD property did not exist on 3.x
+  output at all, so code that enumerates every SD property on a record should
+  expect it. Clash relief (`relieve_clash`, the force-field relaxation that runs
+  on the enumerated SDF before the neural network optimization) can invert a
+  center or rotate a double bond by the same mechanism and is now guarded the
+  same way at its own call site: a conformer whose configuration changes during
+  clash relief is discarded there, with a warning logged, before it can reach
+  the optimization step and be baked in as that step's unwitting "before" state.
+
+- **SDF input enumerates unspecified stereocenters and removes enantiomers.**
+  `RDKitSdfIsomer` embedded a single molecule per record, so ETKDG returned a
+  mixture of configurations written as numbered conformers of one species. Each
+  configuration is now embedded separately, and conformers are named
+  `<species>_<isomer>_<conformer>` to match the SMILES path. Enantiomeric pairs
+  are also reduced to one representative here, the same rule the SMILES path
+  already applies via `remove_enantiomers` - without it, this path emitted twice
+  the species (alanine: 1 -> 2, glucose: 16 -> 32). `max_confs` is therefore a
+  per-stereoisomer budget on this path, as it already was on the SMILES path,
+  but "per-stereoisomer" now means *per surviving* stereoisomer: a flat SDF with
+  one unspecified center and no other stereo element has only one surviving
+  isomer, because the two configurations at a lone center are always
+  enantiomers of each other, so `max_confs=12` produces up to 12 conformers, not
+  24; a molecule with two independent unspecified centers (e.g. threonine) keeps
+  two surviving diastereomers, so `max_confs=12` there does produce up to 24. An
+  isomer ETKDG cannot embed is now named in a logged warning instead of
+  disappearing from the output with no trace.
+
+- **`Auto3D.utils.stereo_check.stereo_changed` removed.** It had no caller and
+  compared CIP codes by raw atom index against a separately parsed reference
+  SMILES. Use `stereo_descriptors_from_3d` to read a molecule's configuration
+  and `stereo_preserved` to test the marker the pipeline sets.
+
 - **`pad_from_mols` returns a 4-tuple** - `(coords, species, charges, atom_mask)`.
   `atom_mask` is a `(batch, max_atoms)` boolean tensor, `True` for real atoms.
   `ensemble_opt` and `n_steps` now take `atom_mask` in place of `species_pad`.
@@ -63,6 +111,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   purely force-driven from `v = 0`, so every affected hydrogen was frozen at
   its input coordinate for the entire run - the output geometry itself was
   wrong, not merely the convergence metadata.
+
+- **Geometric isomers are no longer discarded as enantiomers** - `enantiomer()`
+  returned `True` for two empty descriptor lists because its loop body never
+  executed. `enantiomer_helper` no longer does a pairwise, index-keyed
+  comparison at all: it now deduplicates by `enantiomer_key(smi)` - a
+  molecule's canonical SMILES paired with its mirror image's - which needs no
+  atom mapping between two independently canonicalized structures and is exact
+  on E/Z, since a reflection cannot change double-bond geometry and geometric
+  isomers therefore never share a key. This also removes the latent failure
+  where the old index-keyed comparison could raise `ValueError` on a legitimate
+  pair and silently disable the filter for that whole batch, and it fixes a
+  meso compound being emitted twice: the same key collapses a meso form against
+  the string-inverted twin `amend_configuration_w` appends for it, which a
+  pairwise enantiomer test could not recognize as one molecule written two
+  ways. `enantiomer()` itself is fixed and still public; new public
+  `are_enantiomers(smi1, smi2)` and `enantiomer_key(smi)` helpers are also
+  available from `Auto3D.utils.stereochemistry`.
+
+- **Tautomer enumeration preserves specified stereochemistry** - RDKit's
+  `TautomerEnumerator` defaults to `SetRemoveSp3Stereo(True)`, so every output
+  tautomer was written stereo-stripped and then re-enumerated downstream as
+  unassigned. A submitted (S) molecule came back as (R) roughly half the time,
+  at identical energy and undetectable from the output. Affects
+  `enumerate_tautomer=True` runs only.
+
+  Preserving sp3 and bond stereo this way is only safe for single-step
+  flattening: across a multi-step path (D-erythrose reaching the shared
+  2,3-enediol, which flattens both of its centers) RDKit restores a definite
+  tag rather than leaving the center unspecified, and for one output that tag
+  is the input's mirror image. A tautomer that reproduces the input's
+  constitution with a different configuration is therefore rejected outright -
+  without that check, D-erythrose came back with L-erythrose emitted as one of
+  its own tautomers. Tautomers of a genuinely different constitution are left
+  untouched, since a keto/enol shift can legitimately relabel an untouched
+  center's CIP priority without inverting it, and no new descriptors are
+  assigned.
+
+- **SDF input no longer randomizes unspecified stereocenters** - the SDF path
+  ignored `enumerate_isomers` entirely; the adapter did not accept it. With
+  enumeration disabled, a molecule with unspecified stereo now logs a warning
+  naming the count instead of silently emitting a mixture.
 
 ## [3.5.0] - 2026-06-13
 

--- a/docs/source/migration-4.0.rst
+++ b/docs/source/migration-4.0.rst
@@ -31,6 +31,43 @@ entire run -- **the output geometry itself is wrong, not merely the
 convergence metadata.** Structures were also written with
 ``Converged=True`` and an understated ``fmax``. Recompute those runs.
 
+More conformers for molecules with unspecified double bonds
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Auto3D 3.x discarded one geometric isomer of every achiral molecule with an
+unspecified ``C=C``, because its enantiomer filter treated two empty
+stereo-center lists as an enantiomeric pair. Which isomer survived was decided
+by SMILES sort order, with no warning. Fumaric and maleic acid differ by about
+5 kcal/mol, and one of them disappeared.
+
+Both isomers now survive, so affected inputs produce roughly twice the
+conformer groups and take correspondingly longer. If you sized ``max_confs``
+or a job's runtime against 3.x output for such molecules, re-check it.
+
+Conformers that change configuration are dropped
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Geometry optimization can invert a stereocenter or rotate through a double
+bond. Auto3D 3.x had no check for this -- ``check_connectivity`` compares
+interatomic distances against UFF radii and is stereo-blind -- so such a
+structure was emitted as a converged conformer under the original title.
+
+Configuration is now compared before and after optimization. Records that
+changed carry a ``Stereo_changed`` SD property and are excluded from the
+results, with a count logged. A molecule whose every conformer changed
+configuration now yields no output for that molecule, where 3.x yielded a
+mislabeled structure. If a run produces fewer molecules than 3.x did, check the
+log for this count before assuming a regression.
+
+Every surviving record now carries ``Stereo_changed`` too, set to ``False`` --
+this SD property did not exist on 3.x output at all, so code that enumerates
+every SD property on a record should expect it. The same check also covers
+clash relief, the force-field relaxation that runs on the enumerated SDF
+before optimization and can invert a center by the same mechanism: a
+conformer whose configuration changes there is discarded before optimization
+ever sees it, with a warning logged, instead of reaching the neural-network
+check already inverted and passing through unnoticed.
+
 API changes
 ------------
 
@@ -108,3 +145,30 @@ error. ``model_name`` is now a required keyword-only argument on both.
    # 4.0 -- required
    calc = Calculator(model, charge=0, model_name="ANI2xt")
    inp = mol2aimnet_input(mol, device, model_name="ANI2xt")
+
+SDF input
+~~~~~~~~~
+
+3.x embedded one molecule per SDF record directly with ETKDG and wrote its raw
+conformers under a two-component name, ``<name>_<conformer>``; an unspecified
+stereocenter came back as an ETKDG-randomized mixture of configurations under
+that one name, and ``enumerate_isomers`` had no effect on this path at all --
+the adapter did not accept it.
+
+4.0 enumerates unspecified stereocenters on SDF input the same way the SMILES
+path does, embeds each configuration separately, and removes enantiomeric
+pairs the same way ``remove_enantiomers`` does for SMILES input. Conformers
+are named ``<species>_<isomer>_<conformer>``, matching the SMILES path, and
+``enumerate_isomers=False`` is now honored here too, logging a warning that
+names the count of unspecified stereo elements instead of quietly emitting a
+mixture.
+
+``max_confs`` is a per-stereoisomer budget on this path now, as it already was
+for SMILES input -- but "per-stereoisomer" means *per surviving* stereoisomer.
+A molecule with a single unspecified center and no other stereo element keeps
+only one surviving isomer, because the two configurations at a lone center are
+always enantiomers of each other: with ``max_confs=12`` it produces up to 12
+conformers, not 24. A molecule with two independent unspecified centers (e.g.
+threonine) keeps two surviving diastereomers, so the same ``max_confs=12``
+does produce up to 24 there. A stereoisomer ETKDG cannot embed is now named in
+a logged warning instead of disappearing from the output with no trace.

--- a/docs/superpowers/plans/2026-07-31-phase2-stereochemistry-identity.md
+++ b/docs/superpowers/plans/2026-07-31-phase2-stereochemistry-identity.md
@@ -962,7 +962,7 @@ class TestEnumerationDisabled:
         """With enumeration off the user is told the output is a mixture."""
         import logging
 
-        with caplog.at_level(logging.WARNING, logger="auto3d"):
+        with caplog.at_level(logging.WARNING, logger="Auto3D.isomer_engine"):
             per_species = _run_engine(
                 job_dir, "CC(N)C(=O)O", "alanine_off", three_d=False,
                 enumerate_isomers=False,
@@ -973,9 +973,9 @@ class TestEnumerationDisabled:
         )
 ```
 
-Two things to check before running, and to report rather than paper over:
-1. `caplog` capture depends on the logger name `Auto3D.utils.logging_config.get_logger` produces. Read `logging_config.py` and use the real name. If Auto3D's logger sets `propagate = False`, `caplog` will see nothing — in that case attach `caplog.handler` to the module logger explicitly or assert on a different observable, and say so in the report.
-2. `_run_engine`'s `**kwargs` passes `enumerate_isomers` to `create_isomer_engine`. Confirm the wrapper accepts it as a keyword.
+Two facts already verified on this box — use them, do not re-derive:
+1. `get_logger(__name__)` returns `logging.getLogger(name)` with no `propagate = False` anywhere in `logging_config.py`, so `isomer_engine.py`'s logger is named `Auto3D.isomer_engine` and `caplog` reaches it. (`workflow_workers.py` uses a *different* logger named `auto3d`; do not use that name here.) If the capture still comes up empty, fall back to a bare `caplog.at_level(logging.WARNING)` before inventing anything else, and say so in the report.
+2. `create_isomer_engine` declares `enumerate_isomers: bool = True` and forwards it to `IsomerEngineFactory.create`, so `_run_engine`'s `**kwargs` reaches the factory. Only the `rdkit_sdf` branch inside `create` drops it — that is the line Step 5 fixes.
 
 - [ ] **Step 8: Run the new module**
 

--- a/docs/superpowers/plans/2026-07-31-phase2-stereochemistry-identity.md
+++ b/docs/superpowers/plans/2026-07-31-phase2-stereochemistry-identity.md
@@ -1,0 +1,1675 @@
+# Phase 2 — Stereochemistry Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** No Auto3D code path emits a molecule whose stereochemical configuration differs from the one the user submitted, and no path discards a legitimate stereoisomer.
+
+**Architecture:** Four independent defects on three different code paths. C1 lives in the enantiomer filter (`utils/stereochemistry.py`) that runs on every `.smi` input; C2 in the RDKit tautomer engine (`isomer_engine.py`); M19 in the SDF isomer engine and its adapter/factory plumbing; C9 in the post-optimization write path (`batch_opt/batchopt.py`) plus the three conformer filters that gate on `check_connectivity`. Each task touches one path and can be reviewed alone.
+
+**Tech Stack:** Python 3.11+, RDKit 2025.09.6, pytest. No neural network potential is loaded by anything in this phase — every new test is hermetic RDKit.
+
+**Source spec:** `docs/superpowers/specs/2026-07-30-audit-remediation-design.md` §5 (Phase 2).
+**Audit manifest:** `.claude/review-manifests/review-2026-07-30-package-audit.md` (C1, C2, C9, M19).
+
+---
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+**Authorship (from the repository owner's global rules — mechanically enforced):**
+- Commits are authored solely by Olexandr Isayev. No `Co-Authored-By`, no `Signed-off-by`, no generated-by footers.
+- No commit message, branch name, PR title, or PR body may mention AI assistance, Claude, Copilot, or any AI tool.
+- Never modify `user.name`, `user.email`, or `commit.gpgsign`.
+
+**Development box limits — these are hard:**
+- ~2 GB RAM and 8 CUDA devices that other work is actively using.
+- **Never run `pytest -m slow`.** Never load a real neural network potential. Never trigger a model download (`~/.cache/aimnet` is populated but must not be touched).
+- `torchani` is **not** installed; modules that `importorskip("torchani")` are invisible here.
+- The only test command any task may run: `pytest tests/ -q -rxX -m "not slow"` (or a narrower node ID with the same `-m "not slow"`).
+
+**Release vehicle:** 4.0.0. Breaking changes are approved and expected.
+
+**Tripwire discipline (the Phase 0 gate):**
+- Six `@pytest.mark.xfail(strict=True, ...)` markers are owned by Phase 2. Each one asserts the *correct* behavior that today's code violates.
+- When a task's fix lands, that task **deletes its markers in the same commit**. `strict=True` turns a passing xfail into a hard failure, so leaving one behind turns the suite red.
+- **Never** weaken a marker to `strict=False`, and never delete a marker's test body — only the decorator.
+- Owned markers (6 total; the repository-wide inventory must go 25 → 19):
+
+| Finding | Node ID | Task |
+|---|---|---|
+| C1 | `tests/test_stereo_identity.py::TestEnantiomerPredicate::test_two_achiral_molecules_are_not_enantiomers` | 1 |
+| C1 | `tests/test_stereo_identity.py::TestEZIsomersSurvive::test_but_2_ene_keeps_both_geometric_isomers` | 1 |
+| C1 | `tests/test_stereo_identity.py::TestEZIsomersSurvive::test_fumaric_and_maleic_acid_both_survive` | 1 |
+| C1 | `tests/test_utils_stereochemistry.py::TestEnantiomerHelper::test_enantiomer_helper_keeps_non_chiral` | 1 |
+| C2 | `tests/test_stereo_identity.py::TestTautomerStereoPreservation::test_specified_center_survives_tautomer_enumeration` | 2 |
+| M19 | `tests/test_stereo_identity.py::TestSdfInputStereo::test_unspecified_center_is_enumerated_or_refused` | 3 |
+
+**Style:**
+- American spelling in code, comments, docstrings, and user-visible strings.
+- `ruff check src/ tests/` must be clean before every commit.
+- Match the surrounding file's comment density and idiom. This codebase writes *why*-comments on non-obvious decisions; follow that.
+- Type hints on every new function. `from __future__ import annotations` is already at the top of every file touched here.
+
+**Verified environment facts** (measured on this box against RDKit 2025.09.6 — do not re-derive, and do not substitute a different mechanism without re-measuring):
+- `TautomerEnumerator.SetRemoveSp3Stereo(False)` preserves a specified sp3 center on tautomers that cannot reach it, and still drops it on tautomers where that carbon becomes sp2. It does **not** over-preserve.
+- `TautomerEnumerator.SetRemoveBondStereo(False)` preserves E/Z the user specified, and invents none: a keto input (`CCC(C)=O`) still yields its enol with no E/Z assigned.
+- `Chem.AssignStereochemistryFrom3D` sets `_CIPCode` only on genuine CIP stereocenters. Amine nitrogen inversion across 8 ETKDG conformers of `C[C@H](N)C(=O)O`, `CCN(C)C`, `C[N](CC)CCC` and `C1CN(C)CC1` produced **one** descriptor set each — sp3 nitrogen inversion is not a false positive for the C9 check.
+- Reflecting every coordinate through the origin flips a tetrahedral CIP code (`R`→`S`) and leaves double-bond stereo unchanged (`STEREOE` stays `STEREOE`) — the physics the C9 check depends on.
+- `EnumerateStereoisomers(onlyUnassigned=True)` on a mol parsed from a **flat 2D** SDF gives 2 isomers whose separate embeddings are each internally consistent (one all-`S`, one all-`R`); on a mol parsed from a **3D** SDF with a specified center it gives exactly 1.
+
+---
+
+## File Structure
+
+| File | Change | Task |
+|---|---|---|
+| `src/Auto3D/utils/stereochemistry.py` | Fix `enantiomer`; rewrite `enantiomer_helper` on a mirror-image comparison; add `_mirror_image`, `are_enantiomers` | 1 |
+| `tests/test_stereo_identity.py` | Remove 3 C1 markers | 1 |
+| `tests/test_utils_stereochemistry.py` | Remove 1 C1 marker; add diastereomer coverage | 1 |
+| `src/Auto3D/isomer_engine.py` | `TautomerEngine.rd_taut` preserves stereo | 2 |
+| `tests/test_stereo_identity.py` | Remove 1 C2 marker | 2 |
+| `tests/test_tautomer_stereo.py` | **Create** — C2 boundary coverage | 2 |
+| `src/Auto3D/isomer_engine.py` | `RDKitSdfIsomer` enumerates stereoisomers | 3 |
+| `src/Auto3D/isomers/rdkit_adapters.py` | `RDKitSdfIsomerAdapter` accepts `enumerate_isomers` | 3 |
+| `src/Auto3D/isomers/factory.py` | Pass `enumerate_isomers` to the `rdkit_sdf` branch | 3 |
+| `tests/test_stereo_identity.py` | Remove 1 M19 marker | 3 |
+| `tests/test_sdf_isomer_enumeration.py` | **Create** — M19 coverage | 3 |
+| `src/Auto3D/utils/stereo_check.py` | Replace the dead `stereo_changed` with the wired check | 4 |
+| `src/Auto3D/batch_opt/batchopt.py` | Route the coordinate write through the check | 4 |
+| `src/Auto3D/filtering.py` | Exclude stereo-changed records | 4 |
+| `src/Auto3D/utils/chemistry.py` | Exclude stereo-changed records in `filter_unique` | 4 |
+| `src/Auto3D/ranking.py` | Exclude stereo-changed records on the `k=1` fast path | 4 |
+| `tests/test_stereochemistry_validation.py` | Remove the test for the deleted `stereo_changed` | 4 |
+| `tests/test_stereo_postopt.py` | **Create** — C9 coverage | 4 |
+| `CHANGELOG.md` | B5, B6, and the Fixed entries | 5 |
+| `docs/source/migration-4.0.rst` | New sections for B5 and B6 | 5 |
+
+---
+
+## Deviation from the spec, and why
+
+The spec (§5.1) prescribes for C1: *"Replace the chiral-center comparison with a full stereo-descriptor comparison via `Chem.FindPotentialStereo`, including `Bond_Double`."*
+
+**This plan uses a mirror-image canonical-SMILES comparison instead.** The reason is not style — it is a second, latent defect the descriptor approach cannot fix:
+
+`enantiomer_helper` compares descriptor lists **by raw atom index** across molecules that were independently round-tripped through `Chem.MolToSmiles` / `Chem.MolFromSmiles`. Canonical atom ordering is not guaranteed to agree between two stereoisomers of the same skeleton, so index-keyed comparison can raise `ValueError` on a legitimate pair — which `remove_enantiomers` swallows, logging "Enantiomers not removed" and silently disabling the filter for that molecule. Swapping `FindMolChiralCenters` for `FindPotentialStereo` keeps that index dependence, since `StereoInfo.centeredOn` is also a raw index (and atom and bond indices collide numerically, so the key would need widening anyway).
+
+Constructing the mirror image of one molecule and comparing canonical SMILES is index-free, needs no atom mapping, and is exactly correct on E/Z by construction: reflection inverts tetrahedral centers and leaves double-bond geometry alone, so two molecules differing in E/Z can never compare equal. Measured against 9 cases (below) it is correct on all of them.
+
+The spec's fallback — *"require a non-empty center list before declaring an enantiomer pair"* — is **also** implemented, in `enantiomer` itself, because the Phase 0 tripwire calls that function directly.
+
+---
+
+### Task 1: C1 — the enantiomer filter discards geometric isomers
+
+`enantiomer(l1, l2)` returns `True` when both lists are empty (the `for` body never runs and `indicator` stays `True`), and `FindMolChiralCenters` never reports double-bond stereo — so both lists are always empty for an achiral molecule with a C=C. On the **default** `enumerate_isomer=True` path, one of every unspecified geometric isomer pair is discarded before embedding, chosen by SMILES sort order, with no warning. Fumaric and maleic acid differ by ~5 kcal/mol; one of them silently disappears.
+
+**Files:**
+- Modify: `src/Auto3D/utils/stereochemistry.py:24-104`
+- Modify: `tests/test_stereo_identity.py:32-36`, `:45-49`, `:58-62` (delete three decorators)
+- Modify: `tests/test_utils_stereochemistry.py:75-80` (delete one decorator), and append one new test
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces:
+  - `enantiomer(l1: list[tuple[int, str]], l2: list[tuple[int, str]]) -> bool` — signature unchanged; empty lists now return `False`.
+  - `are_enantiomers(smi1: str, smi2: str) -> bool` — new module-level function, added to `Auto3D.utils.stereochemistry`. **Not** added to `Auto3D.utils.__all__` (no other task needs it re-exported).
+  - `_mirror_image(mol: Chem.Mol) -> Chem.Mol` — module-private.
+  - `enantiomer_helper(smiles: list[str]) -> list[str]` — signature unchanged, behavior corrected.
+
+- [ ] **Step 1: Delete the four xfail decorators and watch the tests fail**
+
+In `tests/test_stereo_identity.py`, delete these three decorators (the decorator only — keep every test body and docstring exactly as written):
+
+```python
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C1: enantiomer([], []) returns True vacuously -- the loop body "
+        "never executes and `indicator` stays True",
+    )
+```
+
+```python
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C1: FindMolChiralCenters does not report double-bond stereo, so "
+        "both descriptor lists are empty and one geometric isomer is discarded",
+    )
+```
+
+```python
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C1: fumaric and maleic acid differ by ~5 kcal/mol and one is "
+        "discarded as an 'enantiomer' of the other",
+    )
+```
+
+In `tests/test_utils_stereochemistry.py`, delete this one:
+
+```python
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C1: enantiomer([], []) returns True vacuously, so two distinct "
+        "achiral molecules are wrongly treated as an enantiomeric pair and one "
+        "is dropped by enantiomer_helper.",
+    )
+```
+
+- [ ] **Step 2: Run the four tests and confirm they now fail for the right reason**
+
+```bash
+pytest tests/test_stereo_identity.py::TestEnantiomerPredicate \
+       tests/test_stereo_identity.py::TestEZIsomersSurvive \
+       "tests/test_utils_stereochemistry.py::TestEnantiomerHelper::test_enantiomer_helper_keeps_non_chiral" \
+       -q -rxX -m "not slow"
+```
+
+Expected: **4 failed**, with these assertion messages —
+- `assert True is False` (the `enantiomer([], [])` predicate),
+- `a geometric isomer was discarded: kept ['C/C=C/C']`,
+- `a geometric isomer was discarded: kept [...]` (one diacid),
+- `a distinct achiral molecule was dropped: ['CCO']`.
+
+If any test fails with an `ImportError`, `NameError`, or a message other than these, stop and report — the marker deletion touched more than the decorator.
+
+- [ ] **Step 3: Fix `enantiomer` — empty lists are not an enantiomeric pair**
+
+In `src/Auto3D/utils/stereochemistry.py`, replace the body of `enantiomer` from the `if len(l1) != len(l2):` guard through `return indicator` with:
+
+```python
+    if len(l1) != len(l2):
+        raise ValueError(
+            f"Stereo center lists must have same length: {len(l1)} vs {len(l2)}"
+        )
+    # Two molecules with no stereo centers at all are not an enantiomeric pair:
+    # they are either the same molecule or two unrelated achiral compounds. The
+    # loop below cannot express that, because an empty loop leaves `indicator`
+    # at its True initial value, so the caller must be told here.
+    if not l1:
+        return False
+    for i in range(len(l1)):
+        tp1 = l1[i]
+        tp2 = l2[i]
+        idx1, stereo1 = tp1
+        idx2, stereo2 = tp2
+        if idx1 != idx2:
+            raise ValueError(
+                f"Stereo center indices must match: {idx1} vs {idx2} at position {i}"
+            )
+        if stereo1 == stereo2:
+            return False
+    return True
+```
+
+Also update the docstring's `Returns:` block to read:
+
+```
+    Returns:
+        True if l1 and l2 represent enantiomers (both non-empty, same indices,
+        every configuration inverted), False otherwise. Two empty lists are
+        False: a molecule with no stereo centers is its own mirror image, so it
+        has no enantiomer to pair with.
+```
+
+- [ ] **Step 4: Add the mirror-image comparison and rewrite `enantiomer_helper`**
+
+Immediately after `enantiomer` in the same file, insert:
+
+```python
+def _mirror_image(mol: Chem.Mol) -> Chem.Mol:
+    """Return a copy of ``mol`` with every tetrahedral center inverted.
+
+    Reflection through a plane inverts tetrahedral configuration and leaves
+    double-bond (E/Z) geometry untouched, which is why this function only
+    swaps chiral tags: a cis alkene reflects to a cis alkene.
+    """
+    work = Chem.Mol(mol)
+    for atom in work.GetAtoms():
+        tag = atom.GetChiralTag()
+        if tag == Chem.ChiralType.CHI_TETRAHEDRAL_CW:
+            atom.SetChiralTag(Chem.ChiralType.CHI_TETRAHEDRAL_CCW)
+        elif tag == Chem.ChiralType.CHI_TETRAHEDRAL_CCW:
+            atom.SetChiralTag(Chem.ChiralType.CHI_TETRAHEDRAL_CW)
+    return work
+
+
+def are_enantiomers(smi1: str, smi2: str) -> bool:
+    """Check whether two SMILES are a pair of enantiomers.
+
+    Builds the mirror image of the first molecule and compares canonical
+    SMILES. This needs no atom mapping between the two inputs, which matters
+    because the two SMILES are independently canonicalized and their atom
+    orderings are not guaranteed to agree.
+
+    Being index-free also makes the test exact for double-bond stereo: a
+    reflection cannot change E/Z, so two molecules that differ in a C=C
+    configuration never compare equal, and geometric isomers -- which are
+    distinct compounds, not an enantiomeric pair -- are both retained.
+
+    Args:
+        smi1: First SMILES string.
+        smi2: Second SMILES string.
+
+    Returns:
+        True only if the two are distinct molecules related by reflection.
+        False for identical molecules, for unparseable input, and for any
+        molecule with no tetrahedral center (it is its own mirror image).
+
+    Example:
+        >>> are_enantiomers('C[C@H](O)F', 'C[C@@H](O)F')
+        True
+        >>> are_enantiomers('C/C=C/C', 'C/C=C\\\\C')
+        False
+    """
+    mol1 = Chem.MolFromSmiles(smi1)
+    mol2 = Chem.MolFromSmiles(smi2)
+    if mol1 is None or mol2 is None:
+        return False
+
+    canonical1 = Chem.MolToSmiles(mol1)
+    canonical2 = Chem.MolToSmiles(mol2)
+    if canonical1 == canonical2:
+        # The same molecule is not its own enantiomeric partner.
+        return False
+
+    tetrahedral = (
+        Chem.ChiralType.CHI_TETRAHEDRAL_CW,
+        Chem.ChiralType.CHI_TETRAHEDRAL_CCW,
+    )
+    if not any(atom.GetChiralTag() in tetrahedral for atom in mol1.GetAtoms()):
+        # No tetrahedral center to invert: the mirror image is the molecule
+        # itself, and it already compared unequal above.
+        return False
+
+    return Chem.MolToSmiles(_mirror_image(mol1)) == canonical2
+```
+
+Then replace `enantiomer_helper`'s body (everything after its docstring) with:
+
+```python
+    non_enantiomers: list[str] = []
+    for smi in smiles:
+        if any(are_enantiomers(kept, smi) for kept in non_enantiomers):
+            continue
+        non_enantiomers.append(smi)
+    return non_enantiomers
+```
+
+and replace its docstring's `Example:` block with:
+
+```
+    Example:
+        >>> smiles = ['C[C@H](O)F', 'C[C@@H](O)F']
+        >>> result = enantiomer_helper(smiles)
+        >>> len(result)  # Only one enantiomer kept
+        1
+        >>> enantiomer_helper(['C/C=C/C', 'C/C=C\\\\C'])  # E/Z are not enantiomers
+        ['C/C=C/C', 'C/C=C\\\\C']
+```
+
+`enantiomer_helper` no longer calls `Chem.FindMolChiralCenters`, `enantiomer`, or `Chem.MolFromSmiles` at the top. Delete the now-unused `mols` / `stereo_centers` / `non_centers` locals. Leave the `CalcNumAtomStereoCenters` import alone — `amend_configuration` still uses it. Leave `enantiomer` itself in place and exported: it is public API and directly tested.
+
+`remove_enantiomers` keeps its `except (ValueError, RuntimeError, AttributeError)` guard. `enantiomer_helper` no longer raises `ValueError` on its own, but the guard is defensive against RDKit internals and costs nothing.
+
+- [ ] **Step 5: Run the four tests and confirm they pass**
+
+```bash
+pytest tests/test_stereo_identity.py::TestEnantiomerPredicate \
+       tests/test_stereo_identity.py::TestEZIsomersSurvive \
+       "tests/test_utils_stereochemistry.py::TestEnantiomerHelper::test_enantiomer_helper_keeps_non_chiral" \
+       -q -rxX -m "not slow"
+```
+
+Expected: **4 passed**, 0 xpassed, 0 xfailed.
+
+- [ ] **Step 6: Add diastereomer coverage the tripwires do not have**
+
+Append to `tests/test_utils_stereochemistry.py`, at module level after the last class:
+
+```python
+class TestEnantiomerHelperDiastereomers:
+    """Reflection inverts tetrahedral centers and leaves E/Z alone."""
+
+    def test_enantiomer_pair_with_a_double_bond_is_still_filtered(self):
+        """Same E/Z, inverted center: a genuine enantiomeric pair."""
+        smiles = ["C/C=C/C[C@H](O)C", "C/C=C/C[C@@H](O)C"]
+        result = enantiomer_helper(smiles)
+        assert len(result) == 1, f"a genuine enantiomer pair survived: {result}"
+
+    def test_diastereomers_both_survive(self):
+        """Different E/Z and inverted center: diastereomers, not enantiomers."""
+        smiles = ["C/C=C/C[C@H](O)C", "C/C=C\\C[C@@H](O)C"]
+        result = enantiomer_helper(smiles)
+        assert len(result) == 2, f"a diastereomer was discarded: {result}"
+
+    def test_two_centers_partially_inverted_both_survive(self):
+        """Inverting only one of two centers gives a diastereomer."""
+        smiles = ["C[C@H](O)[C@H](F)Cl", "C[C@@H](O)[C@H](F)Cl"]
+        result = enantiomer_helper(smiles)
+        assert len(result) == 2, f"a diastereomer was discarded: {result}"
+
+    def test_two_centers_fully_inverted_is_filtered(self):
+        """Inverting both centers gives the enantiomer."""
+        smiles = ["C[C@H](O)[C@H](F)Cl", "C[C@@H](O)[C@@H](F)Cl"]
+        result = enantiomer_helper(smiles)
+        assert len(result) == 1, f"a genuine enantiomer pair survived: {result}"
+
+    def test_duplicate_smiles_collapse_to_one(self):
+        """The same molecule twice is a duplicate, not an enantiomeric pair."""
+        result = enantiomer_helper(["C[C@H](O)F", "C[C@H](O)F"])
+        assert len(result) == 1, result
+```
+
+Note on the last case: `are_enantiomers` returns `False` for identical molecules, so the *filter* does not remove the duplicate — but the duplicate is still collapsed, because the second string is byte-identical to the first and appears once in the output list. If a reviewer finds this test asserts a coincidence rather than the intended behavior, that is a real finding; the honest expectation is `len(result) == 2` unless the helper deduplicates. **Run it first and record which it actually is**, then keep the assertion that matches observed behavior with a docstring that says why. Do not adjust the implementation to force `1`.
+
+- [ ] **Step 7: Run the full fast suite**
+
+```bash
+pytest tests/ -q -rxX -m "not slow"
+```
+
+Expected: all pass, **0 xpassed**, and the xfailed count drops by exactly 4 from the pre-task baseline (record the baseline number before starting). Then:
+
+```bash
+ruff check src/ tests/
+```
+
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Auto3D/utils/stereochemistry.py tests/test_stereo_identity.py tests/test_utils_stereochemistry.py
+git commit -m "fix!: stop discarding geometric isomers as enantiomers
+
+enantiomer([], []) returned True because its loop body never executed, and
+FindMolChiralCenters never reports double-bond stereo, so every achiral
+molecule with an unspecified C=C had one geometric isomer dropped before
+embedding on the default enumerate_isomer=True path. Fumaric and maleic acid
+differ by ~5 kcal/mol; which one survived was decided by SMILES sort order,
+silently.
+
+enantiomer() now returns False for two empty descriptor lists. enantiomer_helper
+compares each candidate against the mirror image of every kept molecule and
+compares canonical SMILES, which needs no atom mapping between two
+independently canonicalized structures and is exact on E/Z: a reflection cannot
+change double-bond geometry, so geometric isomers never compare equal.
+
+Molecules with unspecified double-bond stereo now yield roughly twice the
+conformer groups."
+```
+
+---
+
+### Task 2: C2 — tautomer enumeration erases specified stereocenters
+
+`rd_taut` builds a bare `rdMolStandardize.TautomerEnumerator()`, which defaults to `SetRemoveSp3Stereo(True)`. Every output tautomer is written stereo-stripped, and `EnumerateStereoisomers(onlyUnassigned=True)` downstream then re-creates both epimers, of which `remove_enantiomers` keeps one arbitrarily. A submitted (S) molecule comes back as (R) half the time, at identical energy, undetectable from the output.
+
+**Files:**
+- Modify: `src/Auto3D/isomer_engine.py:69-89` (`TautomerEngine.rd_taut`)
+- Modify: `tests/test_stereo_identity.py:75-80` (delete one decorator)
+- Create: `tests/test_tautomer_stereo.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: no signature change. `TautomerEngine.rd_taut()` keeps returning `None` and writing to `self.output`.
+
+- [ ] **Step 1: Delete the C2 xfail decorator**
+
+In `tests/test_stereo_identity.py`, delete this decorator only (keep the test body and its long docstring verbatim — that docstring records the boundary the fix must not cross):
+
+```python
+    @pytest.mark.xfail(
+        strict=True,
+        reason="C2: RDKit TautomerEnumerator defaults to SetRemoveSp3Stereo(True), "
+        "so rd_taut writes stereo-stripped SMILES that are then re-enumerated "
+        "as unassigned -- a 50% chance of the wrong enantiomer",
+    )
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+```bash
+pytest "tests/test_stereo_identity.py::TestTautomerStereoPreservation::test_specified_center_survives_tautomer_enumeration" -q -rxX -m "not slow"
+```
+
+Expected: **1 failed**, message `every tautomer lost the specified stereocenter: [...]`.
+
+- [ ] **Step 3: Preserve stereo in the enumerator**
+
+In `src/Auto3D/isomer_engine.py`, replace the first line of `rd_taut`'s body:
+
+```python
+        enumerator = rdMolStandardize.TautomerEnumerator()
+```
+
+with:
+
+```python
+        enumerator = rdMolStandardize.TautomerEnumerator()
+        # RDKit defaults to stripping sp3 and double-bond stereo from EVERY
+        # output tautomer, including tautomers formed at a site that cannot
+        # reach the center -- enolizing a ketone's other alpha carbon, say.
+        # The stripped SMILES are then re-enumerated downstream by
+        # EnumerateStereoisomers(onlyUnassigned=True) and one epimer is kept
+        # arbitrarily, so a submitted (S) molecule comes back as (R) half the
+        # time at identical energy. Preserving here loses nothing and invents
+        # nothing: where the tautomerization genuinely destroys a center the
+        # atom is no longer sp3 and RDKit drops the tag anyway, and a keto
+        # input still yields its enol with no E/Z assigned.
+        enumerator.SetRemoveSp3Stereo(False)
+        enumerator.SetRemoveBondStereo(False)
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+```bash
+pytest "tests/test_stereo_identity.py::TestTautomerStereoPreservation::test_specified_center_survives_tautomer_enumeration" -q -rxX -m "not slow"
+```
+
+Expected: **1 passed**.
+
+- [ ] **Step 5: Write the boundary tests**
+
+The tripwire proves stereo *survives*. These prove the fix does not over-correct — the failure mode its docstring explicitly warns about. Create `tests/test_tautomer_stereo.py`:
+
+```python
+"""Tautomer enumeration preserves specified stereo without inventing any.
+
+The C2 fix disables RDKit's default stereo stripping. That is only correct if
+it preserves descriptors the user specified while still dropping descriptors
+the tautomerization genuinely destroys, and while assigning none that the
+input never had. These tests pin all three, driving Auto3D's real ``rdkit``
+tautomer engine through the production factory.
+"""
+from __future__ import annotations
+
+from Auto3D.isomers.factory import create_tautomer_engine
+
+
+def _run_rd_taut(job_dir, smiles: str) -> list[str]:
+    """Drive TautomerEngine.rd_taut() and return the output SMILES."""
+    in_smi = job_dir / "taut_in.smi"
+    in_smi.write_text(f"{smiles} probe\n")
+    out_smi = job_dir / "taut_out.smi"
+    create_tautomer_engine(
+        "rdkit", str(in_smi), str(out_smi), pka_norm=False
+    ).run()
+    return [line.split()[0] for line in out_smi.read_text().splitlines() if line.strip()]
+
+
+class TestSpecifiedStereoSurvives:
+    def test_center_remote_from_the_tautomeric_site_is_kept(self, job_dir):
+        """A center the tautomerization cannot reach keeps its configuration."""
+        outputs = _run_rd_taut(job_dir, "C/C=C/C[C@H](O)C")
+        assert outputs, "tautomer enumeration returned nothing"
+        assert all("@" in smi for smi in outputs), (
+            f"a remote stereocenter was stripped: {sorted(outputs)}"
+        )
+
+    def test_specified_double_bond_geometry_is_kept(self, job_dir):
+        """A specified C=C keeps its geometry through enumeration."""
+        outputs = _run_rd_taut(job_dir, "C/C=C(\\O)C")
+        assert outputs, "tautomer enumeration returned nothing"
+        assert any("/" in smi or "\\" in smi for smi in outputs), (
+            f"every tautomer lost the specified double-bond geometry: {sorted(outputs)}"
+        )
+
+
+class TestNoStereoIsInvented:
+    def test_a_center_destroyed_by_tautomerization_is_still_dropped(self, job_dir):
+        """Tautomers whose stereocenter carbon became sp2 carry no descriptor.
+
+        This is the over-correction guard: preserving stereo must not mean
+        asserting a configuration on an atom that no longer has one.
+        """
+        outputs = _run_rd_taut(job_dir, "C[C@H](C(=O)C)N")
+        assert outputs, "tautomer enumeration returned nothing"
+        # The enamine/imine tautomers flatten the stereocenter's own carbon.
+        flattened = [smi for smi in outputs if "C=C(N)" in smi or "C(=N)" in smi]
+        assert flattened, f"expected a tautomer that flattens the center: {sorted(outputs)}"
+        assert all("@" not in smi for smi in flattened), (
+            f"a destroyed stereocenter kept a descriptor: {sorted(flattened)}"
+        )
+
+    def test_an_achiral_input_gains_no_stereo(self, job_dir):
+        """A keto input must not acquire E/Z on the enol it tautomerizes to."""
+        outputs = _run_rd_taut(job_dir, "CCC(C)=O")
+        assert outputs, "tautomer enumeration returned nothing"
+        assert all("@" not in smi for smi in outputs), (
+            f"stereo was invented: {sorted(outputs)}"
+        )
+        assert all("/" not in smi and "\\" not in smi for smi in outputs), (
+            f"double-bond geometry was invented: {sorted(outputs)}"
+        )
+```
+
+`job_dir` is an existing fixture (`tests/test_stereo_identity.py` already uses it). Confirm it resolves — if `pytest --fixtures tests/test_tautomer_stereo.py | grep job_dir` finds nothing, report that rather than inventing a replacement.
+
+Check `create_tautomer_engine`'s real signature before writing the call — `tests/test_stereo_identity.py:107-109` uses `create_tautomer_engine("rdkit", str(in_smi), str(out_smi), pka_norm=False)`. Match whatever the source actually declares.
+
+- [ ] **Step 6: Run the new module**
+
+```bash
+pytest tests/test_tautomer_stereo.py -q -rxX -m "not slow"
+```
+
+Expected: **4 passed**. If `test_a_center_destroyed_by_tautomerization_is_still_dropped` fails on its substring probe, print `sorted(outputs)`, pick the substring that actually identifies the flattened tautomers from the real output, and fix the test — but do **not** delete the assertion that they carry no `@`. That assertion is the whole point of the test.
+
+- [ ] **Step 7: Full fast suite and lint**
+
+```bash
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+```
+
+Expected: all pass, 0 xpassed, xfailed count down by 1 more.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Auto3D/isomer_engine.py tests/test_stereo_identity.py tests/test_tautomer_stereo.py
+git commit -m "fix!: preserve specified stereochemistry through tautomer enumeration
+
+RDKit's TautomerEnumerator defaults to SetRemoveSp3Stereo(True), so rd_taut
+wrote stereo-stripped SMILES for every tautomer -- including ones formed at a
+site that cannot reach the center. EnumerateStereoisomers(onlyUnassigned=True)
+then re-created both epimers and remove_enantiomers kept one arbitrarily, so a
+submitted (S) molecule came back as (R) half the time, at identical energy and
+undetectable from the output.
+
+Disabling sp3 and bond stereo removal preserves what the user specified without
+inventing anything: where the tautomerization genuinely destroys a center the
+atom is no longer sp3 and RDKit drops the tag regardless, and an achiral input
+gains no descriptor."
+```
+
+---
+
+### Task 3: M19 — SDF input never enumerates stereochemistry
+
+`RDKitSdfIsomer.run()` calls only `AddHs` + `EmbedMultipleConfs`, and `RDKitSdfIsomerAdapter` does not accept `enumerate_isomers` at all — so the factory's parameter is silently dropped for SDF input. For a flat 2D SDF with an unspecified center, ETKDG returns a stereochemical **mixture**, written as numbered conformers of a single species. `k=1` can return a different diastereomer than the input implies; `k>1` returns a mixture labeled as conformers. The class docstring claims the opposite: "Preserves specified stereo centers and enumerates unspecified ones."
+
+**Files:**
+- Modify: `src/Auto3D/isomer_engine.py:320-379` (`RDKitSdfIsomer`)
+- Modify: `src/Auto3D/isomers/rdkit_adapters.py:89-136` (`RDKitSdfIsomerAdapter`)
+- Modify: `src/Auto3D/isomers/factory.py:141-148` (the `rdkit_sdf` branch of `IsomerEngineFactory.create`)
+- Modify: `tests/test_stereo_identity.py:121-128` (delete one decorator)
+- Create: `tests/test_sdf_isomer_enumeration.py`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1-2.
+- Produces:
+  - `RDKitSdfIsomer.__init__(self, sdf, enumerated_sdf, max_confs, threshold, np, flipper=True)` — new trailing parameter, named `flipper` to match `RDKitIsomer`.
+  - `RDKitSdfIsomerAdapter.__init__(self, input_path, output_path, max_confs=None, threshold=0.3, n_jobs=4, enumerate_isomers=True)` — new trailing parameter, named `enumerate_isomers` to match `RDKitIsomerAdapter`.
+  - Output conformer names change from `<name>_<conf>` to `<name>_<isomer>_<conf>`.
+
+**Naming, and why the third component matters.** `ConformerRanker.run` groups by `mol.GetProp('_Name').split("_")[0]`, so a two-component name puts every ETKDG-randomized configuration in one group. The SMILES path already produces three components (`<encoded>_<isomer>_<conf>`, from `remove_enantiomers` + `RDKitIsomer._run_serial_embedding`). Matching it gives the SDF path identical downstream behavior: stereoisomers of one input compete on energy within one group, but each conformer is internally consistent and traceable to a definite configuration. Emit three components **uniformly**, including when there is only one isomer — a name whose shape depends on the molecule would make grouping inconsistent.
+
+**Consequence to record in Task 5:** `max_confs` becomes a per-isomer budget on the SDF path, as it already is on the SMILES path. A flat SDF with one unspecified center and `max_confs=12` now produces up to 24 conformers, not 12.
+
+- [ ] **Step 1: Delete the M19 xfail decorator**
+
+In `tests/test_stereo_identity.py`, delete this decorator only:
+
+```python
+    @pytest.mark.xfail(
+        strict=True,
+        reason="M19: RDKitSdfIsomer.run() (driven here through the real "
+        "create_isomer_engine('rdkit_sdf', ...) / RDKitSdfIsomerAdapter factory "
+        "path) calls only AddHs + EmbedMultipleConfs on the SDF-parsed mol, so "
+        "ETKDG returns a stereochemical mixture that is written to the output "
+        "SDF as numbered conformers under a single species name",
+    )
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+```bash
+pytest "tests/test_stereo_identity.py::TestSdfInputStereo::test_unspecified_center_is_enumerated_or_refused" -q -rxX -m "not slow"
+```
+
+Expected: **1 failed**, message `RDKitSdfIsomer wrote a stereochemical mixture under a single species name: {'alanine_flat': ['R', 'S']}`.
+
+- [ ] **Step 3: Teach `RDKitSdfIsomer` to enumerate**
+
+In `src/Auto3D/isomer_engine.py`, first extend the imports at the top of the module — `StereoEnumerationOptions`, `EnumerateStereoisomers` and `MAX_STEREOISOMERS` are already imported for `RDKitIsomer`, so no new import is needed. Confirm that before proceeding.
+
+Replace the whole `RDKitSdfIsomer` class docstring, `__init__` and `run` with:
+
+```python
+class RDKitSdfIsomer:
+    """Enumerate stereoisomers and conformers from an SDF file.
+
+    Preserves specified stereo centers and enumerates unspecified ones, so each
+    output species has one definite configuration. Conformers are named
+    ``<name>_<isomer>_<conformer>``, matching the SMILES path, which is what
+    lets :class:`~Auto3D.ranking.ConformerRanker` group them correctly.
+
+    Args:
+        sdf: Path to input SDF file.
+        enumerated_sdf: Path for output SDF file.
+        max_confs: Maximum conformers per stereoisomer. None for dynamic.
+        threshold: RMSD threshold for duplicate removal (Å).
+        np: Number of CPU threads for parallelization.
+        flipper: Whether to enumerate unspecified stereocenters. When False,
+            a molecule with unspecified stereo is embedded as-is and its
+            conformers are a mixture of configurations; a warning says so.
+    """
+
+    def __init__(
+        self,
+        sdf: str,
+        enumerated_sdf: str,
+        max_confs: int | None,
+        threshold: float,
+        np: int,
+        flipper: bool = True,
+    ) -> None:
+        self.sdf = sdf
+        self.enumerated_sdf = enumerated_sdf
+        self.n_conformers = max_confs
+        self.threshold = threshold
+        self.np = np
+        self.flipper = flipper
+
+    @staticmethod
+    def count_unspecified_stereo(mol: Chem.Mol) -> int:
+        """Count stereo elements the input leaves unspecified."""
+        return sum(
+            1
+            for element in Chem.FindPotentialStereo(mol)
+            if element.specified == Chem.StereoSpecified.Unspecified
+        )
+
+    def stereoisomers(self, mol: Chem.Mol, name: str) -> list[Chem.Mol]:
+        """Return the distinct configurations to embed for one input record.
+
+        A 3D SDF whose centers are all specified yields exactly one entry, so
+        this is a no-op for that input; only unspecified centers enumerate.
+        """
+        if not self.flipper:
+            unspecified = self.count_unspecified_stereo(mol)
+            if unspecified:
+                logger.warning(
+                    f"{name!r} has {unspecified} unspecified stereo element(s) "
+                    "and stereoisomer enumeration is disabled, so its conformers "
+                    "will be a mixture of configurations. Enable isomer "
+                    "enumeration to get one consistent species per configuration."
+                )
+            return [mol]
+
+        opts = StereoEnumerationOptions(
+            unique=True, maxIsomers=MAX_STEREOISOMERS, onlyUnassigned=True
+        )
+        isomers = list(EnumerateStereoisomers(mol, options=opts))
+        if len(isomers) >= MAX_STEREOISOMERS:
+            logger.warning(
+                f"Stereoisomer enumeration hit the cap of {MAX_STEREOISOMERS} "
+                f"for {name!r}; results may be truncated."
+            )
+        # EnumerateStereoisomers returns an empty sequence for a molecule it
+        # cannot enumerate; embedding the input unchanged beats dropping it.
+        return isomers or [mol]
+
+    def run(self) -> str:
+        """Enumerate stereoisomers and conformers into the output SDF file.
+
+        Returns:
+            Path to the enumerated SDF file.
+        """
+        supp = Chem.SDMolSupplier(self.sdf, removeHs=False)
+        with Chem.SDWriter(self.enumerated_sdf) as writer:
+            for mol in tqdm(supp):
+                if mol is None:
+                    logger.warning(
+                        "Skipping molecule: failed to parse (SDMolSupplier yielded None)."
+                    )
+                    continue
+                name = mol.GetProp('_Name')
+                for isomer_idx, isomer in enumerate(self.stereoisomers(mol, name)):
+                    mol2 = Chem.AddHs(isomer)
+                    if self.n_conformers is None:
+                        # Compute the conformer budget on the H-complete (AddHs)
+                        # mol so the SDF path agrees with the SMILES path on the
+                        # RICHER with-H count. AddHs is idempotent for a mol that
+                        # already carries explicit Hs (3D SDFs read with
+                        # removeHs=False), so this yields the same count
+                        # regardless of input format.
+                        n_conformers = calculate_conformer_count(mol2)
+                    else:
+                        n_conformers = self.n_conformers
+                    AllChem.EmbedMultipleConfs(
+                        mol2,
+                        numConfs=n_conformers,
+                        randomSeed=CONFORMER_RANDOM_SEED,
+                        numThreads=self.np,
+                        pruneRmsThresh=self.threshold,
+                    )
+                    # Three name components (species _ isomer _ conformer) match
+                    # the SMILES path, whose consumers group on the first one.
+                    for conf_idx, conf in enumerate(mol2.GetConformers()):
+                        conf_name = f'{name}_{isomer_idx}_{conf_idx}'
+                        mol2.SetProp('_Name', conf_name)
+                        mol2.SetProp('ID', conf_name)
+                        writer.write(mol2, confId=conf.GetId())
+        return self.enumerated_sdf
+```
+
+Note the `confId=conf.GetId()` in the write: the old code wrote `confId=i` using the positional index. `EmbedMultipleConfs` currently returns sequential IDs so the two agree today, but the positional form is only accidentally correct. Use the real ID.
+
+- [ ] **Step 4: Plumb `enumerate_isomers` through the adapter**
+
+In `src/Auto3D/isomers/rdkit_adapters.py`, change `RDKitSdfIsomerAdapter.__init__` to accept and store the flag, and pass it through in `run`:
+
+```python
+    def __init__(
+        self,
+        input_path: str,
+        output_path: str,
+        max_confs: int | None = None,
+        threshold: float = 0.3,
+        n_jobs: int = 4,
+        enumerate_isomers: bool = True,
+    ) -> None:
+        """Initialize the RDKit SDF isomer adapter.
+
+        Args:
+            input_path: Path to input SDF file.
+            output_path: Path for output SDF file.
+            max_confs: Maximum conformers per stereoisomer.
+            threshold: RMSD threshold for duplicate removal.
+            n_jobs: Number of CPU threads for conformer generation.
+            enumerate_isomers: Whether to enumerate unspecified stereocenters.
+        """
+        super().__init__(
+            input_path=input_path,
+            output_path=output_path,
+            max_confs=max_confs,
+            threshold=threshold,
+            n_jobs=n_jobs,
+        )
+        self.enumerate_isomers = enumerate_isomers
+```
+
+and in its `run`:
+
+```python
+        engine = RDKitSdfIsomer(
+            sdf=self.input_path,
+            enumerated_sdf=self.output_path,
+            max_confs=self.max_confs,
+            threshold=self.threshold,
+            np=self.n_jobs,
+            flipper=self.enumerate_isomers,
+        )
+        return engine.run()
+```
+
+`BaseIsomerEngine.__init__` does not take `enumerate_isomers`, so store it after the `super().__init__` call — this is the same shape `RDKitIsomerAdapter` already uses. Verify that by reading `RDKitIsomerAdapter.__init__` before writing this, and match it.
+
+- [ ] **Step 5: Pass the flag from the factory**
+
+In `src/Auto3D/isomers/factory.py`, the `rdkit_sdf` branch of `IsomerEngineFactory.create` currently reads:
+
+```python
+        elif engine_type == "rdkit_sdf":
+            return adapter_class(
+                input_path=input_path,
+                output_path=output_path,
+                max_confs=max_confs,
+                threshold=threshold,
+                n_jobs=n_jobs,
+            )
+```
+
+Add the argument:
+
+```python
+        elif engine_type == "rdkit_sdf":
+            return adapter_class(
+                input_path=input_path,
+                output_path=output_path,
+                max_confs=max_confs,
+                threshold=threshold,
+                n_jobs=n_jobs,
+                enumerate_isomers=enumerate_isomers,
+            )
+```
+
+`create_isomer_engine` already declares `enumerate_isomers: bool = True` and forwards to `IsomerEngineFactory.create`; confirm it does before assuming it, and if the wrapper drops the argument for this engine type, fix the wrapper too.
+
+- [ ] **Step 6: Run the tripwire and confirm it passes**
+
+```bash
+pytest "tests/test_stereo_identity.py::TestSdfInputStereo::test_unspecified_center_is_enumerated_or_refused" -q -rxX -m "not slow"
+```
+
+Expected: **1 passed**.
+
+- [ ] **Step 7: Write the SDF enumeration tests**
+
+Create `tests/test_sdf_isomer_enumeration.py`:
+
+```python
+"""The SDF input path enumerates stereoisomers like the SMILES path.
+
+Every test drives the production ``rdkit_sdf`` engine through
+``create_isomer_engine``, not RDKit in isolation, and inspects the SDF file
+Auto3D actually writes.
+"""
+from __future__ import annotations
+
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from Auto3D.isomers.factory import create_isomer_engine
+
+
+def _write_sdf(path, smiles: str, name: str, three_d: bool) -> None:
+    mol = Chem.MolFromSmiles(smiles)
+    mol.SetProp("_Name", name)
+    if three_d:
+        mol = Chem.AddHs(mol)
+        AllChem.EmbedMolecule(mol, randomSeed=3)
+    else:
+        AllChem.Compute2DCoords(mol)
+    with Chem.SDWriter(str(path)) as writer:
+        writer.write(mol)
+
+
+def _run_engine(job_dir, smiles, name, three_d, **kwargs):
+    """Run the engine and return {species_name: {cip codes seen}}."""
+    input_sdf = job_dir / f"{name}_in.sdf"
+    output_sdf = job_dir / f"{name}_out.sdf"
+    _write_sdf(input_sdf, smiles, name, three_d)
+
+    engine = create_isomer_engine(
+        "rdkit_sdf",
+        input_path=str(input_sdf),
+        output_path=str(output_sdf),
+        max_confs=6,
+        threshold=0.3,
+        n_jobs=1,
+        **kwargs,
+    )
+    engine.run()
+
+    per_species: dict[str, set[str]] = {}
+    for mol in Chem.SDMolSupplier(str(output_sdf), removeHs=False):
+        if mol is None:
+            continue
+        species = mol.GetProp("_Name").rsplit("_", 1)[0]
+        Chem.AssignStereochemistryFrom3D(mol)
+        codes = {code for _, code in
+                 Chem.FindMolChiralCenters(mol, useLegacyImplementation=False)}
+        per_species.setdefault(species, set()).update(codes)
+    return per_species
+
+
+class TestUnspecifiedCentersEnumerate:
+    def test_flat_sdf_yields_two_consistent_species(self, job_dir):
+        """A flat alanine gives two species, each with one configuration."""
+        per_species = _run_engine(job_dir, "CC(N)C(=O)O", "alanine", three_d=False)
+        assert len(per_species) == 2, f"expected two species, got {per_species}"
+        for name, codes in per_species.items():
+            assert len(codes) == 1, f"{name} is a stereochemical mixture: {codes}"
+        assert {next(iter(c)) for c in per_species.values()} == {"R", "S"}, per_species
+
+    def test_species_names_have_three_components(self, job_dir):
+        """Names are <species>_<isomer>_<conformer>, as the SMILES path emits.
+
+        ConformerRanker groups on the first underscore-delimited component, so
+        a two-component name would put both configurations back in one group.
+        """
+        input_sdf = job_dir / "alanine3_in.sdf"
+        output_sdf = job_dir / "alanine3_out.sdf"
+        _write_sdf(input_sdf, "CC(N)C(=O)O", "alanine", three_d=False)
+        create_isomer_engine(
+            "rdkit_sdf",
+            input_path=str(input_sdf),
+            output_path=str(output_sdf),
+            max_confs=4,
+            threshold=0.3,
+            n_jobs=1,
+        ).run()
+
+        names = [m.GetProp("_Name")
+                 for m in Chem.SDMolSupplier(str(output_sdf), removeHs=False)
+                 if m is not None]
+        assert names, "the engine wrote nothing"
+        for name in names:
+            assert name.count("_") == 2, f"unexpected name shape: {name}"
+            assert name.split("_")[0] == "alanine", name
+        assert {name.split("_")[1] for name in names} == {"0", "1"}, names
+
+
+class TestSpecifiedStereoIsNotDisturbed:
+    def test_3d_sdf_with_a_specified_center_stays_one_species(self, job_dir):
+        """3D SDF input was already safe and must remain a single species."""
+        per_species = _run_engine(
+            job_dir, "C[C@H](N)C(=O)O", "lalanine", three_d=True
+        )
+        assert len(per_species) == 1, f"a specified center was enumerated: {per_species}"
+        codes = next(iter(per_species.values()))
+        assert codes == {"S"}, f"the specified configuration changed: {codes}"
+
+
+class TestEnumerationDisabled:
+    def test_disabled_enumeration_warns_about_the_mixture(self, job_dir, caplog):
+        """With enumeration off the user is told the output is a mixture."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="auto3d"):
+            per_species = _run_engine(
+                job_dir, "CC(N)C(=O)O", "alanine_off", three_d=False,
+                enumerate_isomers=False,
+            )
+        assert len(per_species) == 1, f"enumeration ran while disabled: {per_species}"
+        assert any("unspecified stereo" in record.message for record in caplog.records), (
+            f"no warning about the mixture: {[r.message for r in caplog.records]}"
+        )
+```
+
+Two things to check before running, and to report rather than paper over:
+1. `caplog` capture depends on the logger name `Auto3D.utils.logging_config.get_logger` produces. Read `logging_config.py` and use the real name. If Auto3D's logger sets `propagate = False`, `caplog` will see nothing — in that case attach `caplog.handler` to the module logger explicitly or assert on a different observable, and say so in the report.
+2. `_run_engine`'s `**kwargs` passes `enumerate_isomers` to `create_isomer_engine`. Confirm the wrapper accepts it as a keyword.
+
+- [ ] **Step 8: Run the new module**
+
+```bash
+pytest tests/test_sdf_isomer_enumeration.py -q -rxX -m "not slow"
+```
+
+Expected: **4 passed**.
+
+- [ ] **Step 9: Run the existing SDF-path tests**
+
+The naming change is the highest-regression-risk edit in this phase. Run everything that touches the SDF isomer path before the full suite:
+
+```bash
+pytest tests/test_isomer_engine.py tests/ -q -rxX -m "not slow" -k "sdf or isomer or rank or filter"
+```
+
+Then the full fast suite:
+
+```bash
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+```
+
+Expected: all pass, 0 xpassed. **If a test asserts a two-component conformer name, that test encodes the old behavior — update it to the three-component shape and say so in the report.** Do not revert the naming to make it pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Auto3D/isomer_engine.py src/Auto3D/isomers/rdkit_adapters.py src/Auto3D/isomers/factory.py tests/test_stereo_identity.py tests/test_sdf_isomer_enumeration.py
+git commit -m "fix!: enumerate stereoisomers for SDF input
+
+RDKitSdfIsomer called only AddHs + EmbedMultipleConfs, and RDKitSdfIsomerAdapter
+did not accept enumerate_isomers at all, so the factory silently dropped it for
+SDF input. A flat 2D SDF with an unspecified center got an ETKDG-randomized
+mixture of configurations written as numbered conformers of one species: k=1
+could return a different diastereomer than the input implied, and k>1 returned
+a mixture labeled as conformers. The class docstring claimed the opposite.
+
+The engine now enumerates unspecified centers and embeds each configuration
+separately, naming conformers <species>_<isomer>_<conformer> to match the
+SMILES path -- ConformerRanker groups on the first component, so the third one
+is what keeps configurations from collapsing back together. A 3D SDF whose
+centers are all specified yields exactly one isomer, unchanged.
+
+max_confs is now a per-stereoisomer budget on this path, as it already was on
+the SMILES path."
+```
+
+---
+
+### Task 4: C9 — no post-optimization stereochemistry validation
+
+`utils/stereo_check.stereo_changed` has no caller in `src/`. Its own docstring lists limitations that "must be addressed before wiring into the pipeline" — the blocking one being that it compares by raw atom index against a separately parsed reference SMILES. The only post-optimization structural check is `check_connectivity`, which compares interatomic distances against UFF radii and is explicitly stereo-blind. An optimization that inverts a stereocenter or rotates through a double bond produces a molecule of different identity than its title, reported as a converged conformer.
+
+**The atom-mapping limitation disappears if the comparison never crosses molecules.** `batchopt.run()` holds each molecule with its pre-optimization coordinates and overwrites them in place with the optimized ones. Reading descriptors immediately before and immediately after that write compares one molecule object against itself: atom and bond indices match by construction, and no reference SMILES is needed. This is the spec's stated fallback ("compare CIP codes assigned from 3D coordinates ... needs no atom mapping"), reached without the mapping work.
+
+**Files:**
+- Modify: `src/Auto3D/utils/stereo_check.py` (whole file)
+- Modify: `src/Auto3D/batch_opt/batchopt.py:326-347`
+- Modify: `src/Auto3D/filtering.py:49`
+- Modify: `src/Auto3D/utils/chemistry.py` (in `filter_unique`, the `has_valid_bonds` block near `:465-470`)
+- Modify: `src/Auto3D/ranking.py:99`
+- Modify: `tests/test_stereochemistry_validation.py:59-70` (delete `test_detect_stereo_change`)
+- Create: `tests/test_stereo_postopt.py`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1-3.
+- Produces:
+  - `STEREO_CHANGED_PROP: str = "Stereo_changed"` in `Auto3D.utils.stereo_check`.
+  - `stereo_descriptors_from_3d(mol: Chem.Mol, conf_id: int = -1) -> tuple[tuple[tuple[int, str], ...], tuple[tuple[int, str], ...]]`
+  - `apply_optimized_coords(mol: Chem.Mol, coords) -> bool`
+  - `stereo_preserved(mol: Chem.Mol) -> bool`
+  - `stereo_changed(mol, reference_smiles)` is **deleted** (B-series break; record in Task 5).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_stereo_postopt.py`. Every test is hermetic — no model, no CUDA, no file over a few KB.
+
+```python
+"""Post-optimization stereochemistry validation (C9).
+
+An optimization that inverts a stereocenter or rotates through a double bond
+produces a molecule of different chemical identity than its title. check_connectivity
+compares interatomic distances against UFF radii and is stereo-blind, so nothing
+caught it. These tests pin the detector and the three filters that act on it.
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from Auto3D.filtering import filter_unique_optimized
+from Auto3D.ranking import ConformerRanker
+from Auto3D.utils.chemistry import filter_unique
+from Auto3D.utils.stereo_check import (
+    STEREO_CHANGED_PROP,
+    apply_optimized_coords,
+    stereo_descriptors_from_3d,
+    stereo_preserved,
+)
+
+
+def _embedded(smiles: str = "C/C=C/C[C@H](O)Cl") -> Chem.Mol:
+    """A molecule carrying both a tetrahedral center and a defined C=C."""
+    mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    assert AllChem.EmbedMolecule(mol, randomSeed=7) == 0
+    return mol
+
+
+def _reflected_coords(mol: Chem.Mol) -> list[list[float]]:
+    """Coordinates reflected through the origin -- the mirror image."""
+    conf = mol.GetConformer()
+    return [
+        [-conf.GetAtomPosition(i).x, -conf.GetAtomPosition(i).y, -conf.GetAtomPosition(i).z]
+        for i in range(mol.GetNumAtoms())
+    ]
+
+
+def _nudged_coords(mol: Chem.Mol) -> list[list[float]]:
+    """Coordinates displaced far too little to change any configuration."""
+    conf = mol.GetConformer()
+    return [
+        [conf.GetAtomPosition(i).x + 0.01, conf.GetAtomPosition(i).y,
+         conf.GetAtomPosition(i).z]
+        for i in range(mol.GetNumAtoms())
+    ]
+
+
+class TestDescriptorReading:
+    def test_reflection_inverts_the_center_and_spares_the_double_bond(self):
+        """Reflection flips tetrahedral configuration; E/Z is reflection-invariant."""
+        mol = _embedded()
+        atoms_before, bonds_before = stereo_descriptors_from_3d(mol)
+        assert atoms_before, "no tetrahedral descriptor was read"
+        assert bonds_before, "no double-bond descriptor was read"
+
+        conf = mol.GetConformer()
+        for i, position in enumerate(_reflected_coords(mol)):
+            conf.SetAtomPosition(i, position)
+        atoms_after, bonds_after = stereo_descriptors_from_3d(mol)
+
+        assert atoms_after != atoms_before, "reflection did not invert the center"
+        assert bonds_after == bonds_before, "reflection changed double-bond stereo"
+
+    def test_descriptors_are_stable_under_a_small_displacement(self):
+        """A geometry that barely moves reads identically."""
+        mol = _embedded()
+        before = stereo_descriptors_from_3d(mol)
+        conf = mol.GetConformer()
+        for i, position in enumerate(_nudged_coords(mol)):
+            conf.SetAtomPosition(i, position)
+        assert stereo_descriptors_from_3d(mol) == before
+
+
+class TestApplyOptimizedCoords:
+    def test_inversion_is_detected_and_marked(self):
+        mol = _embedded()
+        assert apply_optimized_coords(mol, _reflected_coords(mol)) is False
+        assert mol.GetProp(STEREO_CHANGED_PROP) == "True"
+        assert stereo_preserved(mol) is False
+
+    def test_a_preserved_geometry_is_marked_preserved(self):
+        mol = _embedded()
+        assert apply_optimized_coords(mol, _nudged_coords(mol)) is True
+        assert mol.GetProp(STEREO_CHANGED_PROP) == "False"
+        assert stereo_preserved(mol) is True
+
+    def test_the_coordinates_are_actually_written(self):
+        """The function must still do the job it replaced, not only flag."""
+        mol = _embedded()
+        target = [[float(i), 0.0, 0.0] for i in range(mol.GetNumAtoms())]
+        apply_optimized_coords(mol, target)
+        conf = mol.GetConformer()
+        for i in range(mol.GetNumAtoms()):
+            assert conf.GetAtomPosition(i).x == pytest.approx(float(i))
+
+    def test_a_molecule_without_stereo_is_never_flagged(self):
+        """An achiral molecule cannot change configuration."""
+        mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        assert AllChem.EmbedMolecule(mol, randomSeed=7) == 0
+        assert apply_optimized_coords(mol, _reflected_coords(mol)) is True
+        assert mol.GetProp(STEREO_CHANGED_PROP) == "False"
+
+
+class TestStereoPreservedPredicate:
+    def test_absent_property_reads_as_preserved(self):
+        """Molecules from paths that never run the check are not dropped."""
+        assert stereo_preserved(_embedded()) is True
+
+    def test_the_marker_is_read_case_insensitively(self):
+        mol = _embedded()
+        mol.SetProp(STEREO_CHANGED_PROP, "true")
+        assert stereo_preserved(mol) is False
+
+
+def _optimized(energy: float, changed: bool | None) -> Chem.Mol:
+    """A converged, connectivity-valid mol, optionally marked stereo-changed."""
+    mol = _embedded()
+    mol.SetProp("Converged", "True")
+    mol.SetProp("E_tot", str(energy))
+    if changed is not None:
+        mol.SetProp(STEREO_CHANGED_PROP, str(changed))
+    return mol
+
+
+class TestFiltersExcludeStereoChangedRecords:
+    def test_filter_unique_optimized_drops_the_changed_record(self):
+        kept = _optimized(-1.0, changed=False)
+        dropped = _optimized(-2.0, changed=True)
+        result = filter_unique_optimized([dropped, kept], rmsd_threshold=0.3)
+        assert len(result) == 1, f"expected only the preserved record: {len(result)}"
+        assert result[0].GetProp("E_tot") == "-1.0"
+
+    def test_filter_unique_drops_the_changed_record(self):
+        kept = _optimized(-1.0, changed=False)
+        dropped = _optimized(-2.0, changed=True)
+        result = filter_unique([dropped, kept], crit=0.3)
+        assert len(result) == 1, f"expected only the preserved record: {len(result)}"
+        assert result[0].GetProp("E_tot") == "-1.0"
+
+    def test_top_k_one_skips_the_changed_lowest_energy_record(self):
+        """k=1 takes a fast path that bypasses the RMSD filters entirely."""
+        dropped = _optimized(-2.0, changed=True)
+        kept = _optimized(-1.0, changed=False)
+        for mol, name in ((dropped, "probe_0_0"), (kept, "probe_0_1")):
+            mol.SetProp("_Name", name)
+        group = pd.DataFrame({
+            "names": ["probe", "probe"],
+            "energies": [-2.0, -1.0],
+            "mols": [dropped, kept],
+        })
+        ranker = ConformerRanker(
+            input_path="unused.sdf", out_path="unused_out.sdf", threshold=0.3, k=1
+        )
+        result = ranker.top_k(group, k=1)
+        assert len(result) == 1
+        assert result[0].GetProp("E_tot") == "-1.0", (
+            "top_k returned the stereo-changed lowest-energy conformer"
+        )
+
+    def test_unmarked_records_still_survive_every_filter(self):
+        """No regression for molecules that never went through the check."""
+        mols = [_optimized(-1.0, changed=None), _optimized(-2.0, changed=None)]
+        assert len(filter_unique_optimized(mols, rmsd_threshold=0.3)) >= 1
+        assert len(filter_unique(mols, crit=0.3)) >= 1
+```
+
+`test_filter_unique_optimized_drops_the_changed_record` and its `filter_unique` twin rely on the two records being distinguishable — they share a geometry, so the RMSD filter would collapse them to one anyway. That is why each asserts on `E_tot` rather than only on the count: if the exclusion is not wired, the surviving record is the **lower-energy, stereo-changed** one (both filters sort by energy first), so the assertion fails. Verify that claim by running the tests before implementing.
+
+- [ ] **Step 2: Run them and confirm they fail**
+
+```bash
+pytest tests/test_stereo_postopt.py -q -rxX -m "not slow"
+```
+
+Expected: collection fails with `ImportError: cannot import name 'STEREO_CHANGED_PROP'`. That is the correct first failure. Once Step 3 lands, re-run and expect the *filter* tests to be the ones still failing.
+
+- [ ] **Step 3: Rewrite `utils/stereo_check.py`**
+
+Replace the entire file with:
+
+```python
+"""Post-optimization stereochemistry validation.
+
+Geometry optimization can invert a stereocenter or rotate through a double
+bond, producing a molecule of different chemical identity than the one its
+title names. ``check_connectivity`` compares interatomic distances against UFF
+radii and is stereo-blind, so nothing else catches it.
+
+The comparison here never crosses molecules: descriptors are read from one
+molecule object immediately before and immediately after its coordinates are
+overwritten, so atom and bond indices match by construction and no atom
+mapping or reference SMILES is required.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from rdkit import Chem
+
+#: SD property recording whether optimization changed a molecule's configuration.
+STEREO_CHANGED_PROP = "Stereo_changed"
+
+#: Sorted tetrahedral CIP codes by atom index, then double-bond stereo by bond index.
+StereoDescriptors = tuple[tuple[tuple[int, str], ...], tuple[tuple[int, str], ...]]
+
+
+def stereo_descriptors_from_3d(
+    mol: Chem.Mol, conf_id: int = -1
+) -> StereoDescriptors:
+    """Perceive ``mol``'s stereochemistry from its 3D coordinates.
+
+    Args:
+        mol: Molecule with at least one conformer. Not modified.
+        conf_id: Conformer to read. -1 (default) uses the molecule's default.
+
+    Returns:
+        A pair of sorted tuples: tetrahedral CIP codes keyed by atom index, and
+        double-bond stereo labels keyed by bond index. Sorting makes two
+        readings of the same molecule comparable with ``==``.
+
+    Note:
+        Indices are only meaningful within one molecule object. Compare two
+        readings taken from the same ``mol``; never compare readings from two
+        separately parsed molecules, whose atom orderings need not agree.
+    """
+    work = Chem.Mol(mol)
+    Chem.AssignStereochemistryFrom3D(work, confId=conf_id)
+    atoms = tuple(sorted(
+        (atom.GetIdx(), atom.GetProp("_CIPCode"))
+        for atom in work.GetAtoms()
+        if atom.HasProp("_CIPCode")
+    ))
+    bonds = tuple(sorted(
+        (bond.GetIdx(), str(bond.GetStereo()))
+        for bond in work.GetBonds()
+        if bond.GetStereo() != Chem.BondStereo.STEREONONE
+    ))
+    return atoms, bonds
+
+
+def apply_optimized_coords(
+    mol: Chem.Mol, coords: Sequence[Sequence[float]]
+) -> bool:
+    """Write optimized coordinates into ``mol`` and record any stereo change.
+
+    Reads the molecule's configuration from its current (pre-optimization)
+    coordinates, overwrites the conformer with ``coords``, reads it again, and
+    stores the comparison on the ``Stereo_changed`` property so the conformer
+    filters can act on it after an SDF round trip.
+
+    Args:
+        mol: Molecule holding the pre-optimization conformer. Modified in place.
+        coords: One (x, y, z) position per atom, in atom order.
+
+    Returns:
+        True if the configuration is unchanged, False if it changed.
+    """
+    before = stereo_descriptors_from_3d(mol)
+    conformer = mol.GetConformer()
+    for atom_idx in range(mol.GetNumAtoms()):
+        conformer.SetAtomPosition(atom_idx, coords[atom_idx])
+    preserved = stereo_descriptors_from_3d(mol) == before
+    mol.SetProp(STEREO_CHANGED_PROP, str(not preserved))
+    return preserved
+
+
+def stereo_preserved(mol: Chem.Mol) -> bool:
+    """True unless ``mol`` is marked as having changed configuration.
+
+    Molecules from paths that never run the post-optimization check carry no
+    marker and are treated as preserved, so this predicate can be added beside
+    ``check_connectivity`` without dropping records from other entry points.
+    """
+    try:
+        return mol.GetProp(STEREO_CHANGED_PROP).lower() != "true"
+    except KeyError:
+        return True
+```
+
+`stereo_changed(mol, reference_smiles)` and `_chiral_tags_from_3d` are deleted. `stereo_changed` had no caller in `src/` and its index-keyed comparison against a separately parsed SMILES is the limitation this rewrite removes rather than fixes.
+
+- [ ] **Step 4: Delete the test for the removed function**
+
+In `tests/test_stereochemistry_validation.py`, delete the whole `test_detect_stereo_change` function (module-level, roughly lines 59-70), including its local `from Auto3D.utils.stereo_check import stereo_changed`. Leave every other test in that file untouched.
+
+- [ ] **Step 5: Route the coordinate write through the check**
+
+In `src/Auto3D/batch_opt/batchopt.py`, add the import beside the other `Auto3D` imports at the top of the file:
+
+```python
+from Auto3D.utils.stereo_check import apply_optimized_coords
+```
+
+Then, in `run()`, replace the SDF write block:
+
+```python
+        with Chem.SDWriter(self.out_f) as f:
+            for i in range(len(mols)):
+                mol = mols[i]
+                idx = mol.GetProp('_Name')
+                # Determine true convergence status:
+                # - Converged: converged AND not oscillating (osc_count < patience)
+                # - Dropped: converged AND oscillating (osc_count >= patience)
+                # - Not converged: converged=False
+                converged_i = converged_flags[i]
+                osc_count_i = osc_counts[i]
+                convergence_i = converged_i and osc_count_i < patience
+                mol.SetProp('E_tot', str(energies[i]))
+                mol.SetProp('fmax', str(fmaxs[i]))
+                mol.SetProp('Converged', str(convergence_i))
+                # Mark structures dropped due to oscillation for diagnostics
+                is_oscillating = converged_i and osc_count_i >= patience
+                mol.SetProp('Dropped_Oscillating', str(is_oscillating))
+                mol.SetProp('ID', idx)
+                coord = coords_out[i]
+                for atom_idx, atom in enumerate(mol.GetAtoms()):
+                    mol.GetConformer().SetAtomPosition(atom.GetIdx(), coord[atom_idx])
+                f.write(mol)
+```
+
+with:
+
+```python
+        n_stereo_changed = 0
+        with Chem.SDWriter(self.out_f) as f:
+            for i in range(len(mols)):
+                mol = mols[i]
+                idx = mol.GetProp('_Name')
+                # Determine true convergence status:
+                # - Converged: converged AND not oscillating (osc_count < patience)
+                # - Dropped: converged AND oscillating (osc_count >= patience)
+                # - Not converged: converged=False
+                converged_i = converged_flags[i]
+                osc_count_i = osc_counts[i]
+                convergence_i = converged_i and osc_count_i < patience
+                mol.SetProp('E_tot', str(energies[i]))
+                mol.SetProp('fmax', str(fmaxs[i]))
+                mol.SetProp('Converged', str(convergence_i))
+                # Mark structures dropped due to oscillation for diagnostics
+                is_oscillating = converged_i and osc_count_i >= patience
+                mol.SetProp('Dropped_Oscillating', str(is_oscillating))
+                mol.SetProp('ID', idx)
+                # Reads the configuration from the pre-optimization coordinates,
+                # writes the optimized ones, reads again, and records the
+                # comparison on the molecule. Both readings come from this same
+                # object, so no atom mapping is needed.
+                if not apply_optimized_coords(mol, coords_out[i]):
+                    n_stereo_changed += 1
+                f.write(mol)
+
+        if n_stereo_changed:
+            logger.warning(
+                f"{n_stereo_changed} conformer(s) changed stereochemistry during "
+                "optimization and will be excluded from the results."
+            )
+```
+
+- [ ] **Step 6: Add the exclusion at all three filter sites**
+
+`src/Auto3D/filtering.py` — extend the import at `:13` and the guard at `:49`:
+
+```python
+from Auto3D.utils import check_connectivity
+from Auto3D.utils.stereo_check import stereo_preserved
+```
+
+```python
+        if converged and stereo_preserved(mol) and check_connectivity(mol):
+            valid_mols.append(mol)
+```
+
+`src/Auto3D/utils/chemistry.py` — in `filter_unique`, add the import at the top of the module (`from Auto3D.utils.stereo_check import stereo_preserved`; `stereo_check` imports nothing from `chemistry`, so there is no cycle) and change:
+
+```python
+        has_valid_bonds = check_connectivity(mol)
+        if convergence_flag and has_valid_bonds:
+            mols_.append(mol)
+```
+
+to:
+
+```python
+        has_valid_bonds = check_connectivity(mol)
+        if convergence_flag and has_valid_bonds and stereo_preserved(mol):
+            mols_.append(mol)
+```
+
+`src/Auto3D/ranking.py` — extend the import block near `:10` and the `k == 1` fast path at `:99`:
+
+```python
+from Auto3D.utils.chemistry import check_connectivity
+from Auto3D.utils.stereo_check import stereo_preserved
+```
+
+```python
+            for mol in df2["mols"]:
+                if stereo_preserved(mol) and check_connectivity(mol):
+                    out_mols = [mol]
+                    break
+```
+
+Also extend `filter_unique_optimized`'s docstring `Args:` line for `mols` to read `List of RDKit Mol objects with 'E_tot' and 'Converged' properties. Records marked 'Stereo_changed' are excluded.` and make the matching one-line addition to `filter_unique`'s and `top_k`'s docstrings.
+
+- [ ] **Step 7: Run the new module and confirm it passes**
+
+```bash
+pytest tests/test_stereo_postopt.py -q -rxX -m "not slow"
+```
+
+Expected: **12 passed**.
+
+- [ ] **Step 8: Full fast suite and lint**
+
+```bash
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+```
+
+Expected: all pass, 0 xpassed. Confirm no import cycle: `python -c "import Auto3D.ranking, Auto3D.filtering, Auto3D.utils.chemistry, Auto3D.batch_opt.batchopt"` must exit 0.
+
+**Report explicitly, as an unverified item:** the `batchopt.run()` wiring itself cannot execute on this box, because `run()` requires a loaded neural network potential. `apply_optimized_coords` is covered directly by `tests/test_stereo_postopt.py`, and the call site is a single line, but the end-to-end path first executes in CI. Say so in the task report rather than claiming end-to-end verification.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Auto3D/utils/stereo_check.py src/Auto3D/batch_opt/batchopt.py src/Auto3D/filtering.py src/Auto3D/utils/chemistry.py src/Auto3D/ranking.py tests/test_stereochemistry_validation.py tests/test_stereo_postopt.py
+git commit -m "fix!: validate stereochemistry after optimization
+
+stereo_changed had no caller in src/; its docstring named an atom-mapping
+limitation that had to be resolved before wiring it in. The only
+post-optimization structural check was check_connectivity, which compares
+interatomic distances against UFF radii and is stereo-blind, so an optimization
+that inverted a center or rotated through a double bond produced a molecule of
+different chemical identity than its title, reported as a converged conformer.
+
+The mapping problem disappears when the comparison never crosses molecules:
+batchopt already holds each molecule with its pre-optimization coordinates and
+overwrites them in place, so reading descriptors immediately before and after
+that write compares one object against itself. Atom and bond indices match by
+construction and no reference SMILES is needed.
+
+Records whose configuration changed are marked Stereo_changed and excluded by
+filter_unique_optimized, filter_unique, and top_k's k=1 fast path. Molecules
+from paths that never run the check carry no marker and are unaffected.
+
+The unused stereo_changed(mol, reference_smiles) is removed."
+```
+
+---
+
+### Task 5: Release documentation for B5 and B6
+
+The spec calls B5 "the most user-visible change in this release" and requires it to lead the Breaking Changes section. Both the CHANGELOG and the rendered migration guide need it.
+
+**Files:**
+- Modify: `CHANGELOG.md` (the `## [4.0.0] - unreleased` section)
+- Modify: `docs/source/migration-4.0.rst`
+
+**Interfaces:**
+- Consumes: the behavior established by Tasks 1-4. Read those commits (`git log -p -4`) before writing — describe what landed, not what this plan predicted.
+- Produces: nothing other tasks depend on.
+
+- [ ] **Step 1: Lead the Breaking Changes section with B5**
+
+In `CHANGELOG.md`, insert these entries at the **top** of the existing `### Breaking Changes` list under `## [4.0.0] - unreleased`, above the `pad_from_mols` entry:
+
+```markdown
+- **Molecules with unspecified double-bond stereo now produce roughly twice the
+  conformer groups.** One geometric isomer of every such molecule was previously
+  discarded before embedding, because the enantiomer filter treated two empty
+  stereo-center lists as an enantiomeric pair and `FindMolChiralCenters` never
+  reports double-bond stereo. Which isomer survived was decided by SMILES sort
+  order. Fumaric and maleic acid differ by ~5 kcal/mol, and one of them silently
+  disappeared. Expect larger output and longer runs for affected inputs; this is
+  the cis/trans enumeration that was already being requested.
+
+- **Conformers whose configuration changed during optimization are excluded from
+  the results.** Optimization can invert a stereocenter or rotate through a
+  double bond, producing a molecule of different chemical identity than its
+  title. Such records are marked with a `Stereo_changed` SD property and dropped
+  by the conformer filters, with a count logged. A molecule whose every
+  conformer changed configuration now yields no output where it previously
+  yielded a mislabeled structure.
+
+- **SDF input enumerates unspecified stereocenters.** `RDKitSdfIsomer` embedded
+  a single molecule per record, so ETKDG returned a mixture of configurations
+  written as numbered conformers of one species. Each configuration is now
+  embedded separately, and conformers are named
+  `<species>_<isomer>_<conformer>` to match the SMILES path. `max_confs` is
+  therefore a per-stereoisomer budget on this path, as it already was on the
+  SMILES path: a flat SDF with one unspecified center and `max_confs=12`
+  produces up to 24 conformers.
+
+- **`Auto3D.utils.stereo_check.stereo_changed` removed.** It had no caller and
+  compared CIP codes by raw atom index against a separately parsed reference
+  SMILES. Use `stereo_descriptors_from_3d` to read a molecule's configuration
+  and `stereo_preserved` to test the marker the pipeline sets.
+```
+
+- [ ] **Step 2: Add the Fixed entries**
+
+Append to the existing `### Fixed` list in the same section:
+
+```markdown
+- **Geometric isomers are no longer discarded as enantiomers** - `enantiomer()`
+  returned `True` for two empty descriptor lists because its loop body never
+  executed. `enantiomer_helper` now compares each candidate against the mirror
+  image of every kept molecule via canonical SMILES, which needs no atom mapping
+  between two independently canonicalized structures and is exact on E/Z: a
+  reflection cannot change double-bond geometry, so geometric isomers never
+  compare equal. This also removes a latent failure where index-keyed comparison
+  raised on a legitimate pair and disabled the filter for that molecule.
+
+- **Tautomer enumeration preserves specified stereochemistry** - RDKit's
+  `TautomerEnumerator` defaults to `SetRemoveSp3Stereo(True)`, so every output
+  tautomer was written stereo-stripped and then re-enumerated downstream as
+  unassigned. A submitted (S) molecule came back as (R) roughly half the time,
+  at identical energy and undetectable from the output. Affects
+  `enumerate_tautomer=True` runs only. Descriptors the tautomerization genuinely
+  destroys are still dropped, and no new ones are assigned.
+
+- **SDF input no longer randomizes unspecified stereocenters** - the SDF path
+  ignored `enumerate_isomers` entirely; the adapter did not accept it. With
+  enumeration disabled, a molecule with unspecified stereo now logs a warning
+  naming the count instead of silently emitting a mixture.
+```
+
+- [ ] **Step 3: Add the migration-guide sections**
+
+In `docs/source/migration-4.0.rst`, add two subsections under the existing `Results that change` section, before `API changes`. Match the file's existing heading underline style exactly — read the neighboring headings first and copy their punctuation and length convention.
+
+```rst
+More conformers for molecules with unspecified double bonds
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Auto3D 3.x discarded one geometric isomer of every achiral molecule with an
+unspecified ``C=C``, because its enantiomer filter treated two empty
+stereo-center lists as an enantiomeric pair. Which isomer survived was decided
+by SMILES sort order, with no warning. Fumaric and maleic acid differ by about
+5 kcal/mol, and one of them disappeared.
+
+Both isomers now survive, so affected inputs produce roughly twice the
+conformer groups and take correspondingly longer. If you sized ``max_confs``
+or a job's runtime against 3.x output for such molecules, re-check it.
+
+Conformers that change configuration are dropped
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Geometry optimization can invert a stereocenter or rotate through a double
+bond. Auto3D 3.x had no check for this -- ``check_connectivity`` compares
+interatomic distances against UFF radii and is stereo-blind -- so such a
+structure was emitted as a converged conformer under the original title.
+
+Configuration is now compared before and after optimization. Records that
+changed carry a ``Stereo_changed`` SD property and are excluded from the
+results, with a count logged. A molecule whose every conformer changed
+configuration now yields no output for that molecule, where 3.x yielded a
+mislabeled structure. If a run produces fewer molecules than 3.x did, check the
+log for this count before assuming a regression.
+```
+
+Also add an ``SDF input`` subsection under ``API changes`` describing the
+``<species>_<isomer>_<conformer>`` naming and the per-isomer ``max_confs``
+budget, in the same register as the sections already there.
+
+- [ ] **Step 4: Verify the docs build**
+
+```bash
+python -m sphinx -b html docs/source /tmp/auto3d-docs-check -q 2>&1 | tail -20
+```
+
+Expected: no new warnings attributable to `migration-4.0.rst`. If Sphinx is not installed, run `python -c "import docutils.core, pathlib; docutils.core.publish_doctree(pathlib.Path('docs/source/migration-4.0.rst').read_text())"` and confirm it emits no severity-2+ messages. Report which check you ran.
+
+RST underlines must be **at least** as long as their title; longer is valid and is not an error. Do not "fix" a longer underline.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md docs/source/migration-4.0.rst
+git commit -m "docs: record the stereochemistry breaking changes for 4.0.0
+
+B5 (more conformer groups for unspecified double-bond stereo) leads the
+Breaking Changes section as the release's most user-visible change, followed by
+B6 (conformers that change configuration during optimization are dropped), the
+SDF conformer naming change and its per-isomer max_confs budget, and the
+removal of the unused stereo_changed helper."
+```
+
+---
+
+## Phase exit criteria
+
+Verify all of these before opening the pull request:
+
+1. `pytest tests/ -q -rxX -m "not slow"` — all pass, **0 xpassed**, 0 failed.
+2. `grep -rn 'reason="[CM][0-9]' tests/ | wc -l` returns **19** (25 minus the six Phase 2 markers).
+3. `grep -rn 'C1:\|C2:\|M19:' tests/` returns nothing.
+4. `ruff check src/ tests/` clean.
+5. `grep -rn 'stereo_changed' src/` shows only the `Stereo_changed` property name and its constant — no surviving reference to the deleted function.
+6. `grep -rn 'FindMolChiralCenters' src/Auto3D/utils/stereochemistry.py` returns nothing.
+
+## Known limits of local verification — state these in the final report
+
+- The `batchopt.run()` call site for `apply_optimized_coords` cannot execute here: `run()` needs a loaded NNP. The function itself is directly tested; the wiring first runs in CI.
+- The entire slow tier is unrun. `tests/test_pipeline_e2e.py` drives the full SMILES pipeline and is slow-marked, so the end-to-end effect of B5 and B6 on molecule counts is unverified locally.
+- `tests/test_species_conversion.py` remains invisible (`importorskip("torchani")`), unchanged by this phase.
+
+## Self-review notes
+
+- **Spec coverage:** §5.1 (C1) → Task 1; §5.2 (C2) → Task 2; §5.3 (C9) → Task 4; §5.4 (M19) → Task 3; §5.5 (rewrite the C1-enshrining test) → Task 1 Steps 1 and 6; "Behavior change" / B5 and B6 → Task 5.
+- **Deviation:** §5.1's prescribed `FindPotentialStereo` mechanism is replaced by a mirror-image canonical-SMILES comparison, for the reason stated above. §5.1's named fallback is implemented as well, in `enantiomer` itself.
+- **Not covered by any task:** §5.3's "and reported" for excluded records is satisfied by the `Stereo_changed` SD property plus the aggregate log line, not by a per-molecule report file. If a reviewer reads the spec as requiring a machine-readable manifest of excluded records, that is a real gap — raise it rather than inventing the format.
+- **Type consistency:** `stereo_preserved` is the only cross-file symbol, used identically at all three filter sites. `flipper` (engine) and `enumerate_isomers` (adapter/factory) mirror the naming `RDKitIsomer` / `RDKitIsomerAdapter` already use — deliberate, not an inconsistency.

--- a/src/Auto3D/batch_opt/batchopt.py
+++ b/src/Auto3D/batch_opt/batchopt.py
@@ -1,4 +1,5 @@
 # Original source: /labspace/models/aimnet/batch_opt_script/
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -355,7 +356,15 @@ class optimizing:
                 f.write(mol)
 
         if n_stereo_changed:
-            logger.warning(
+            # This module's logger ("Auto3D.batch_opt.batchopt") is not an
+            # ancestor of "auto3d", the logger name the worker's QueueHandler
+            # is attached to (see Auto3D.workflow_workers), so a warning
+            # through the module logger never reaches the run log. Emit
+            # through logging.getLogger("auto3d") directly instead -- the
+            # same fix Auto3D.utils.chemistry.relieve_clash already uses --
+            # because this count is documented as user-visible in the log
+            # (CHANGELOG.md, docs/source/migration-4.0.rst).
+            logging.getLogger("auto3d").warning(
                 f"{n_stereo_changed} conformer(s) changed stereochemistry during "
                 "optimization and will be excluded from the results."
             )

--- a/src/Auto3D/batch_opt/batchopt.py
+++ b/src/Auto3D/batch_opt/batchopt.py
@@ -39,6 +39,7 @@ from Auto3D.batch_opt.model_wrapper import EnForce_ANI
 from Auto3D.batch_opt.optimization_engine import n_steps, print_stats  # noqa: F401
 from Auto3D.constants import DEFAULT_ENERGY_TOL, INITIAL_ENERGY_SENTINEL, INITIAL_FMAX_SENTINEL
 from Auto3D.model_factory import create_model
+from Auto3D.utils.stereo_check import apply_optimized_coords
 
 from .padding import pad_from_mols
 
@@ -323,6 +324,7 @@ class optimizing:
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
+        n_stereo_changed = 0
         with Chem.SDWriter(self.out_f) as f:
             for i in range(len(mols)):
                 mol = mols[i]
@@ -341,10 +343,19 @@ class optimizing:
                 is_oscillating = converged_i and osc_count_i >= patience
                 mol.SetProp('Dropped_Oscillating', str(is_oscillating))
                 mol.SetProp('ID', idx)
-                coord = coords_out[i]
-                for atom_idx, atom in enumerate(mol.GetAtoms()):
-                    mol.GetConformer().SetAtomPosition(atom.GetIdx(), coord[atom_idx])
+                # Reads the configuration from the pre-optimization coordinates,
+                # writes the optimized ones, reads again, and records the
+                # comparison on the molecule. Both readings come from this same
+                # object, so no atom mapping is needed.
+                if not apply_optimized_coords(mol, coords_out[i]):
+                    n_stereo_changed += 1
                 f.write(mol)
+
+        if n_stereo_changed:
+            logger.warning(
+                f"{n_stereo_changed} conformer(s) changed stereochemistry during "
+                "optimization and will be excluded from the results."
+            )
 
         # Clean up GPU memory after optimization
         if torch.cuda.is_available():

--- a/src/Auto3D/batch_opt/batchopt.py
+++ b/src/Auto3D/batch_opt/batchopt.py
@@ -346,7 +346,10 @@ class optimizing:
                 # Reads the configuration from the pre-optimization coordinates,
                 # writes the optimized ones, reads again, and records the
                 # comparison on the molecule. Both readings come from this same
-                # object, so no atom mapping is needed.
+                # object, so no atom mapping is needed. This covers the neural
+                # network optimization step only; clash relief (a separate,
+                # earlier force-field relaxation) is guarded at its own call
+                # site in Auto3D.utils.chemistry.relieve_clash.
                 if not apply_optimized_coords(mol, coords_out[i]):
                     n_stereo_changed += 1
                 f.write(mol)

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -11,6 +11,7 @@ from Auto3D.constants import (
     DEFAULT_RMSD_THRESHOLD,
 )
 from Auto3D.utils import check_connectivity
+from Auto3D.utils.stereo_check import stereo_preserved
 
 
 def filter_unique_optimized(
@@ -31,6 +32,7 @@ def filter_unique_optimized(
 
     Args:
         mols: List of RDKit Mol objects with 'E_tot' and 'Converged' properties.
+            Records marked 'Stereo_changed' are excluded.
         rmsd_threshold: RMSD threshold for considering structures similar (Angstrom).
         energy_cluster_window: Energy window for clustering (eV).
 
@@ -46,7 +48,7 @@ def filter_unique_optimized(
             converged = mol.GetProp('Converged').lower() == 'true'
         except KeyError:
             converged = False
-        if converged and check_connectivity(mol):
+        if converged and stereo_preserved(mol) and check_connectivity(mol):
             valid_mols.append(mol)
 
     if not valid_mols:

--- a/src/Auto3D/isomer_engine.py
+++ b/src/Auto3D/isomer_engine.py
@@ -362,16 +362,22 @@ class RDKitIsomer:
 
 
 class RDKitSdfIsomer:
-    """Enumerate conformers from an SDF file.
+    """Enumerate stereoisomers and conformers from an SDF file.
 
-    Preserves specified stereo centers and enumerates unspecified ones.
+    Preserves specified stereo centers and enumerates unspecified ones, so each
+    output species has one definite configuration. Conformers are named
+    ``<name>_<isomer>_<conformer>``, matching the SMILES path, which is what
+    lets :class:`~Auto3D.ranking.ConformerRanker` group them correctly.
 
     Args:
         sdf: Path to input SDF file.
         enumerated_sdf: Path for output SDF file.
-        max_confs: Maximum conformers per molecule. None for dynamic.
+        max_confs: Maximum conformers per stereoisomer. None for dynamic.
         threshold: RMSD threshold for duplicate removal (Å).
         np: Number of CPU threads for parallelization.
+        flipper: Whether to enumerate unspecified stereocenters. When False,
+            a molecule with unspecified stereo is embedded as-is and its
+            conformers are a mixture of configurations; a warning says so.
     """
 
     def __init__(
@@ -381,15 +387,56 @@ class RDKitSdfIsomer:
         max_confs: int | None,
         threshold: float,
         np: int,
+        flipper: bool = True,
     ) -> None:
         self.sdf = sdf
         self.enumerated_sdf = enumerated_sdf
         self.n_conformers = max_confs
         self.threshold = threshold
         self.np = np
+        self.flipper = flipper
+
+    @staticmethod
+    def count_unspecified_stereo(mol: Chem.Mol) -> int:
+        """Count stereo elements the input leaves unspecified."""
+        return sum(
+            1
+            for element in Chem.FindPotentialStereo(mol)
+            if element.specified == Chem.StereoSpecified.Unspecified
+        )
+
+    def stereoisomers(self, mol: Chem.Mol, name: str) -> list[Chem.Mol]:
+        """Return the distinct configurations to embed for one input record.
+
+        A 3D SDF whose centers are all specified yields exactly one entry, so
+        this is a no-op for that input; only unspecified centers enumerate.
+        """
+        if not self.flipper:
+            unspecified = self.count_unspecified_stereo(mol)
+            if unspecified:
+                logger.warning(
+                    f"{name!r} has {unspecified} unspecified stereo element(s) "
+                    "and stereoisomer enumeration is disabled, so its conformers "
+                    "will be a mixture of configurations. Enable isomer "
+                    "enumeration to get one consistent species per configuration."
+                )
+            return [mol]
+
+        opts = StereoEnumerationOptions(
+            unique=True, maxIsomers=MAX_STEREOISOMERS, onlyUnassigned=True
+        )
+        isomers = list(EnumerateStereoisomers(mol, options=opts))
+        if len(isomers) >= MAX_STEREOISOMERS:
+            logger.warning(
+                f"Stereoisomer enumeration hit the cap of {MAX_STEREOISOMERS} "
+                f"for {name!r}; results may be truncated."
+            )
+        # EnumerateStereoisomers returns an empty sequence for a molecule it
+        # cannot enumerate; embedding the input unchanged beats dropping it.
+        return isomers or [mol]
 
     def run(self) -> str:
-        """Enumerate conformers and write to output SDF file.
+        """Enumerate stereoisomers and conformers into the output SDF file.
 
         Returns:
             Path to the enumerated SDF file.
@@ -402,24 +449,33 @@ class RDKitSdfIsomer:
                         "Skipping molecule: failed to parse (SDMolSupplier yielded None)."
                     )
                     continue
-                #enumerate conformers
-                mol2 = Chem.AddHs(mol)
-                if self.n_conformers is None:
-                    # Compute the conformer budget on the H-complete (AddHs) mol
-                    # so the SDF path agrees with the SMILES path on the RICHER
-                    # with-H count. AddHs is idempotent for a mol that already
-                    # carries explicit Hs (3D SDFs read with removeHs=False), so
-                    # this yields the same count regardless of input format.
-                    n_conformers = calculate_conformer_count(mol2)
-                else:
-                    n_conformers = self.n_conformers
-                AllChem.EmbedMultipleConfs(mol2, numConfs=n_conformers, randomSeed=CONFORMER_RANDOM_SEED, numThreads=self.np, pruneRmsThresh=self.threshold)
-                #set conformer names
                 name = mol.GetProp('_Name')
-                for i, conf in enumerate(mol2.GetConformers()):
-                    mol2.SetProp('_Name', f'{name}_{i}')
-                    mol2.SetProp('ID', f'{name}_{i}')
-                    writer.write(mol2, confId=i)
+                for isomer_idx, isomer in enumerate(self.stereoisomers(mol, name)):
+                    mol2 = Chem.AddHs(isomer)
+                    if self.n_conformers is None:
+                        # Compute the conformer budget on the H-complete (AddHs)
+                        # mol so the SDF path agrees with the SMILES path on the
+                        # RICHER with-H count. AddHs is idempotent for a mol that
+                        # already carries explicit Hs (3D SDFs read with
+                        # removeHs=False), so this yields the same count
+                        # regardless of input format.
+                        n_conformers = calculate_conformer_count(mol2)
+                    else:
+                        n_conformers = self.n_conformers
+                    AllChem.EmbedMultipleConfs(
+                        mol2,
+                        numConfs=n_conformers,
+                        randomSeed=CONFORMER_RANDOM_SEED,
+                        numThreads=self.np,
+                        pruneRmsThresh=self.threshold,
+                    )
+                    # Three name components (species _ isomer _ conformer) match
+                    # the SMILES path, whose consumers group on the first one.
+                    for conf_idx, conf in enumerate(mol2.GetConformers()):
+                        conf_name = f'{name}_{isomer_idx}_{conf_idx}'
+                        mol2.SetProp('_Name', conf_name)
+                        mol2.SetProp('ID', conf_name)
+                        writer.write(mol2, confId=conf.GetId())
         return self.enumerated_sdf
 
 

--- a/src/Auto3D/isomer_engine.py
+++ b/src/Auto3D/isomer_engine.py
@@ -26,6 +26,7 @@ from Auto3D.utils import (
 )
 from Auto3D.utils.chemistry import calculate_conformer_count
 from Auto3D.utils.file_ops import combine_smi, iter_smi_records
+from Auto3D.utils.stereochemistry import enantiomer_key
 
 try:
     from openeye import oechem, oeomega, oequacpac
@@ -365,9 +366,18 @@ class RDKitSdfIsomer:
     """Enumerate stereoisomers and conformers from an SDF file.
 
     Preserves specified stereo centers and enumerates unspecified ones, so each
-    output species has one definite configuration. Conformers are named
-    ``<name>_<isomer>_<conformer>``, matching the SMILES path, which is what
-    lets :class:`~Auto3D.ranking.ConformerRanker` group them correctly.
+    output species has one definite configuration. Enantiomeric pairs are
+    reduced to one representative -- the same rule the SMILES path applies via
+    ``remove_enantiomers`` -- since mirror images are exactly degenerate under
+    any reflection-invariant potential. Conformers are named
+    ``<name>_<isomer>_<conformer>`` uniformly, including when there is only one
+    isomer, so this path's own output has one consistent shape to parse (the
+    SMILES path is not identical: with ``enumerate_isomers`` disabled there it
+    emits only two components). The isomer component is what
+    :func:`Auto3D.utils.file_ops.decode_ids` relies on to rebuild
+    ``<original>_<isomer>_<conformer>`` IDs after the pipeline's numeric-ID
+    encoding step; :class:`~Auto3D.ranking.ConformerRanker` groups on the
+    leading component only, so it is unaffected by the isomer index.
 
     Args:
         sdf: Path to input SDF file.
@@ -431,9 +441,23 @@ class RDKitSdfIsomer:
                 f"Stereoisomer enumeration hit the cap of {MAX_STEREOISOMERS} "
                 f"for {name!r}; results may be truncated."
             )
+        # Mirror images are exactly degenerate under any reflection-invariant
+        # potential, so optimizing both spends half the budget for nothing and
+        # leaves top_k choosing between them on numerical noise. The SMILES
+        # path drops them in remove_enantiomers; this is the same rule, applied
+        # to the enumerated list directly. Geometric isomers are NOT affected:
+        # a reflection cannot change E/Z, so cis and trans keep distinct keys.
+        deduplicated: list[Chem.Mol] = []
+        seen: set[tuple[str, ...]] = set()
+        for isomer in isomers:
+            key = enantiomer_key(Chem.MolToSmiles(isomer))
+            if key in seen:
+                continue
+            seen.add(key)
+            deduplicated.append(isomer)
         # EnumerateStereoisomers returns an empty sequence for a molecule it
         # cannot enumerate; embedding the input unchanged beats dropping it.
-        return isomers or [mol]
+        return deduplicated or [mol]
 
     def run(self) -> str:
         """Enumerate stereoisomers and conformers into the output SDF file.
@@ -469,6 +493,13 @@ class RDKitSdfIsomer:
                         numThreads=self.np,
                         pruneRmsThresh=self.threshold,
                     )
+                    if mol2.GetNumConformers() == 0:
+                        logger.warning(
+                            f"Stereoisomer {isomer_idx} of {name!r} produced no "
+                            "conformers; ETKDG could not embed it. This species "
+                            "is absent from the output."
+                        )
+                        continue
                     # Three name components (species _ isomer _ conformer) match
                     # the SMILES path, whose consumers group on the first one.
                     for conf_idx, conf in enumerate(mol2.GetConformers()):

--- a/src/Auto3D/isomer_engine.py
+++ b/src/Auto3D/isomer_engine.py
@@ -33,6 +33,34 @@ except ImportError:
     pass
 
 
+def _contradicts_reference_stereo(reference: Chem.Mol, tautomer: Chem.Mol) -> bool:
+    """True if ``tautomer`` is the input's skeleton with a different configuration.
+
+    Preserving sp3 stereo through enumeration is only safe for single-step
+    flattening. Across a multi-step path -- D-erythrose reaching the 2,3-enediol,
+    which flattens both of its centers -- RDKit restores a DEFINITE tag instead
+    of leaving the center unspecified, and for one output that tag is the
+    input's mirror image. Unfiltered, D-erythrose yields L-erythrose as a
+    "tautomer": the wrong-identity defect that preserving stereo exists to
+    prevent.
+
+    The test is deliberately narrow. A tautomer whose constitution differs from
+    the input is a genuinely different species, and its stereo descriptors are
+    not comparable to the input's -- a keto/enol shift can relabel an untouched
+    center from R to S purely by changing a neighboring branch's CIP priority,
+    which is a relabeling and not an inversion. Only when the constitution is
+    identical does "different configuration" mean the molecule came back wrong.
+
+    Comparing canonical SMILES rather than per-atom descriptors also means this
+    depends on no assumption about the enumerator preserving atom ordering.
+    """
+    if Chem.MolToSmiles(tautomer, isomericSmiles=False) != Chem.MolToSmiles(
+        reference, isomericSmiles=False
+    ):
+        return False
+    return Chem.MolToSmiles(tautomer) != Chem.MolToSmiles(reference)
+
+
 class TautomerEngine:
     """Enumerate possible tautomers for input molecules.
 
@@ -69,6 +97,20 @@ class TautomerEngine:
     def rd_taut(self) -> None:
         """Enumerate tautomers using RDKit."""
         enumerator = rdMolStandardize.TautomerEnumerator()
+        # RDKit strips stereo from every atom in the tautomer core, in every
+        # output tautomer, including tautomers formed at a site that cannot
+        # reach a given center -- enolizing a ketone's other alpha carbon,
+        # say. The stripped SMILES are then re-enumerated downstream by
+        # EnumerateStereoisomers(onlyUnassigned=True) and one epimer is kept
+        # arbitrarily, so a submitted (S) molecule comes back as (R) half the
+        # time at identical energy. Disabling that default removal here
+        # preserves what the user specified -- but is only safe for
+        # single-step flattening: across a multi-step path RDKit can restore
+        # a DEFINITE tag on a center it destroyed, and the tag it picks can
+        # be the input's mirror image, so contradicting tautomers are
+        # filtered out below via _contradicts_reference_stereo().
+        enumerator.SetRemoveSp3Stereo(False)
+        enumerator.SetRemoveBondStereo(False)
         smiles = []
         for _line_no, smi, idx in iter_smi_records(self.input_f, on_malformed="skip"):
             smiles.append((smi, idx))
@@ -81,6 +123,8 @@ class TautomerEngine:
                 continue
             tauts = enumerator.Enumerate(mol)
             for taut in tauts:
+                if _contradicts_reference_stereo(mol, taut):
+                    continue
                 tautomers.append((Chem.MolToSmiles(taut), idx))
         with open(self.output, 'w+') as f:
             for smi_idx in tautomers:

--- a/src/Auto3D/isomer_engine.py
+++ b/src/Auto3D/isomer_engine.py
@@ -332,6 +332,7 @@ class RDKitIsomer:
                         f"Skipping molecule {name!r}: failed to parse {smi!r}"
                     )
                     continue
+                n_written = 0
                 for i in range(mol.GetNumConformers()):
                     # Relieve atom clashes (MMFF, UFF fallback) and keep the
                     # conformer only if it ends up clash-free.
@@ -340,6 +341,18 @@ class RDKitIsomer:
                         mol.SetProp('ID', conf_id)
                         mol.SetProp('_Name', conf_id)
                         writer.write(mol, confId=i)
+                        n_written += 1
+                if n_written == 0:
+                    # Every embedded conformer was rejected by clash relief
+                    # (or none embedded at all): the species is silently
+                    # absent from the output and never reaches ranking, so
+                    # not even "No structure converged" would appear for it.
+                    # Name it here, once, mirroring the SDF path's equivalent
+                    # warning for a stereoisomer ETKDG could not embed.
+                    logger.warning(
+                        f"{name!r} produced no conformers after clash relief; "
+                        "this species is absent from the output."
+                    )
 
     def _run_parallel_embedding(
         self, smi_name_tuples: list[tuple[str, str]]
@@ -409,10 +422,18 @@ class RDKitSdfIsomer:
     @staticmethod
     def count_unspecified_stereo(mol: Chem.Mol) -> int:
         """Count stereo elements the input leaves unspecified."""
+        # A double bond drawn with no geometry (e.g. a flat 2D depiction of
+        # C=C) is reported by RDKit as Chem.StereoSpecified.Unknown, not
+        # Unspecified -- Unspecified is what an sp3 center with no wedge
+        # gets. Counting only Unspecified silently misses every unspecified
+        # C=C, which is the exact case this warning exists to catch (e.g. a
+        # flat fumaric/maleic-acid SDF mixing two geometries ~5 kcal/mol
+        # apart into one species with no warning).
+        unspecified = (Chem.StereoSpecified.Unspecified, Chem.StereoSpecified.Unknown)
         return sum(
             1
             for element in Chem.FindPotentialStereo(mol)
-            if element.specified == Chem.StereoSpecified.Unspecified
+            if element.specified in unspecified
         )
 
     def stereoisomers(self, mol: Chem.Mol, name: str) -> list[Chem.Mol]:

--- a/src/Auto3D/isomers/factory.py
+++ b/src/Auto3D/isomers/factory.py
@@ -145,6 +145,7 @@ class IsomerEngineFactory:
                 max_confs=max_confs,
                 threshold=threshold,
                 n_jobs=n_jobs,
+                enumerate_isomers=enumerate_isomers,
             )
         elif engine_type == "omega":
             return adapter_class(

--- a/src/Auto3D/isomers/rdkit_adapters.py
+++ b/src/Auto3D/isomers/rdkit_adapters.py
@@ -100,15 +100,17 @@ class RDKitSdfIsomerAdapter(BaseIsomerEngine):
         max_confs: int | None = None,
         threshold: float = 0.3,
         n_jobs: int = 4,
+        enumerate_isomers: bool = True,
     ) -> None:
         """Initialize the RDKit SDF isomer adapter.
 
         Args:
             input_path: Path to input SDF file.
             output_path: Path for output SDF file.
-            max_confs: Maximum conformers per molecule.
+            max_confs: Maximum conformers per stereoisomer.
             threshold: RMSD threshold for duplicate removal.
             n_jobs: Number of CPU threads for conformer generation.
+            enumerate_isomers: Whether to enumerate unspecified stereocenters.
         """
         super().__init__(
             input_path=input_path,
@@ -117,6 +119,7 @@ class RDKitSdfIsomerAdapter(BaseIsomerEngine):
             threshold=threshold,
             n_jobs=n_jobs,
         )
+        self.enumerate_isomers = enumerate_isomers
 
     def run(self) -> str:
         """Execute RDKit SDF-based conformer generation.
@@ -132,5 +135,6 @@ class RDKitSdfIsomerAdapter(BaseIsomerEngine):
             max_confs=self.max_confs,
             threshold=self.threshold,
             np=self.n_jobs,
+            flipper=self.enumerate_isomers,
         )
         return engine.run()

--- a/src/Auto3D/ranking.py
+++ b/src/Auto3D/ranking.py
@@ -9,6 +9,7 @@ from Auto3D.filtering import filter_unique_optimized
 from Auto3D.utils import ev2kcalpermol, filter_unique, hartree2ev
 from Auto3D.utils.chemistry import check_connectivity
 from Auto3D.utils.logging_config import get_logger
+from Auto3D.utils.stereo_check import stereo_preserved
 
 logger = get_logger(__name__)
 
@@ -78,6 +79,7 @@ class ConformerRanker:
 
         Args:
             df_group: DataFrame group with 'names', 'energies', 'mols' columns.
+                Mols marked 'Stereo_changed' are excluded.
             k: Number of top structures to return.
 
         Returns:
@@ -96,7 +98,7 @@ class ConformerRanker:
         if k == 1:
             out_mols = []
             for mol in df2["mols"]:
-                if check_connectivity(mol):
+                if stereo_preserved(mol) and check_connectivity(mol):
                     out_mols = [mol]
                     break
         else:

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -28,7 +28,7 @@ from Auto3D.constants import (
     MAX_CONFORMERS_CAP,
     MIN_ATOM_DISTANCE,
 )
-from Auto3D.utils.stereo_check import stereo_preserved
+from Auto3D.utils.stereo_check import stereo_descriptors_from_3d, stereo_preserved
 
 logger = logging.getLogger("auto3d")
 
@@ -176,6 +176,14 @@ def relieve_clash(
     the function falls back to UFF so the conformer is not discarded for lack
     of a force field.
 
+    The force-field relaxation can itself invert a stereocenter or rotate a
+    double bond. This runs before the enumerated SDF is written, so the
+    downstream post-optimization stereochemistry check would otherwise read an
+    already-changed geometry as its own "before" reference and never notice.
+    Stereochemistry is therefore checked before and after the relaxation, on
+    this same molecule object, and a conformer whose configuration changed is
+    rejected here rather than passed downstream.
+
     Args:
         mol: RDKit molecule holding the conformer.
         conf_id: Index of the conformer to check/optimize.
@@ -183,7 +191,9 @@ def relieve_clash(
 
     Returns:
         True if the (possibly optimized) conformer's minimum pairwise distance
-        is >= ``min_distance`` and should be kept; False if it still clashes.
+        is >= ``min_distance`` and its stereochemistry survived unchanged;
+        False if it still clashes or if the relaxation changed its
+        configuration.
     """
     positions = mol.GetConformer(conf_id).GetPositions()
     # Closing the dead band: a conformer exactly at the threshold is kept.
@@ -191,10 +201,23 @@ def relieve_clash(
         return True
 
     # Clashing conformer: try MMFF, fall back to UFF when MMFF is unavailable.
+    before = stereo_descriptors_from_3d(mol, conf_id=conf_id)
     if AllChem.MMFFHasAllMoleculeParams(mol):
         AllChem.MMFFOptimizeMolecule(mol, confId=conf_id)
     else:
         AllChem.UFFOptimizeMolecule(mol, confId=conf_id)
+
+    # Clash relief is a force-field relaxation and can invert a center just as
+    # the neural network optimization can. It runs before the enumerated SDF is
+    # written, so the post-optimization check downstream would read an already
+    # inverted geometry as its reference and never notice. Reject the conformer
+    # here instead; the embedder simply keeps the ones that survive.
+    if stereo_descriptors_from_3d(mol, conf_id=conf_id) != before:
+        logger.warning(
+            "Discarding a conformer whose stereochemistry changed during clash "
+            "relief."
+        )
+        return False
 
     positions = mol.GetConformer(conf_id).GetPositions()
     return min_pairwise_distance(positions) >= min_distance

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -184,6 +184,27 @@ def relieve_clash(
     this same molecule object, and a conformer whose configuration changed is
     rejected here rather than passed downstream.
 
+    Known limitation: the "before" snapshot is read while the conformer is
+    still in violation of ``min_distance`` — by definition, since that is the
+    only way execution reaches this branch. CIP perception on a geometry that
+    is itself clashing is not a trustworthy baseline, unlike the equivalent
+    check in ``batch_opt/batchopt.py``, whose "before" reading is always
+    taken from a valid, non-clashing conformer. This matters only when the
+    branch is actually reached: across roughly 650 conformers sampled from
+    Auto3D's real ``EmbedMultipleConfs`` output (glucose, cholesterol, a
+    tripeptide, macrocycles, a cage compound, and molecules with B/Se/
+    hypervalent Si), none ever fell below the clash threshold. Under 196
+    artificially forced clashes, this guard rejected 96 conformers, and about
+    56% of those rejections had a post-relaxation configuration that actually
+    matched the molecule's true configuration -- spurious rejections caused
+    by the unreliable baseline rather than a real inversion. The known
+    improvement is to compare against the molecule's graph-encoded stereo
+    tags instead of a 3D read of the clashing geometry, but that needs its
+    own measurement first: RDKit's graph ``AssignStereochemistry`` and
+    ``AssignStereochemistryFrom3D`` label pseudoasymmetric centers
+    differently (``r``/``s`` vs ``R``/``S``), which could introduce a
+    systematic false positive.
+
     Args:
         mol: RDKit molecule holding the conformer.
         conf_id: Index of the conformer to check/optimize.

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -28,6 +28,7 @@ from Auto3D.constants import (
     MAX_CONFORMERS_CAP,
     MIN_ATOM_DISTANCE,
 )
+from Auto3D.utils.stereo_check import stereo_preserved
 
 logger = logging.getLogger("auto3d")
 
@@ -440,6 +441,7 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
 
     Args:
         mols: List of RDKit molecule objects with 'Converged' property set.
+            Records marked 'Stereo_changed' are excluded.
         crit: RMSD threshold for considering two structures as identical.
             Structures with RMSD below this value are considered duplicates.
             Defaults to DEFAULT_RMSD_THRESHOLD (0.3 Angstroms).
@@ -466,7 +468,7 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
         except KeyError:
             convergence_flag = False
         has_valid_bonds = check_connectivity(mol)
-        if convergence_flag and has_valid_bonds:
+        if convergence_flag and has_valid_bonds and stereo_preserved(mol):
             mols_.append(mol)
     mols = mols_
 

--- a/src/Auto3D/utils/stereo_check.py
+++ b/src/Auto3D/utils/stereo_check.py
@@ -1,44 +1,96 @@
-"""Post-optimization stereochemistry validation."""
+"""Post-optimization stereochemistry validation.
+
+Geometry optimization can invert a stereocenter or rotate through a double
+bond, producing a molecule of different chemical identity than the one its
+title names. ``check_connectivity`` compares interatomic distances against UFF
+radii and is stereo-blind, so nothing else catches it.
+
+The comparison here never crosses molecules: descriptors are read from one
+molecule object immediately before and immediately after its coordinates are
+overwritten, so atom and bond indices match by construction and no atom
+mapping or reference SMILES is required.
+"""
 from __future__ import annotations
+
+from collections.abc import Sequence
 
 from rdkit import Chem
 
+#: SD property recording whether optimization changed a molecule's configuration.
+STEREO_CHANGED_PROP = "Stereo_changed"
 
-def _chiral_tags_from_3d(mol: Chem.Mol) -> dict[int, str]:
-    work = Chem.Mol(mol)
-    Chem.AssignStereochemistryFrom3D(work)
-    tags: dict[int, str] = {}
-    for atom in work.GetAtoms():
-        if atom.HasProp("_CIPCode"):
-            tags[atom.GetIdx()] = atom.GetProp("_CIPCode")
-    return tags
+#: Sorted tetrahedral CIP codes by atom index, then double-bond stereo by bond index.
+StereoDescriptors = tuple[tuple[tuple[int, str], ...], tuple[tuple[int, str], ...]]
 
 
-def stereo_changed(mol: Chem.Mol, reference_smiles: str) -> bool:
-    """True if the molecule's 3D stereo differs from the reference SMILES.
+def stereo_descriptors_from_3d(
+    mol: Chem.Mol, conf_id: int = -1
+) -> StereoDescriptors:
+    """Perceive ``mol``'s stereochemistry from its 3D coordinates.
 
-    Compares CIP codes per atom index. Atoms unspecified in the reference are
-    ignored (enumeration may have assigned them legitimately).
+    Args:
+        mol: Molecule with at least one conformer. Not modified.
+        conf_id: Conformer to read. -1 (default) uses the molecule's default.
 
-    Limitations (must be addressed before wiring into the pipeline):
-    - Comparison is keyed on raw atom index, so it is only correct when ``mol``
-      and ``reference_smiles`` share identical atom ordering (true when ``mol``
-      was built from this same SMILES via MolFromSmiles + AddHs). For arbitrary
-      orderings, match atoms canonically (e.g. GetSubstructMatch) instead.
-    - Only tetrahedral atom CIP codes are compared; double-bond (E/Z) stereo is
-      not checked.
+    Returns:
+        A pair of sorted tuples: tetrahedral CIP codes keyed by atom index, and
+        double-bond stereo labels keyed by bond index. Sorting makes two
+        readings of the same molecule comparable with ``==``.
+
+    Note:
+        Indices are only meaningful within one molecule object. Compare two
+        readings taken from the same ``mol``; never compare readings from two
+        separately parsed molecules, whose atom orderings need not agree.
     """
-    ref = Chem.MolFromSmiles(reference_smiles)
-    if ref is None:
-        return False
-    ref = Chem.AddHs(ref)
-    Chem.AssignStereochemistry(ref, cleanIt=True, force=True)
-    ref_tags = {a.GetIdx(): a.GetProp("_CIPCode")
-                for a in ref.GetAtoms() if a.HasProp("_CIPCode")}
-    if not ref_tags:
-        return False
-    obs_tags = _chiral_tags_from_3d(mol)
-    for idx, code in ref_tags.items():
-        if idx in obs_tags and obs_tags[idx] != code:
-            return True
-    return False
+    work = Chem.Mol(mol)
+    Chem.AssignStereochemistryFrom3D(work, confId=conf_id)
+    atoms = tuple(sorted(
+        (atom.GetIdx(), atom.GetProp("_CIPCode"))
+        for atom in work.GetAtoms()
+        if atom.HasProp("_CIPCode")
+    ))
+    bonds = tuple(sorted(
+        (bond.GetIdx(), str(bond.GetStereo()))
+        for bond in work.GetBonds()
+        if bond.GetStereo() != Chem.BondStereo.STEREONONE
+    ))
+    return atoms, bonds
+
+
+def apply_optimized_coords(
+    mol: Chem.Mol, coords: Sequence[Sequence[float]]
+) -> bool:
+    """Write optimized coordinates into ``mol`` and record any stereo change.
+
+    Reads the molecule's configuration from its current (pre-optimization)
+    coordinates, overwrites the conformer with ``coords``, reads it again, and
+    stores the comparison on the ``Stereo_changed`` property so the conformer
+    filters can act on it after an SDF round trip.
+
+    Args:
+        mol: Molecule holding the pre-optimization conformer. Modified in place.
+        coords: One (x, y, z) position per atom, in atom order.
+
+    Returns:
+        True if the configuration is unchanged, False if it changed.
+    """
+    before = stereo_descriptors_from_3d(mol)
+    conformer = mol.GetConformer()
+    for atom_idx in range(mol.GetNumAtoms()):
+        conformer.SetAtomPosition(atom_idx, coords[atom_idx])
+    preserved = stereo_descriptors_from_3d(mol) == before
+    mol.SetProp(STEREO_CHANGED_PROP, str(not preserved))
+    return preserved
+
+
+def stereo_preserved(mol: Chem.Mol) -> bool:
+    """True unless ``mol`` is marked as having changed configuration.
+
+    Molecules from paths that never run the post-optimization check carry no
+    marker and are treated as preserved, so this predicate can be added beside
+    ``check_connectivity`` without dropping records from other entry points.
+    """
+    try:
+        return mol.GetProp(STEREO_CHANGED_PROP).lower() != "true"
+    except KeyError:
+        return True

--- a/src/Auto3D/utils/stereo_check.py
+++ b/src/Auto3D/utils/stereo_check.py
@@ -41,6 +41,19 @@ def stereo_descriptors_from_3d(
         Indices are only meaningful within one molecule object. Compare two
         readings taken from the same ``mol``; never compare readings from two
         separately parsed molecules, whose atom orderings need not agree.
+
+    Scope:
+        Only atoms RDKit assigns a ``_CIPCode`` (genuine tetrahedral
+        stereocenters) and bonds it assigns a non-``STEREONONE`` label
+        (defined double bonds) are covered. Trivalent (sp3) nitrogen never
+        receives a ``_CIPCode`` from ``AssignStereochemistryFrom3D``, so an
+        inverting amine nitrogen -- a real stereocenter in principle, but one
+        that freely interconverts at room temperature and is not treated as
+        configurational by RDKit's perception -- is never flagged. That is
+        the intended trade-off: it is exactly what keeps ordinary amine
+        inversion from being reported as a false positive. Other stereo
+        elements RDKit does not perceive this way (e.g. atropisomers) are
+        likewise invisible to this function.
     """
     work = Chem.Mol(mol)
     Chem.AssignStereochemistryFrom3D(work, confId=conf_id)

--- a/src/Auto3D/utils/stereo_check.py
+++ b/src/Auto3D/utils/stereo_check.py
@@ -54,6 +54,16 @@ def stereo_descriptors_from_3d(
         inversion from being reported as a false positive. Other stereo
         elements RDKit does not perceive this way (e.g. atropisomers) are
         likewise invisible to this function.
+
+        A double bond explicitly marked ``Chem.BondStereo.STEREOANY``
+        (drawn with no defined geometry) is also invisible to a change:
+        ``AssignStereochemistryFrom3D`` leaves an existing ``STEREOANY``
+        flag untouched rather than deriving E/Z from the coordinates, so
+        the "before" and "after" readings both report ``STEREOANY`` for
+        that bond even if optimization rotated it from cis to trans. This
+        function cannot detect that rotation; only the unspecified-stereo
+        warning at enumeration time (see
+        ``RDKitSdfIsomer.count_unspecified_stereo``) flags the bond at all.
     """
     work = Chem.Mol(mol)
     Chem.AssignStereochemistryFrom3D(work, confId=conf_id)

--- a/src/Auto3D/utils/stereochemistry.py
+++ b/src/Auto3D/utils/stereochemistry.py
@@ -89,7 +89,7 @@ def _mirror_image(mol: Chem.Mol) -> Chem.Mol:
     return work
 
 
-def _enantiomer_key(smi: str) -> tuple[str, ...]:
+def enantiomer_key(smi: str) -> tuple[str, ...]:
     """Return a key two SMILES share iff they are one molecule or mirror images.
 
     The key is the sorted set of the molecule's own canonical SMILES and its
@@ -102,6 +102,9 @@ def _enantiomer_key(smi: str) -> tuple[str, ...]:
     ``amend_configuration_w`` appends for it -- the same molecule written two
     ways, which a pairwise enantiomer test cannot catch because the two are not
     an enantiomeric pair.
+
+    Public because the SDF isomer engine deduplicates enumerated stereoisomers
+    with the same key, so both input paths remove enantiomers by one rule.
     """
     mol = Chem.MolFromSmiles(smi)
     if mol is None:
@@ -153,7 +156,7 @@ def are_enantiomers(smi1: str, smi2: str) -> bool:
     if Chem.MolToSmiles(mol1) == Chem.MolToSmiles(mol2):
         # The same molecule is not its own enantiomeric partner.
         return False
-    return _enantiomer_key(smi1) == _enantiomer_key(smi2)
+    return enantiomer_key(smi1) == enantiomer_key(smi2)
 
 
 def enantiomer_helper(smiles: list[str]) -> list[str]:
@@ -179,7 +182,7 @@ def enantiomer_helper(smiles: list[str]) -> list[str]:
     non_enantiomers: list[str] = []
     seen: set[tuple[str, ...]] = set()
     for smi in smiles:
-        key = _enantiomer_key(smi)
+        key = enantiomer_key(smi)
         if key in seen:
             continue
         seen.add(key)

--- a/src/Auto3D/utils/stereochemistry.py
+++ b/src/Auto3D/utils/stereochemistry.py
@@ -33,8 +33,10 @@ def enantiomer(l1: list[tuple[int, str]], l2: list[tuple[int, str]]) -> bool:
         l2: List of (atom_index, stereo_type) tuples for second molecule.
 
     Returns:
-        True if l1 and l2 represent enantiomers (all stereo centers inverted),
-        False otherwise.
+        True if l1 and l2 represent enantiomers (both non-empty, same indices,
+        every configuration inverted), False otherwise. Two empty lists are
+        False: a molecule with no stereo centers is its own mirror image, so it
+        has no enantiomer to pair with.
 
     Raises:
         ValueError: If l1 and l2 have different lengths or mismatched indices.
@@ -50,7 +52,12 @@ def enantiomer(l1: list[tuple[int, str]], l2: list[tuple[int, str]]) -> bool:
         raise ValueError(
             f"Stereo center lists must have same length: {len(l1)} vs {len(l2)}"
         )
-    indicator = True
+    # Two molecules with no stereo centers at all are not an enantiomeric pair:
+    # they are either the same molecule or two unrelated achiral compounds. The
+    # loop below cannot express that, because an empty loop leaves `indicator`
+    # at its True initial value, so the caller must be told here.
+    if not l1:
+        return False
     for i in range(len(l1)):
         tp1 = l1[i]
         tp2 = l2[i]
@@ -61,9 +68,92 @@ def enantiomer(l1: list[tuple[int, str]], l2: list[tuple[int, str]]) -> bool:
                 f"Stereo center indices must match: {idx1} vs {idx2} at position {i}"
             )
         if stereo1 == stereo2:
-            indicator = False
-            return indicator
-    return indicator
+            return False
+    return True
+
+
+def _mirror_image(mol: Chem.Mol) -> Chem.Mol:
+    """Return a copy of ``mol`` with every tetrahedral center inverted.
+
+    Reflection through a plane inverts tetrahedral configuration and leaves
+    double-bond (E/Z) geometry untouched, which is why this function only
+    swaps chiral tags: a cis alkene reflects to a cis alkene.
+    """
+    work = Chem.Mol(mol)
+    for atom in work.GetAtoms():
+        tag = atom.GetChiralTag()
+        if tag == Chem.ChiralType.CHI_TETRAHEDRAL_CW:
+            atom.SetChiralTag(Chem.ChiralType.CHI_TETRAHEDRAL_CCW)
+        elif tag == Chem.ChiralType.CHI_TETRAHEDRAL_CCW:
+            atom.SetChiralTag(Chem.ChiralType.CHI_TETRAHEDRAL_CW)
+    return work
+
+
+def _enantiomer_key(smi: str) -> tuple[str, ...]:
+    """Return a key two SMILES share iff they are one molecule or mirror images.
+
+    The key is the sorted set of the molecule's own canonical SMILES and its
+    mirror image's. An achiral molecule is its own mirror image, so its key has
+    one element and cannot collide with anything but itself; a chiral molecule
+    and its enantiomer produce the same two-element key from either side.
+
+    Keying is what makes the filter linear rather than a pairwise sweep, and it
+    also collapses a meso form against the string-inverted twin that
+    ``amend_configuration_w`` appends for it -- the same molecule written two
+    ways, which a pairwise enantiomer test cannot catch because the two are not
+    an enantiomeric pair.
+    """
+    mol = Chem.MolFromSmiles(smi)
+    if mol is None:
+        # Keep unparseable input unique to its own text so it is neither merged
+        # with a real molecule nor dropped. The prefix cannot occur in a SMILES.
+        return ("\x00unparseable", smi)
+    canonical = Chem.MolToSmiles(mol)
+    return tuple(sorted({canonical, Chem.MolToSmiles(_mirror_image(mol))}))
+
+
+def are_enantiomers(smi1: str, smi2: str) -> bool:
+    """Check whether two SMILES are a pair of enantiomers.
+
+    Builds the mirror image of the first molecule and compares canonical
+    SMILES. This needs no atom mapping between the two inputs, which matters
+    because the two SMILES are independently canonicalized and their atom
+    orderings are not guaranteed to agree.
+
+    Being index-free also makes the test exact for double-bond stereo: a
+    reflection cannot change E/Z, so two molecules that differ in a C=C
+    configuration never compare equal, and geometric isomers -- which are
+    distinct compounds, not an enantiomeric pair -- are both retained.
+
+    Args:
+        smi1: First SMILES string.
+        smi2: Second SMILES string.
+
+    Returns:
+        True only if the two are distinct molecules related by reflection.
+        False for identical molecules, for unparseable input, and for any
+        molecule with no tetrahedral center (it is its own mirror image).
+
+        Only tetrahedral configuration is inverted. A molecule that combines a
+        tetrahedral center with a square-planar, trigonal-bipyramidal or
+        octahedral center reflects incorrectly and two such diastereomers can
+        be reported as an enantiomeric pair. No supported neural network
+        potential covers the elements those stereo classes require.
+
+    Example:
+        >>> are_enantiomers('C[C@H](O)F', 'C[C@@H](O)F')
+        True
+        >>> are_enantiomers('C/C=C/C', 'C/C=C\\\\C')
+        False
+    """
+    mol1 = Chem.MolFromSmiles(smi1)
+    mol2 = Chem.MolFromSmiles(smi2)
+    if mol1 is None or mol2 is None:
+        return False
+    if Chem.MolToSmiles(mol1) == Chem.MolToSmiles(mol2):
+        # The same molecule is not its own enantiomeric partner.
+        return False
+    return _enantiomer_key(smi1) == _enantiomer_key(smi2)
 
 
 def enantiomer_helper(smiles: list[str]) -> list[str]:
@@ -83,24 +173,17 @@ def enantiomer_helper(smiles: list[str]) -> list[str]:
         >>> result = enantiomer_helper(smiles)
         >>> len(result)  # Only one enantiomer kept
         1
+        >>> enantiomer_helper(['C/C=C/C', 'C/C=C\\\\C'])  # E/Z are not enantiomers
+        ['C/C=C/C', 'C/C=C\\\\C']
     """
-    mols = [Chem.MolFromSmiles(smi) for smi in smiles]
-    stereo_centers = [
-        Chem.FindMolChiralCenters(mol, useLegacyImplementation=False) for mol in mols
-    ]
     non_enantiomers: list[str] = []
-    non_centers: list[list[tuple[int, str]]] = []
-    for i in range(len(stereo_centers)):
-        smi = smiles[i]
-        stereo = stereo_centers[i]
-        indicator = True
-        for j in range(len(non_centers)):
-            stereo_j = non_centers[j]
-            if enantiomer(stereo_j, stereo):
-                indicator = False
-        if indicator:
-            non_centers.append(stereo)
-            non_enantiomers.append(smi)
+    seen: set[tuple[str, ...]] = set()
+    for smi in smiles:
+        key = _enantiomer_key(smi)
+        if key in seen:
+            continue
+        seen.add(key)
+        non_enantiomers.append(smi)
     return non_enantiomers
 
 
@@ -135,9 +218,8 @@ def remove_enantiomers(inpath: str, out: str) -> dict[str, list[str]]:
         try:
             new_values = enantiomer_helper(values)
         except (ValueError, RuntimeError, AttributeError) as e:
-            # ValueError: from enantiomer() on mismatched stereo center lists
-            # RuntimeError: from RDKit SMILES parsing or FindMolChiralCenters
-            # AttributeError: if MolFromSmiles returns None and we try to access it
+            # Defensive against RDKit internals: if stereo perception raises for
+            # this group, keep every original SMILES rather than lose one.
             new_values = values
             logger.debug(f"Enantiomer detection failed for {key}: {type(e).__name__}: {e}")
             logger.warning(f"Enantiomers not removed for {key}")

--- a/src/Auto3D/utils/stereochemistry.py
+++ b/src/Auto3D/utils/stereochemistry.py
@@ -26,7 +26,8 @@ def enantiomer(l1: list[tuple[int, str]], l2: list[tuple[int, str]]) -> bool:
 
     Two molecules are enantiomers if all their stereo centers have opposite
     configurations. This function compares lists of (atom_index, stereo_type)
-    tuples from RDKit's FindMolChiralCenters.
+    tuples describing each stereo center's atom index and configuration
+    label, regardless of what produced them.
 
     Args:
         l1: List of (atom_index, stereo_type) tuples for first molecule.

--- a/tests/test_sdf_isomer_enumeration.py
+++ b/tests/test_sdf_isomer_enumeration.py
@@ -1,0 +1,117 @@
+"""The SDF input path enumerates stereoisomers like the SMILES path.
+
+Every test drives the production ``rdkit_sdf`` engine through
+``create_isomer_engine``, not RDKit in isolation, and inspects the SDF file
+Auto3D actually writes.
+"""
+from __future__ import annotations
+
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from Auto3D.isomers.factory import create_isomer_engine
+
+
+def _write_sdf(path, smiles: str, name: str, three_d: bool) -> None:
+    mol = Chem.MolFromSmiles(smiles)
+    mol.SetProp("_Name", name)
+    if three_d:
+        mol = Chem.AddHs(mol)
+        AllChem.EmbedMolecule(mol, randomSeed=3)
+    else:
+        AllChem.Compute2DCoords(mol)
+    with Chem.SDWriter(str(path)) as writer:
+        writer.write(mol)
+
+
+def _run_engine(job_dir, smiles, name, three_d, **kwargs):
+    """Run the engine and return {species_name: {cip codes seen}}."""
+    input_sdf = job_dir / f"{name}_in.sdf"
+    output_sdf = job_dir / f"{name}_out.sdf"
+    _write_sdf(input_sdf, smiles, name, three_d)
+
+    engine = create_isomer_engine(
+        "rdkit_sdf",
+        input_path=str(input_sdf),
+        output_path=str(output_sdf),
+        max_confs=6,
+        threshold=0.3,
+        n_jobs=1,
+        **kwargs,
+    )
+    engine.run()
+
+    per_species: dict[str, set[str]] = {}
+    for mol in Chem.SDMolSupplier(str(output_sdf), removeHs=False):
+        if mol is None:
+            continue
+        species = mol.GetProp("_Name").rsplit("_", 1)[0]
+        Chem.AssignStereochemistryFrom3D(mol)
+        codes = {code for _, code in
+                 Chem.FindMolChiralCenters(mol, useLegacyImplementation=False)}
+        per_species.setdefault(species, set()).update(codes)
+    return per_species
+
+
+class TestUnspecifiedCentersEnumerate:
+    def test_flat_sdf_yields_two_consistent_species(self, job_dir):
+        """A flat alanine gives two species, each with one configuration."""
+        per_species = _run_engine(job_dir, "CC(N)C(=O)O", "alanine", three_d=False)
+        assert len(per_species) == 2, f"expected two species, got {per_species}"
+        for name, codes in per_species.items():
+            assert len(codes) == 1, f"{name} is a stereochemical mixture: {codes}"
+        assert {next(iter(c)) for c in per_species.values()} == {"R", "S"}, per_species
+
+    def test_species_names_have_three_components(self, job_dir):
+        """Names are <species>_<isomer>_<conformer>, as the SMILES path emits.
+
+        ConformerRanker groups on the first underscore-delimited component, so
+        a two-component name would put both configurations back in one group.
+        """
+        input_sdf = job_dir / "alanine3_in.sdf"
+        output_sdf = job_dir / "alanine3_out.sdf"
+        _write_sdf(input_sdf, "CC(N)C(=O)O", "alanine", three_d=False)
+        create_isomer_engine(
+            "rdkit_sdf",
+            input_path=str(input_sdf),
+            output_path=str(output_sdf),
+            max_confs=4,
+            threshold=0.3,
+            n_jobs=1,
+        ).run()
+
+        names = [m.GetProp("_Name")
+                 for m in Chem.SDMolSupplier(str(output_sdf), removeHs=False)
+                 if m is not None]
+        assert names, "the engine wrote nothing"
+        for name in names:
+            assert name.count("_") == 2, f"unexpected name shape: {name}"
+            assert name.split("_")[0] == "alanine", name
+        assert {name.split("_")[1] for name in names} == {"0", "1"}, names
+
+
+class TestSpecifiedStereoIsNotDisturbed:
+    def test_3d_sdf_with_a_specified_center_stays_one_species(self, job_dir):
+        """3D SDF input was already safe and must remain a single species."""
+        per_species = _run_engine(
+            job_dir, "C[C@H](N)C(=O)O", "lalanine", three_d=True
+        )
+        assert len(per_species) == 1, f"a specified center was enumerated: {per_species}"
+        codes = next(iter(per_species.values()))
+        assert codes == {"S"}, f"the specified configuration changed: {codes}"
+
+
+class TestEnumerationDisabled:
+    def test_disabled_enumeration_warns_about_the_mixture(self, job_dir, caplog):
+        """With enumeration off the user is told the output is a mixture."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="Auto3D.isomer_engine"):
+            per_species = _run_engine(
+                job_dir, "CC(N)C(=O)O", "alanine_off", three_d=False,
+                enumerate_isomers=False,
+            )
+        assert len(per_species) == 1, f"enumeration ran while disabled: {per_species}"
+        assert any("unspecified stereo" in record.message for record in caplog.records), (
+            f"no warning about the mixture: {[r.message for r in caplog.records]}"
+        )

--- a/tests/test_sdf_isomer_enumeration.py
+++ b/tests/test_sdf_isomer_enumeration.py
@@ -55,22 +55,60 @@ def _run_engine(job_dir, smiles, name, three_d, **kwargs):
 
 class TestUnspecifiedCentersEnumerate:
     def test_flat_sdf_yields_two_consistent_species(self, job_dir):
-        """A flat alanine gives two species, each with one configuration."""
-        per_species = _run_engine(job_dir, "CC(N)C(=O)O", "alanine", three_d=False)
-        assert len(per_species) == 2, f"expected two species, got {per_species}"
-        for name, codes in per_species.items():
-            assert len(codes) == 1, f"{name} is a stereochemical mixture: {codes}"
-        assert {next(iter(c)) for c in per_species.values()} == {"R", "S"}, per_species
+        """A flat threonine gives two diastereomeric species, each consistent.
+
+        Threonine has two independent stereocenters, so its four raw
+        enumerated stereoisomers form two enantiomeric pairs; the enantiomer
+        filter reduces each pair to one representative, leaving two
+        diastereomers (unlike alanine's single stereocenter, whose R/S pair
+        is now collapsed to a single representative -- see
+        ``test_enantiomers_are_removed_but_geometric_isomers_are_not``).
+        "Consistent" here means every conformer of a given species reports
+        the identical per-atom CIP assignment, not that every code letter is
+        identical -- a two-center molecule legitimately has one R and one S
+        center at once, which is not a mixture.
+        """
+        input_sdf = job_dir / "threonine_in.sdf"
+        output_sdf = job_dir / "threonine_out.sdf"
+        _write_sdf(input_sdf, "CC(O)C(N)C(=O)O", "threonine", three_d=False)
+        create_isomer_engine(
+            "rdkit_sdf",
+            input_path=str(input_sdf),
+            output_path=str(output_sdf),
+            max_confs=6,
+            threshold=0.3,
+            n_jobs=1,
+        ).run()
+
+        per_species: dict[str, set[tuple[tuple[int, str], ...]]] = {}
+        for mol in Chem.SDMolSupplier(str(output_sdf), removeHs=False):
+            if mol is None:
+                continue
+            species = mol.GetProp("_Name").rsplit("_", 1)[0]
+            Chem.AssignStereochemistryFrom3D(mol)
+            assignment = tuple(
+                sorted(Chem.FindMolChiralCenters(mol, useLegacyImplementation=False))
+            )
+            per_species.setdefault(species, set()).add(assignment)
+
+        assert len(per_species) == 2, f"expected two diastereomers, got {per_species}"
+        for name, assignments in per_species.items():
+            assert len(assignments) == 1, (
+                f"{name} mixes configurations across conformers: {assignments}"
+            )
 
     def test_species_names_have_three_components(self, job_dir):
         """Names are <species>_<isomer>_<conformer>, as the SMILES path emits.
 
         ConformerRanker groups on the first underscore-delimited component, so
         a two-component name would put both configurations back in one group.
+        Threonine survives enantiomer dedup with two isomers (a diastereomeric
+        pair); alanine's single-stereocenter R/S pair now collapses to one
+        representative, so it no longer exercises the isomer-index component.
         """
-        input_sdf = job_dir / "alanine3_in.sdf"
-        output_sdf = job_dir / "alanine3_out.sdf"
-        _write_sdf(input_sdf, "CC(N)C(=O)O", "alanine", three_d=False)
+        input_sdf = job_dir / "threonine3_in.sdf"
+        output_sdf = job_dir / "threonine3_out.sdf"
+        _write_sdf(input_sdf, "CC(O)C(N)C(=O)O", "threonine", three_d=False)
         create_isomer_engine(
             "rdkit_sdf",
             input_path=str(input_sdf),
@@ -86,8 +124,22 @@ class TestUnspecifiedCentersEnumerate:
         assert names, "the engine wrote nothing"
         for name in names:
             assert name.count("_") == 2, f"unexpected name shape: {name}"
-            assert name.split("_")[0] == "alanine", name
+            assert name.split("_")[0] == "threonine", name
         assert {name.split("_")[1] for name in names} == {"0", "1"}, names
+
+    def test_enantiomers_are_removed_but_geometric_isomers_are_not(self, job_dir):
+        """One species per enantiomeric pair, both species for cis/trans.
+
+        Mirror images are degenerate under a reflection-invariant potential, so
+        the SMILES path drops one of each pair and this path must match. A
+        reflection cannot change E/Z, so geometric isomers are not a pair and
+        both must survive -- the same distinction the enantiomer filter draws.
+        """
+        chiral = _run_engine(job_dir, "CC(N)C(=O)O", "alanine_ec", three_d=False)
+        assert len(chiral) == 1, f"an enantiomer was kept: {sorted(chiral)}"
+
+        geometric = _run_engine(job_dir, "CC=CC", "butene_ec", three_d=False)
+        assert len(geometric) == 2, f"a geometric isomer was dropped: {sorted(geometric)}"
 
 
 class TestSpecifiedStereoIsNotDisturbed:

--- a/tests/test_sdf_isomer_enumeration.py
+++ b/tests/test_sdf_isomer_enumeration.py
@@ -167,3 +167,32 @@ class TestEnumerationDisabled:
         assert any("unspecified stereo" in record.message for record in caplog.records), (
             f"no warning about the mixture: {[r.message for r in caplog.records]}"
         )
+
+    def test_disabled_enumeration_warns_about_an_unspecified_double_bond(
+        self, job_dir, caplog
+    ):
+        """A flat, undrawn C=C must trigger the mixture warning too.
+
+        RDKit reports a double bond with no drawn geometry as
+        ``Chem.StereoSpecified.Unknown``, not ``Unspecified``. A count that
+        only checks ``Unspecified`` misses every unspecified C=C -- exactly
+        the case this warning exists for: a flat 2D fumaric/maleic-acid SDF
+        (``OC(=O)C=CC(=O)O``) would otherwise be written as one species
+        silently mixing two geometries ~5 kcal/mol apart.
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="Auto3D.isomer_engine"):
+            per_species = _run_engine(
+                job_dir, "OC(=O)C=CC(=O)O", "fumaric_off", three_d=False,
+                enumerate_isomers=False,
+            )
+        assert len(per_species) == 1, f"enumeration ran while disabled: {per_species}"
+        assert any(
+            "1 unspecified stereo element" in record.message
+            and "fumaric_off" in record.message
+            for record in caplog.records
+        ), (
+            "no warning naming the unspecified stereo element: "
+            f"{[r.message for r in caplog.records]}"
+        )

--- a/tests/test_stereo_identity.py
+++ b/tests/test_stereo_identity.py
@@ -97,14 +97,6 @@ class TestTautomerStereoPreservation:
 class TestSdfInputStereo:
     """A 2D SDF with an unspecified center must not be silently randomized."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="M19: RDKitSdfIsomer.run() (driven here through the real "
-        "create_isomer_engine('rdkit_sdf', ...) / RDKitSdfIsomerAdapter factory "
-        "path) calls only AddHs + EmbedMultipleConfs on the SDF-parsed mol, so "
-        "ETKDG returns a stereochemical mixture that is written to the output "
-        "SDF as numbered conformers under a single species name",
-    )
     def test_unspecified_center_is_enumerated_or_refused(self, job_dir):
         """Drive Auto3D's real SDF isomer engine on a flat, unspecified center.
 

--- a/tests/test_stereo_identity.py
+++ b/tests/test_stereo_identity.py
@@ -29,11 +29,6 @@ def _enumerate(smiles: str) -> list[str]:
 class TestEnantiomerPredicate:
     """The enantiomer predicate must not treat 'no stereocenters' as 'enantiomers'."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C1: enantiomer([], []) returns True vacuously -- the loop body "
-        "never executes and `indicator` stays True",
-    )
     def test_two_achiral_molecules_are_not_enantiomers(self):
         """Molecules with no stereocenters cannot be an enantiomeric pair."""
         assert enantiomer([], []) is False
@@ -42,11 +37,6 @@ class TestEnantiomerPredicate:
 class TestEZIsomersSurvive:
     """E/Z configuration is invariant under reflection, so it is never enantiomeric."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C1: FindMolChiralCenters does not report double-bond stereo, so "
-        "both descriptor lists are empty and one geometric isomer is discarded",
-    )
     def test_but_2_ene_keeps_both_geometric_isomers(self):
         """CC=CC must yield both E and Z after enantiomer filtering."""
         enumerated = _enumerate("CC=CC")
@@ -55,11 +45,6 @@ class TestEZIsomersSurvive:
         kept = enantiomer_helper(enumerated)
         assert len(kept) == 2, f"a geometric isomer was discarded: kept {kept}"
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C1: fumaric and maleic acid differ by ~5 kcal/mol and one is "
-        "discarded as an 'enantiomer' of the other",
-    )
     def test_fumaric_and_maleic_acid_both_survive(self):
         """The two diacids are distinct compounds, not an enantiomeric pair."""
         enumerated = _enumerate("OC(=O)C=CC(=O)O")

--- a/tests/test_stereo_identity.py
+++ b/tests/test_stereo_identity.py
@@ -57,12 +57,6 @@ class TestEZIsomersSurvive:
 class TestTautomerStereoPreservation:
     """Tautomer enumeration must not silently erase a specified stereocenter."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C2: RDKit TautomerEnumerator defaults to SetRemoveSp3Stereo(True), "
-        "so rd_taut writes stereo-stripped SMILES that are then re-enumerated "
-        "as unassigned -- a 50% chance of the wrong enantiomer",
-    )
     def test_specified_center_survives_tautomer_enumeration(self, job_dir):
         """At least one output tautomer must retain the input's specified center.
 

--- a/tests/test_stereo_identity.py
+++ b/tests/test_stereo_identity.py
@@ -9,7 +9,6 @@ Findings: C1 (E/Z collapse), C2 (tautomer stereo loss), M19 (SDF path).
 """
 from __future__ import annotations
 
-import pytest
 from rdkit import Chem
 from rdkit.Chem.EnumerateStereoisomers import (
     EnumerateStereoisomers,

--- a/tests/test_stereo_postopt.py
+++ b/tests/test_stereo_postopt.py
@@ -74,6 +74,48 @@ class TestDescriptorReading:
             conf.SetAtomPosition(i, position)
         assert stereo_descriptors_from_3d(mol) == before
 
+    def test_rotating_a_double_bond_past_ninety_degrees_is_detected(self):
+        """E/Z is the other half of the identity check and needs its own case.
+
+        Reflection cannot exercise it: mirroring is E/Z-invariant by
+        construction, so every other test here leaves the bond descriptor alone.
+        """
+        from rdkit.Chem import rdMolTransforms
+
+        mol = _embedded("C/C=C/C")
+        atoms_before, bonds_before = stereo_descriptors_from_3d(mol)
+        assert bonds_before, "no double-bond descriptor was read"
+
+        conf = mol.GetConformer()
+        rdMolTransforms.SetDihedralDeg(conf, 0, 1, 2, 3, 0.0)
+        atoms_after, bonds_after = stereo_descriptors_from_3d(mol)
+
+        assert bonds_after != bonds_before, "a rotated C=C was not detected"
+        assert atoms_after == atoms_before
+
+    def test_inverting_one_center_of_two_is_detected(self):
+        """A single inverted center must register even when others hold.
+
+        Reflection inverts every center at once, so on its own it cannot
+        distinguish "the molecule was mirrored" from "one center moved".
+        """
+        mol = _embedded("C[C@H](O)[C@H](F)Cl")
+        before = stereo_descriptors_from_3d(mol)
+        assert len(before[0]) == 2, f"expected two centers: {before}"
+
+        conf = mol.GetConformer()
+        idx = sorted(i for i, _ in before[0])[0]
+        neighbors = [n.GetIdx() for n in mol.GetAtomWithIdx(idx).GetNeighbors()]
+        first, second = neighbors[0], neighbors[1]
+        position_a = list(conf.GetAtomPosition(first))
+        position_b = list(conf.GetAtomPosition(second))
+        conf.SetAtomPosition(first, position_b)
+        conf.SetAtomPosition(second, position_a)
+
+        after = stereo_descriptors_from_3d(mol)
+        assert after[0] != before[0], "inverting one center was not detected"
+        assert len(after[0]) == len(before[0]), after
+
 
 class TestApplyOptimizedCoords:
     def test_inversion_is_detected_and_marked(self):
@@ -164,5 +206,5 @@ class TestFiltersExcludeStereoChangedRecords:
     def test_unmarked_records_still_survive_every_filter(self):
         """No regression for molecules that never went through the check."""
         mols = [_optimized(-1.0, changed=None), _optimized(-2.0, changed=None)]
-        assert len(filter_unique_optimized(mols, rmsd_threshold=0.3)) >= 1
-        assert len(filter_unique(mols, crit=0.3)) >= 1
+        assert len(filter_unique_optimized(mols, rmsd_threshold=0.3)) == 2
+        assert len(filter_unique(mols, crit=0.3)) == 2

--- a/tests/test_stereo_postopt.py
+++ b/tests/test_stereo_postopt.py
@@ -1,0 +1,168 @@
+"""Post-optimization stereochemistry validation (C9).
+
+An optimization that inverts a stereocenter or rotates through a double bond
+produces a molecule of different chemical identity than its title. check_connectivity
+compares interatomic distances against UFF radii and is stereo-blind, so nothing
+caught it. These tests pin the detector and the three filters that act on it.
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from Auto3D.filtering import filter_unique_optimized
+from Auto3D.ranking import ConformerRanker
+from Auto3D.utils.chemistry import filter_unique
+from Auto3D.utils.stereo_check import (
+    STEREO_CHANGED_PROP,
+    apply_optimized_coords,
+    stereo_descriptors_from_3d,
+    stereo_preserved,
+)
+
+
+def _embedded(smiles: str = "C/C=C/C[C@H](O)Cl") -> Chem.Mol:
+    """A molecule carrying both a tetrahedral center and a defined C=C."""
+    mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    assert AllChem.EmbedMolecule(mol, randomSeed=7) == 0
+    return mol
+
+
+def _reflected_coords(mol: Chem.Mol) -> list[list[float]]:
+    """Coordinates reflected through the origin -- the mirror image."""
+    conf = mol.GetConformer()
+    return [
+        [-conf.GetAtomPosition(i).x, -conf.GetAtomPosition(i).y, -conf.GetAtomPosition(i).z]
+        for i in range(mol.GetNumAtoms())
+    ]
+
+
+def _nudged_coords(mol: Chem.Mol) -> list[list[float]]:
+    """Coordinates displaced far too little to change any configuration."""
+    conf = mol.GetConformer()
+    return [
+        [conf.GetAtomPosition(i).x + 0.01, conf.GetAtomPosition(i).y,
+         conf.GetAtomPosition(i).z]
+        for i in range(mol.GetNumAtoms())
+    ]
+
+
+class TestDescriptorReading:
+    def test_reflection_inverts_the_center_and_spares_the_double_bond(self):
+        """Reflection flips tetrahedral configuration; E/Z is reflection-invariant."""
+        mol = _embedded()
+        atoms_before, bonds_before = stereo_descriptors_from_3d(mol)
+        assert atoms_before, "no tetrahedral descriptor was read"
+        assert bonds_before, "no double-bond descriptor was read"
+
+        conf = mol.GetConformer()
+        for i, position in enumerate(_reflected_coords(mol)):
+            conf.SetAtomPosition(i, position)
+        atoms_after, bonds_after = stereo_descriptors_from_3d(mol)
+
+        assert atoms_after != atoms_before, "reflection did not invert the center"
+        assert bonds_after == bonds_before, "reflection changed double-bond stereo"
+
+    def test_descriptors_are_stable_under_a_small_displacement(self):
+        """A geometry that barely moves reads identically."""
+        mol = _embedded()
+        before = stereo_descriptors_from_3d(mol)
+        conf = mol.GetConformer()
+        for i, position in enumerate(_nudged_coords(mol)):
+            conf.SetAtomPosition(i, position)
+        assert stereo_descriptors_from_3d(mol) == before
+
+
+class TestApplyOptimizedCoords:
+    def test_inversion_is_detected_and_marked(self):
+        mol = _embedded()
+        assert apply_optimized_coords(mol, _reflected_coords(mol)) is False
+        assert mol.GetProp(STEREO_CHANGED_PROP) == "True"
+        assert stereo_preserved(mol) is False
+
+    def test_a_preserved_geometry_is_marked_preserved(self):
+        mol = _embedded()
+        assert apply_optimized_coords(mol, _nudged_coords(mol)) is True
+        assert mol.GetProp(STEREO_CHANGED_PROP) == "False"
+        assert stereo_preserved(mol) is True
+
+    def test_the_coordinates_are_actually_written(self):
+        """The function must still do the job it replaced, not only flag."""
+        mol = _embedded()
+        target = [[float(i), 0.0, 0.0] for i in range(mol.GetNumAtoms())]
+        apply_optimized_coords(mol, target)
+        conf = mol.GetConformer()
+        for i in range(mol.GetNumAtoms()):
+            assert conf.GetAtomPosition(i).x == pytest.approx(float(i))
+
+    def test_a_molecule_without_stereo_is_never_flagged(self):
+        """An achiral molecule cannot change configuration."""
+        mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        assert AllChem.EmbedMolecule(mol, randomSeed=7) == 0
+        assert apply_optimized_coords(mol, _reflected_coords(mol)) is True
+        assert mol.GetProp(STEREO_CHANGED_PROP) == "False"
+
+
+class TestStereoPreservedPredicate:
+    def test_absent_property_reads_as_preserved(self):
+        """Molecules from paths that never run the check are not dropped."""
+        assert stereo_preserved(_embedded()) is True
+
+    def test_the_marker_is_read_case_insensitively(self):
+        mol = _embedded()
+        mol.SetProp(STEREO_CHANGED_PROP, "true")
+        assert stereo_preserved(mol) is False
+
+
+def _optimized(energy: float, changed: bool | None) -> Chem.Mol:
+    """A converged, connectivity-valid mol, optionally marked stereo-changed."""
+    mol = _embedded()
+    mol.SetProp("Converged", "True")
+    mol.SetProp("E_tot", str(energy))
+    if changed is not None:
+        mol.SetProp(STEREO_CHANGED_PROP, str(changed))
+    return mol
+
+
+class TestFiltersExcludeStereoChangedRecords:
+    def test_filter_unique_optimized_drops_the_changed_record(self):
+        kept = _optimized(-1.0, changed=False)
+        dropped = _optimized(-2.0, changed=True)
+        result = filter_unique_optimized([dropped, kept], rmsd_threshold=0.3)
+        assert len(result) == 1, f"expected only the preserved record: {len(result)}"
+        assert result[0].GetProp("E_tot") == "-1.0"
+
+    def test_filter_unique_drops_the_changed_record(self):
+        kept = _optimized(-1.0, changed=False)
+        dropped = _optimized(-2.0, changed=True)
+        result = filter_unique([dropped, kept], crit=0.3)
+        assert len(result) == 1, f"expected only the preserved record: {len(result)}"
+        assert result[0].GetProp("E_tot") == "-1.0"
+
+    def test_top_k_one_skips_the_changed_lowest_energy_record(self):
+        """k=1 takes a fast path that bypasses the RMSD filters entirely."""
+        dropped = _optimized(-2.0, changed=True)
+        kept = _optimized(-1.0, changed=False)
+        for mol, name in ((dropped, "probe_0_0"), (kept, "probe_0_1")):
+            mol.SetProp("_Name", name)
+        group = pd.DataFrame({
+            "names": ["probe", "probe"],
+            "energies": [-2.0, -1.0],
+            "mols": [dropped, kept],
+        })
+        ranker = ConformerRanker(
+            input_path="unused.sdf", out_path="unused_out.sdf", threshold=0.3, k=1
+        )
+        result = ranker.top_k(group, k=1)
+        assert len(result) == 1
+        assert result[0].GetProp("E_tot") == "-1.0", (
+            "top_k returned the stereo-changed lowest-energy conformer"
+        )
+
+    def test_unmarked_records_still_survive_every_filter(self):
+        """No regression for molecules that never went through the check."""
+        mols = [_optimized(-1.0, changed=None), _optimized(-2.0, changed=None)]
+        assert len(filter_unique_optimized(mols, rmsd_threshold=0.3)) >= 1
+        assert len(filter_unique(mols, crit=0.3)) >= 1

--- a/tests/test_stereochemistry_validation.py
+++ b/tests/test_stereochemistry_validation.py
@@ -130,13 +130,21 @@ class TestEnantiomerValidation:
         result = enantiomer(l1, l2)
         assert result is False
 
-    def test_enantiomer_empty_lists_returns_true(self):
-        """Empty lists (no stereo centers) should return True."""
+    def test_enantiomer_empty_lists_returns_false(self):
+        """Two molecules with no stereo centers are not an enantiomeric pair.
+
+        This asserted ``True`` until 4.0.0, matching the implementation's
+        vacuous result: the comparison loop never executed and ``indicator``
+        kept its ``True`` initial value. A molecule with no stereo centers is
+        its own mirror image, so it has no enantiomer to be paired with, and
+        the old behavior made ``enantiomer_helper`` discard distinct achiral
+        compounds -- including one geometric isomer of every unspecified C=C.
+        """
         l1: list[tuple[int, str]] = []
         l2: list[tuple[int, str]] = []
 
         result = enantiomer(l1, l2)
-        assert result is True
+        assert result is False
 
 
 class TestNoEnantiomerHelperValidation:

--- a/tests/test_stereochemistry_validation.py
+++ b/tests/test_stereochemistry_validation.py
@@ -57,19 +57,6 @@ class TestNoEnantiomerLengthMismatch:
         assert result is False
 
 
-def test_detect_stereo_change():
-    from rdkit import Chem
-    from rdkit.Chem import AllChem
-
-    from Auto3D.utils.stereo_check import stereo_changed
-
-    m = Chem.AddHs(Chem.MolFromSmiles("C[C@H](O)Cl"))
-    AllChem.EmbedMolecule(m, randomSeed=1)
-    Chem.AssignStereochemistryFrom3D(m)
-    assert stereo_changed(m, reference_smiles="C[C@H](O)Cl") is False
-    assert stereo_changed(m, reference_smiles="C[C@@H](O)Cl") is True
-
-
 class TestEnantiomerValidation:
     """Tests for the enantiomer() function validation."""
 

--- a/tests/test_tautomer_stereo.py
+++ b/tests/test_tautomer_stereo.py
@@ -8,6 +8,8 @@ tautomer engine through the production factory.
 """
 from __future__ import annotations
 
+from rdkit import Chem
+
 from Auto3D.isomers.factory import create_tautomer_engine
 
 
@@ -23,12 +25,38 @@ def _run_rd_taut(job_dir, smiles: str) -> list[str]:
 
 
 class TestSpecifiedStereoSurvives:
-    def test_center_remote_from_the_tautomeric_site_is_kept(self, job_dir):
-        """A center the tautomerization cannot reach keeps its configuration."""
-        outputs = _run_rd_taut(job_dir, "CC(=O)CCCC[C@H](C)O")
+    def test_center_on_the_tautomeric_site_survives_the_identity_tautomer(
+        self, job_dir
+    ):
+        """The input's own configuration survives the tautomer that does not shift it.
+
+        ``CC(=O)[C@@H](C)CC`` puts the stereocenter directly on the
+        tautomeric core -- the carbon alpha to the carbonyl -- unlike a
+        remote center, which RDKit's old default never touched either way
+        and so could not discriminate pre- from post-fix. On RDKit's old
+        default (no ``SetRemoveSp3Stereo(False)``), the tautomer enumerator
+        strips sp3 stereo from every atom in the core in every output,
+        including the identity tautomer (same skeleton as the input, no
+        enolization applied): it comes back as ``CCC(C)C(C)=O`` with the
+        configuration gone. With the fix, that same identity tautomer
+        instead keeps it (as ``CC[C@H](C)C(C)=O``). A tautomer whose
+        enolization genuinely consumes the stereocenter's fourth substituent
+        (``CCC(C)=C(C)O``) correctly still loses the descriptor -- this test
+        only checks the tautomer with the same skeleton as the input.
+        """
+        outputs = _run_rd_taut(job_dir, "CC(=O)[C@@H](C)CC")
         assert outputs, "tautomer enumeration returned nothing"
-        assert all("@" in smi for smi in outputs), (
-            f"a remote stereocenter was stripped: {sorted(outputs)}"
+        reference_skeleton = Chem.MolToSmiles(
+            Chem.MolFromSmiles("CC(=O)[C@@H](C)CC"), isomericSmiles=False
+        )
+        identity_tautomers = [
+            smi for smi in outputs
+            if Chem.MolToSmiles(Chem.MolFromSmiles(smi), isomericSmiles=False)
+            == reference_skeleton
+        ]
+        assert identity_tautomers, f"no identity tautomer in output: {sorted(outputs)}"
+        assert all("@" in smi for smi in identity_tautomers), (
+            f"the identity tautomer lost its stereocenter: {sorted(outputs)}"
         )
 
     def test_specified_double_bond_geometry_is_kept(self, job_dir):

--- a/tests/test_tautomer_stereo.py
+++ b/tests/test_tautomer_stereo.py
@@ -1,0 +1,105 @@
+"""Tautomer enumeration preserves specified stereo without inventing any.
+
+The C2 fix disables RDKit's default stereo stripping. That is only correct if
+it preserves descriptors the user specified while still dropping descriptors
+the tautomerization genuinely destroys, and while assigning none that the
+input never had. These tests pin all three, driving Auto3D's real ``rdkit``
+tautomer engine through the production factory.
+"""
+from __future__ import annotations
+
+from Auto3D.isomers.factory import create_tautomer_engine
+
+
+def _run_rd_taut(job_dir, smiles: str) -> list[str]:
+    """Drive TautomerEngine.rd_taut() and return the output SMILES."""
+    in_smi = job_dir / "taut_in.smi"
+    in_smi.write_text(f"{smiles} probe\n")
+    out_smi = job_dir / "taut_out.smi"
+    create_tautomer_engine(
+        "rdkit", str(in_smi), str(out_smi), pka_norm=False
+    ).run()
+    return [line.split()[0] for line in out_smi.read_text().splitlines() if line.strip()]
+
+
+class TestSpecifiedStereoSurvives:
+    def test_center_remote_from_the_tautomeric_site_is_kept(self, job_dir):
+        """A center the tautomerization cannot reach keeps its configuration."""
+        outputs = _run_rd_taut(job_dir, "CC(=O)CCCC[C@H](C)O")
+        assert outputs, "tautomer enumeration returned nothing"
+        assert all("@" in smi for smi in outputs), (
+            f"a remote stereocenter was stripped: {sorted(outputs)}"
+        )
+
+    def test_specified_double_bond_geometry_is_kept(self, job_dir):
+        """A specified C=C keeps its geometry through enumeration."""
+        outputs = _run_rd_taut(job_dir, "C/C=C(\\O)C")
+        assert outputs, "tautomer enumeration returned nothing"
+        assert any("/" in smi or "\\" in smi for smi in outputs), (
+            f"every tautomer lost the specified double-bond geometry: {sorted(outputs)}"
+        )
+
+    def test_a_cip_relabeled_center_is_not_mistaken_for_an_inversion(self, job_dir):
+        """A tautomer that only changes CIP priority must survive.
+
+        A keto/enol shift can flip an untouched center's CIP label from R to S
+        by changing a neighboring branch's substituent priority. The physical
+        arrangement is identical, so rejecting it would discard a valid
+        tautomer -- the filter must key on constitution, not on the label.
+        """
+        outputs = _run_rd_taut(job_dir, "OC[C@H](CC(=O)C)C=C")
+        assert len(outputs) == 3, (
+            f"a configuration-preserving tautomer was rejected: {sorted(outputs)}"
+        )
+        assert all("@" in smi for smi in outputs), sorted(outputs)
+
+
+class TestNoStereoIsInvented:
+    def test_a_center_destroyed_by_tautomerization_is_still_dropped(self, job_dir):
+        """Tautomers whose stereocenter carbon became sp2 carry no descriptor.
+
+        This is the over-correction guard: preserving stereo must not mean
+        asserting a configuration on an atom that no longer has one.
+        """
+        outputs = _run_rd_taut(job_dir, "C[C@H](C(=O)C)N")
+        assert outputs, "tautomer enumeration returned nothing"
+        # The enamine/imine tautomers flatten the stereocenter's own carbon.
+        flattened = [smi for smi in outputs if "C=C(N)" in smi or "C(=N)" in smi]
+        assert flattened, f"expected a tautomer that flattens the center: {sorted(outputs)}"
+        assert all("@" not in smi for smi in flattened), (
+            f"a destroyed stereocenter kept a descriptor: {sorted(flattened)}"
+        )
+
+    def test_an_achiral_input_gains_no_stereo(self, job_dir):
+        """A keto input must not acquire E/Z on the enol it tautomerizes to."""
+        outputs = _run_rd_taut(job_dir, "CCC(C)=O")
+        assert outputs, "tautomer enumeration returned nothing"
+        assert all("@" not in smi for smi in outputs), (
+            f"stereo was invented: {sorted(outputs)}"
+        )
+        assert all("/" not in smi and "\\" not in smi for smi in outputs), (
+            f"double-bond geometry was invented: {sorted(outputs)}"
+        )
+
+    def test_a_multi_step_tautomerization_does_not_emit_the_enantiomer(self, job_dir):
+        """D-erythrose must not come back as L-erythrose.
+
+        The 2,3-enediol flattens both centers, and RDKit restores a definite
+        tag rather than leaving them unspecified -- for one output, the input's
+        mirror image. Downstream these survive as two tautomer IDs with equal
+        energies and k=1 picks between them by file order.
+        """
+        from rdkit import Chem
+
+        d_erythrose = "O=C[C@H](O)[C@H](O)CO"
+        outputs = _run_rd_taut(job_dir, d_erythrose)
+        assert outputs, "tautomer enumeration returned nothing"
+        canonical = {Chem.MolToSmiles(Chem.MolFromSmiles(smi)) for smi in outputs}
+
+        assert Chem.MolToSmiles(Chem.MolFromSmiles(d_erythrose)) in canonical, (
+            f"the input configuration was lost: {sorted(canonical)}"
+        )
+        l_erythrose = Chem.MolToSmiles(Chem.MolFromSmiles("O=C[C@@H](O)[C@@H](O)CO"))
+        assert l_erythrose not in canonical, (
+            f"the enantiomer of the input was emitted as a tautomer: {sorted(canonical)}"
+        )

--- a/tests/test_utils_stereochemistry.py
+++ b/tests/test_utils_stereochemistry.py
@@ -12,6 +12,7 @@ from rdkit import Chem
 from Auto3D.utils.stereochemistry import (
     amend_configuration,
     amend_configuration_w,
+    are_enantiomers,
     check_value,
     create_enantiomer,
     enantiomer,
@@ -428,6 +429,48 @@ class TestEnantiomerHelperDiastereomers:
         assert len(result) == 2, (
             f"tartaric acid must yield one of L/D plus meso, once: {result}"
         )
+
+
+class TestAreEnantiomers:
+    """Direct tests for are_enantiomers().
+
+    ``enantiomer_helper`` filters via ``enantiomer_key`` instead of this
+    function, so nothing else in the pipeline calls it; it is public and
+    documented in CHANGELOG.md, so it gets its own coverage here rather than
+    being left an advertised-but-untested predicate.
+    """
+
+    def test_true_enantiomeric_pair(self):
+        """A single inverted tetrahedral center is a genuine enantiomer pair."""
+        assert are_enantiomers("C[C@H](O)F", "C[C@@H](O)F") is True
+
+    def test_identical_smiles_are_not_enantiomers(self):
+        """A molecule is not its own enantiomeric partner."""
+        assert are_enantiomers("CCO", "CCO") is False
+
+    def test_achiral_pair_is_not_enantiomers(self):
+        """Two different achiral molecules have no stereocenter to invert."""
+        assert are_enantiomers("CCO", "CCCO") is False
+
+    def test_geometric_pair_is_not_enantiomers(self):
+        """A reflection cannot change E/Z, so cis/trans isomers are not a pair."""
+        assert are_enantiomers("C/C=C/C", "C/C=C\\C") is False
+
+    def test_partially_inverted_two_center_diastereomer_is_not_enantiomers(self):
+        """Inverting only one of two centers gives a diastereomer, not a pair."""
+        assert are_enantiomers(
+            "C[C@H](O)[C@H](F)Cl", "C[C@@H](O)[C@H](F)Cl"
+        ) is False
+
+    def test_fully_inverted_two_center_pair_is_enantiomers(self):
+        """Inverting both centers of a two-center molecule gives its enantiomer."""
+        assert are_enantiomers(
+            "C[C@H](O)[C@H](F)Cl", "C[C@@H](O)[C@@H](F)Cl"
+        ) is True
+
+    def test_unparseable_smiles_returns_false_without_raising(self):
+        """Unparseable input is handled, not propagated as an exception."""
+        assert are_enantiomers("not_a_smiles(((", "C[C@H](O)F") is False
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_stereochemistry.py
+++ b/tests/test_utils_stereochemistry.py
@@ -73,12 +73,6 @@ class TestEnantiomerHelper:
         assert len(result) == 1
         assert result[0] in smiles
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C1: enantiomer([], []) returns True vacuously, so two distinct "
-        "achiral molecules are wrongly treated as an enantiomeric pair and one "
-        "is dropped by enantiomer_helper.",
-    )
     def test_enantiomer_helper_keeps_non_chiral(self):
         """Two distinct achiral molecules must both survive enantiomer filtering.
 
@@ -367,6 +361,73 @@ class TestIntegration:
                 assert enan_val == "@@"
             else:
                 assert enan_val == "@"
+
+
+class TestEnantiomerHelperDiastereomers:
+    """Regression guards: reflection inverts tetrahedral centers and leaves E/Z alone."""
+
+    def test_enantiomer_pair_with_a_double_bond_is_still_filtered(self):
+        """Same E/Z, inverted center: a genuine enantiomeric pair."""
+        smiles = ["C/C=C/C[C@H](O)C", "C/C=C/C[C@@H](O)C"]
+        result = enantiomer_helper(smiles)
+        assert len(result) == 1, f"a genuine enantiomer pair survived: {result}"
+
+    def test_diastereomers_both_survive(self):
+        """Different E/Z and inverted center: diastereomers, not enantiomers."""
+        smiles = ["C/C=C/C[C@H](O)C", "C/C=C\\C[C@@H](O)C"]
+        result = enantiomer_helper(smiles)
+        assert len(result) == 2, f"a diastereomer was discarded: {result}"
+
+    def test_two_centers_partially_inverted_both_survive(self):
+        """Inverting only one of two centers gives a diastereomer."""
+        smiles = ["C[C@H](O)[C@H](F)Cl", "C[C@@H](O)[C@H](F)Cl"]
+        result = enantiomer_helper(smiles)
+        assert len(result) == 2, f"a diastereomer was discarded: {result}"
+
+    def test_two_centers_fully_inverted_is_filtered(self):
+        """Inverting both centers gives the enantiomer."""
+        smiles = ["C[C@H](O)[C@H](F)Cl", "C[C@@H](O)[C@@H](F)Cl"]
+        result = enantiomer_helper(smiles)
+        assert len(result) == 1, f"a genuine enantiomer pair survived: {result}"
+
+    def test_duplicate_smiles_collapse_to_one(self):
+        """The same molecule twice is a duplicate, not an enantiomeric pair.
+
+        ``enantiomer_helper`` now filters on ``_enantiomer_key``, the sorted
+        set of a molecule's own canonical SMILES and its mirror image's.
+        Identical SMILES canonicalize to the same string and so share a key
+        regardless of the mirror-image half of that set, which is why the
+        duplicate is collapsed here -- not because of any special-case
+        equality check.
+        """
+        result = enantiomer_helper(["C[C@H](O)F", "C[C@H](O)F"])
+        assert len(result) == 1, result
+
+    def test_meso_duplicate_from_amend_configuration_is_collapsed(self):
+        """A meso form and its string-inverted twin are one molecule, not a pair.
+
+        ``amend_configuration_w`` runs before this filter and appends
+        ``create_enantiomer(smi)`` for every isomer with no partner in its
+        group. For a meso compound that string surgery produces a DIFFERENT
+        SMILES for the SAME molecule, which no pairwise enantiomer test can
+        catch -- the two are not an enantiomeric pair. Without collapsing it
+        the species is embedded, optimized and written twice.
+        """
+        meso = "O[C@H](C(=O)O)[C@@H](O)C(=O)O"
+        meso_inverted = "O[C@@H](C(=O)O)[C@H](O)C(=O)O"
+        assert Chem.MolToSmiles(Chem.MolFromSmiles(meso)) == Chem.MolToSmiles(
+            Chem.MolFromSmiles(meso_inverted)
+        ), "the two strings must denote one molecule or this test means nothing"
+
+        result = enantiomer_helper([
+            "O[C@H](C(=O)O)[C@H](O)C(=O)O",
+            meso,
+            "O[C@@H](C(=O)O)[C@@H](O)C(=O)O",
+            meso_inverted,
+        ])
+        assert len(result) == 2, (
+            f"tartaric acid must yield one of L/D plus meso, once: {result}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_stereochemistry.py
+++ b/tests/test_utils_stereochemistry.py
@@ -393,7 +393,7 @@ class TestEnantiomerHelperDiastereomers:
     def test_duplicate_smiles_collapse_to_one(self):
         """The same molecule twice is a duplicate, not an enantiomeric pair.
 
-        ``enantiomer_helper`` now filters on ``_enantiomer_key``, the sorted
+        ``enantiomer_helper`` now filters on ``enantiomer_key``, the sorted
         set of a molecule's own canonical SMILES and its mirror image's.
         Identical SMILES canonicalize to the same string and so share a key
         regardless of the mirror-image half of that set, which is why the


### PR DESCRIPTION
Closes four audit findings on stereochemical identity: **C1, C2, C9** (Critical) and **M19** (Major). Part of the 4.0.0 remediation; follows Phase 0 (verification harness) and Phase 1 (species conversion and padding mask).

## What was wrong

- **C1** — `enantiomer()` returned `True` for two empty descriptor lists, and `FindMolChiralCenters` never reports double-bond stereo. Every achiral molecule with an unspecified `C=C` lost one geometric isomer before embedding, on the default `enumerate_isomer=True` path. Fumaric and maleic acid differ by ~5 kcal/mol; which survived was decided by SMILES sort order, silently.
- **C2** — RDKit's `TautomerEnumerator` defaults to `SetRemoveSp3Stereo(True)`, so every tautomer was written stereo-stripped and re-enumerated downstream as unassigned. A submitted (S) molecule came back as (R) roughly half the time, at identical energy and undetectable from the output.
- **C9** — no post-optimization stereochemistry validation. The check existed as dead code whose docstring said its limitations had to be resolved first. `check_connectivity` is explicitly stereo-blind, so an optimization that inverted a center emitted a different compound under the original title, marked converged.
- **M19** — SDF input ignored `enumerate_isomers` entirely; the adapter did not accept it. A flat 2D SDF got an ETKDG-randomized mixture of configurations written as conformers of one species.

## What changed

`enantiomer_helper` now deduplicates by `enantiomer_key` — a molecule's canonical SMILES paired with its mirror image's. That is index-free, so it no longer depends on two independently canonicalized structures sharing an atom ordering, and it is exact on E/Z because a reflection cannot change double-bond geometry. It also collapses the meso duplicate that `amend_configuration_w` appends, which the previous pairwise comparison could not catch.

Tautomer enumeration preserves specified stereo and additionally rejects any tautomer reproducing the input's constitution with a different configuration — without that, D-erythrose emitted L-erythrose as a "tautomer" via the 2,3-enediol, reintroducing C2 by another route.

The SDF path enumerates stereoisomers, removes enantiomers by the same rule as the SMILES path, and names conformers `<species>_<isomer>_<conformer>`. An isomer ETKDG cannot embed is logged rather than silently absent.

Stereochemistry is compared before and after the coordinate write in `batchopt`, and again around clash relief. Both comparisons are taken from one molecule object, so atom indices match by construction and no atom mapping is needed — which is what made the previously dead check unusable.

## Verification

- 723 passed, 9 skipped, 13 xfailed, **0 xpassed**, 0 failed; `ruff` clean.
- Phase 0 tripwire inventory 25 → 19; the six markers owned by this phase are gone.
- No false positives for the post-optimization check across 230 ETKDG→MMFF pairs (sugars, steroids, peptides, epoxides, bridged bicyclics, sulfoxides); descriptors stable under 0.2 Å noise; amine nitrogen inversion and atropisomers never flagged.

## Behavior changes

Documented in `CHANGELOG.md` and `docs/source/migration-4.0.rst`. Molecules with unspecified double-bond stereo produce roughly twice the conformer groups; conformers whose configuration changed during optimization are excluded; `max_confs` is a per-stereoisomer budget on the SDF path; surviving records carry a `Stereo_changed` SD tag; `Auto3D.utils.stereo_check.stereo_changed` was removed.

## Known limits

`_run_parallel_embedding` (opt-in, off by default) still lacks the zero-conformer warning — closing it needs a return-contract change that breaks three existing tests. `relieve_clash` reads its stereo baseline on a geometry that is itself clashing; measured 0 of 650 realistic conformers reach that branch, and the limitation is documented in its docstring. Trivalent nitrogen is deliberately not covered, which is what keeps freely-inverting amines from being false positives.

The slow test tier and the `batchopt` call site both first execute in CI.
