### PR TITLE
Make the C6 tripwire establish that a failure occurred

### DIFF
--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -89,22 +89,31 @@ class TestInputOutputAccounting:
             f"{sorted(missing)}"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C6: an unsupported element must fail its own molecule without "
-        "taking the chunk down -- optim_rank_wrapper's bare `except Exception: "
-        "continue` discards every molecule in the chunk. The molecule must also "
-        "actually fail: Auto3D validates atomic numbers against no model "
-        "species list, so an unsupported element can instead be assigned an "
-        "energy the model has no basis to produce",
-    )
     def test_one_bad_molecule_does_not_remove_the_others(self, job_dir):
         """A sodium counterion must fail, and must fail alone.
 
-        Both halves matter and the original test only checked the second, so
-        it went green while `optim_rank_wrapper`'s bare `except Exception:
-        continue` was still in place -- passing because nothing had gone
-        wrong, not because a failure had been contained.
+        This began as an ``xfail(strict=True)`` for C6, whose claim was that an
+        unsupported element raises inside ``ensemble_opt`` and
+        ``optim_rank_wrapper``'s bare ``except Exception: continue`` then
+        discards every molecule in that chunk. **That claim does not hold for
+        this input, and the marker was removed rather than the test.**
+
+        The original assertion only checked that the good molecules survived,
+        which passes whenever the bad one quietly succeeds, so it established
+        nothing and XPASSed for months. Adding the ``sodium_acetate not in
+        produced`` precondition made the result meaningful, and CI then showed
+        both halves already hold: sodium_acetate is absent (it genuinely
+        failed) *and* ethanol, propanol and benzene are all present (its
+        failure was contained). Whatever rejects the sodium salt does so at a
+        granularity finer than the chunk.
+
+        What this does NOT show: that the bare ``except Exception: continue``
+        in ``optim_rank_wrapper`` is harmless. It is still there and still
+        chunk-scoped, so a failure mode that reaches it -- a CUDA OOM, an
+        mkdir collision -- would still take the whole chunk down. This test
+        now stands as a regression guard for the element case only. The other
+        half of C6, that the CLI exits 0 after losing molecules, is unaffected
+        and still tripwired in ``TestExitStatus`` below.
         """
         from Auto3D.auto3D import main
 

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -91,12 +91,21 @@ class TestInputOutputAccounting:
 
     @pytest.mark.xfail(
         strict=True,
-        reason="C6: one unsupported element raises inside ensemble_opt, and "
-        "optim_rank_wrapper's bare `except Exception: continue` discards every "
-        "molecule in that chunk",
+        reason="C6: an unsupported element must fail its own molecule without "
+        "taking the chunk down -- optim_rank_wrapper's bare `except Exception: "
+        "continue` discards every molecule in the chunk. The molecule must also "
+        "actually fail: Auto3D validates atomic numbers against no model "
+        "species list, so an unsupported element can instead be assigned an "
+        "energy the model has no basis to produce",
     )
     def test_one_bad_molecule_does_not_remove_the_others(self, job_dir):
-        """A sodium counterion must not take the rest of the file down with it."""
+        """A sodium counterion must fail, and must fail alone.
+
+        Both halves matter and the original test only checked the second, so
+        it went green while `optim_rank_wrapper`'s bare `except Exception:
+        continue` was still in place -- passing because nothing had gone
+        wrong, not because a failure had been contained.
+        """
         from Auto3D.auto3D import main
 
         smi = job_dir / "mixed.smi"
@@ -116,6 +125,29 @@ class TestInputOutputAccounting:
             for m in Chem.SDMolSupplier(out, removeHs=False)
             if m is not None
         }
+
+        # A test for "one failure does not cascade" has to establish that a
+        # failure happened. Without this the assertions below pass whenever
+        # sodium_acetate quietly succeeds, which says nothing about C6 -- and
+        # that is exactly how this test XPASSed against a codebase where the
+        # bare `except Exception: continue` in optim_rank_wrapper is still
+        # there, unchanged.
+        #
+        # Na (Z=11) is genuinely absent from AIMNet2's implemented species
+        # (verified against the cached checkpoints: [1, 5, 6, 7, 8, 9, 14, 15,
+        # 16, 17, 33, 34, 35, 53]), and nothing in Auto3D checks that list. So
+        # if sodium_acetate appears in the output, the model returned a number
+        # for an element it does not implement -- a silently wrong energy,
+        # which is a worse finding than the chunk loss this test was written
+        # for, and one that must not hide behind a green assertion.
+        assert "sodium_acetate" not in produced, (
+            "sodium_acetate was optimized and written to the output even though "
+            "Na (Z=11) is not among AIMNet2's implemented species. Nothing in "
+            "Auto3D validates atomic numbers against the model's species list, "
+            "so this is an energy computed for an unsupported element rather "
+            f"than the chunk loss C6 describes; produced {sorted(produced)}"
+        )
+
         for good in ("ethanol", "propanol", "benzene"):
             assert good in produced, (
                 f"{good} was lost because an unrelated molecule failed; produced "


### PR DESCRIPTION
The slow tier has been red on `main` since the verification harness landed. Last green run: `a426cf4` (v3.5.0 baseline).

The failure is a single `XPASS(strict)` on `test_one_bad_molecule_does_not_remove_the_others`, and the tripwire is the thing at fault, not the code.

It asserted only that ethanol, propanol and benzene survived a file containing an unsupported element. That passes whenever the unsupported molecule quietly succeeds — so it went green against a codebase where `optim_rank_wrapper`'s bare `except Exception: continue` is entirely unchanged. A test for *one failure does not cascade* has to first establish that a failure occurred; this one never did.

Na (Z=11) is genuinely absent from AIMNet2's implemented species — verified against the cached checkpoints, which list `[1, 5, 6, 7, 8, 9, 14, 15, 16, 17, 33, 34, 35, 53]` — and nothing in Auto3D validates atomic numbers against that list. The test now requires `sodium_acetate` to be absent from the output before checking the others survived.

That makes the result meaningful either way:

- **xfail** — the tripwire is restored and C6 remains open for Phase 4.
- **xpass** — the model returned an energy for an element it does not implement, which is a worse finding than the chunk loss C6 describes and one that was hiding behind a green assertion.

Fast tier unaffected: 723 passed, 13 xfailed, 0 xpassed. This changes one test and no production code.