### PR TITLE
Phase 4: accounting and diagnosis (C6, C7, C8, M21, M22, M30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **`auto3d run` exits non-zero (code `6`) when input molecules are missing
+  from the output.** `_finalize_output` previously raised only when *zero*
+  outputs existed at all, so a run that silently lost 9 of 10 chunks -- to
+  memory pressure, a crashed worker, or any other per-chunk failure -- still
+  printed a results summary and exited `0`, indistinguishable from complete
+  success to a calling shell script (`auto3d run --json && next_step`). The
+  results summary and, with `--json`, the JSON document are still printed
+  *before* the process exits -- a scripted consumer always receives a
+  parseable description of what happened, even on the run that is about to
+  signal failure. `6` (`EXIT_PARTIAL_SUCCESS`) extends `cli/errors.py`'s
+  existing `0`-`5` exit-code convention (`2` configuration/input, `3`
+  dependency, `4` GPU, `5` model) with the next unused code, rather than
+  reusing `1` and making a partial run indistinguishable from a crash.
+  Scripts that treat exit `0` as "everything succeeded" must now also check
+  for `6`, and can inspect the JSON `failures` list (or
+  `WorkflowResult.failures` from the Python API) for which molecules were
+  missing.
+
 - **`calc_thermo` relaxes more inputs, and relaxes them further, before it will
   compute a Hessian.** The entry gate and the optimizer's convergence
   threshold both now use `opt_tol` (`DEFAULT_THERMO_CONVERGENCE_THRESHOLD`,
@@ -283,6 +301,105 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   names before checking for a same-named file on disk, so a stray file named
   e.g. `ANI2xt` in the working directory can no longer shadow the built-in
   engine.
+
+- **Unknown `optimizing_engine` names are rejected up front instead of
+  failing silently inside a worker.** `optimizing_engine` validation
+  prefix-matched on `"aimnet2"`, so a typo like `"aimnet2-2025x"` passed
+  both `utils/validation.py`'s `check_valid_configuration` and the CLI's
+  `CLIConfig` schema, survived config parsing, and only failed once a
+  spawned worker tried to resolve it -- where `optim_rank_wrapper`'s
+  per-chunk handler swallowed the error and the run quietly produced
+  nothing. Both call sites now resolve the name through
+  `models/preflight.py`'s `resolve_engine_name` (a pure, offline registry
+  lookup), which raises `ConfigurationError` listing the valid registry
+  aliases. `CLIConfig._validate_engine` and the three auxiliary CLI
+  commands (`auto3d energy`/`optimize`/`thermo`) are now validated the same
+  way -- those three previously passed `engine` straight through to
+  `calc_spe`/`opt_geometry`/`calc_thermo` with no validation at all, despite
+  a comment claiming it was "validated downstream". That downstream
+  validation still does not exist: `calc_spe`, `opt_geometry`, and
+  `calc_thermo` themselves remain unguarded, so a script that calls any of
+  the three directly with a bad engine name gets exactly the old, opaque
+  failure. Only the CLI layer (`auto3d run`/`energy`/`optimize`/`thermo`)
+  rejects it up front.
+
+- **The optimizing model's availability is verified, without loading it,
+  before any worker is forked.** `WorkflowOrchestrator._validate_input` (and
+  `smiles2mols`) call `preflight_model`, which resolves the engine name and
+  confirms the model file can be obtained -- a cache hit, a successful
+  download and checksum, or an ANI2xt/custom-path model that exists on disk
+  -- before any chunk is processed. A cold cache with no network, a cached
+  file whose checksum no longer matches, or an unwritable cache directory
+  previously surfaced only inside a spawned worker's per-chunk handler,
+  reported as an opaque "no 3D structure converged"; the failure now names
+  the network, the cache directory (respecting `AIMNET_CACHE_DIR`), and, for
+  a checksum mismatch, the exact file to delete. `preflight_model` resolves
+  only the model's on-disk path
+  (`aimnet.calculators.model_registry.get_registry_model_path`); it does
+  **not** construct or load the model. An earlier version of this fix built
+  the full model to validate it, which made the fast test suite construct a
+  real AIMNet2 model six times over (wall time 20s -> 75s, peak RSS 1.38GB
+  on a ~2GB box) and would have made every fast CI job attempt a network
+  download; that version was replaced with the path-only check before
+  landing, and `preflight_model` also lost its unused `device` parameter.
+  Separately, the cache-directory-naming fallback inside `preflight_model`'s
+  error handlers could itself raise: calling the real `get_cache_dir()` from
+  inside a handler re-ran the same failing `os.makedirs` call that triggered
+  the handler, double-faulting into a raw `PermissionError` instead of the
+  intended `ModelLoadError` and losing the `AIMNET_CACHE_DIR` hint along
+  with it. The directory is now resolved once, before the `try`, as a plain
+  string that cannot itself fail. The two "no 3D structure converged"
+  messages in `workflow.py` were reworded to state what pre-flight has
+  actually ruled out, replacing a stock three-reason guess ("1. Allocated
+  memory is not enough; 2. invalid SMILES; 3. Patience is too small") that
+  named causes irrelevant to, e.g., a cold cache behind a firewall.
+
+- **`main()`/`smiles2mols()` report every input molecule that produced no
+  output, by ID.** `find_smiles_not_in_sdf` existed, was exported, and was
+  tested, but had no production caller, so a molecule that vanished
+  mid-pipeline left no trace anywhere reachable from `main()`'s return
+  value. `WorkflowOrchestrator._finalize_output` now reconciles the original
+  input against the final, decoded output SDF -- via `find_smiles_not_in_sdf`
+  for `.smi` input, and a new `find_ids_not_in_sdf` for `.sdf` input -- and
+  populates `self.failures`; `main()` carries that list through as
+  `WorkflowResult.failures` (the existing `str`-subclass return type, not a
+  new one -- it already carried `n_molecules`/`n_conformers`).
+  `smiles2mols` calls `find_smiles_not_in_sdf` directly and logs the result,
+  since its `list[Chem.Mol]` return has no carrier for a failure list.
+  `auto3d run`'s CLI summary and `--json` output now report *which*
+  molecules failed, replacing a count derived as
+  `max(0, input_count - molecules)` that silently floored to zero whenever
+  tautomer enumeration made the output count legitimately exceed the input
+  count and could never say which molecule was lost.
+
+- **Warnings logged via `get_logger(__name__)` now reach the run's
+  `Auto3D.log` file, not just stderr.** `get_logger` produces loggers under
+  the `Auto3D.*` tree, but the worker processes' `QueueHandler` (the
+  mechanism that feeds `Auto3D.log`) was attached only to the case-distinct,
+  unrelated `auto3d` tree, so no warning issued through `get_logger` --
+  including several diagnostics added earlier in this release, e.g. the
+  stereochemistry-change count and the symmetry-number default warning --
+  ever reached the run log; `Auto3D.workflow`, `Auto3D.utils.chemistry`, and
+  one warning in `Auto3D.batch_opt.batchopt` avoided this only by logging
+  through `auto3d` directly. `workflow_workers.py`'s worker functions
+  (`isomer_wrapper`, `optim_rank_wrapper`) now attach a `QueueHandler` to
+  both the `auto3d` and `Auto3D` trees. A gap remains: a warning fired
+  purely in the main process, outside `chunk_manager`/`workflow.py` (i.e.
+  not inside a spawned worker, and not one of the call sites above that
+  already logs through `auto3d`), still reaches only stderr, not
+  `Auto3D.log`.
+
+- **`--verbose` shows a full traceback for an unexpected (non-`Auto3DError`)
+  failure.** `handle_error` previously printed only `str(error)` at every
+  verbosity, so an internal bug (e.g. a bare `KeyError('ID')` from a missing
+  SDF property) rendered as an unactionable red box with no file, line, or
+  stack -- and every CLI entry point funnels through `handle_error`. The
+  panel now always names the exception type and points at `-v`/`--verbose`;
+  passing `-v` (or, for the legacy `auto3d parameters.yaml` entry point,
+  setting `verbose: true` in the YAML, which has no `-v` flag of its own)
+  additionally prints the traceback via `rich.traceback.Traceback`. Wired
+  into every CLI command (`run`, `energy`, `optimize`, `thermo`, `tautomers`,
+  `models test`, and the legacy YAML path).
 
 ## [3.5.0] - 2026-06-13
 

--- a/docs/source/migration-4.0.rst
+++ b/docs/source/migration-4.0.rst
@@ -267,3 +267,75 @@ conformers, not 24. A molecule with two independent unspecified centers (e.g.
 threonine) keeps two surviving diastereomers, so the same ``max_confs=12``
 does produce up to 24 there. A stereoisomer ETKDG cannot embed is now named in
 a logged warning instead of disappearing from the output with no trace.
+
+CLI behavior changes
+--------------------
+
+``auto3d run`` exits non-zero when molecules are missing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+3.x's ``_finalize_output`` raised only when *zero* outputs existed at all. A
+run that silently lost 9 of 10 chunks -- to memory pressure, a crashed
+worker, or any other per-chunk failure -- still printed a results summary
+and exited ``0``, indistinguishable from a fully successful run to a calling
+shell script (``auto3d run --json && next_step``).
+
+4.0 exits ``6`` whenever any input molecule produced no output. The results
+summary and, with ``--json``, the JSON document are still printed *before*
+that exit -- a scripted consumer always receives a parseable description of
+what happened, even on the run that is about to signal failure. ``6``
+(``EXIT_PARTIAL_SUCCESS``) extends the exit codes ``cli/errors.py`` already
+used for exceptions raised before or during the run (``0`` success, ``1``
+generic, ``2`` configuration/input, ``3`` dependency, ``4`` GPU, ``5``
+model) with the next unused code, rather than reusing ``1`` and making a
+partial run indistinguishable from a crash.
+
+If your pipeline currently checks only ``$? -eq 0`` -- or chains
+``auto3d run --json && next_step`` -- a run with partial output now stops
+it where 3.x would have continued silently. Check ``$?`` explicitly against
+``6`` if a partial run is something you want to detect and handle rather
+than treat as a hard failure, and inspect the JSON ``failures`` list (or
+``WorkflowResult.failures`` from the Python API, see below) for which
+molecules were missing.
+
+Missing molecules are reported by ID
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+3.x's CLI derived a failure *count* as ``max(0, input_count - molecules)``.
+That floored to zero whenever tautomer enumeration made the output count
+legitimately exceed the input count, and it could never say *which*
+molecule was lost -- ``results.failures`` was hardcoded to an empty list
+regardless. Separately, ``find_smiles_not_in_sdf`` existed, was exported,
+and was tested, but had no production caller at all, so a molecule that
+vanished mid-pipeline left no trace anywhere reachable from ``main()``'s
+return value.
+
+4.0 reconciles the original input against the final output SDF and reports
+every missing molecule by ID:
+
+- ``main()`` returns the missing input IDs as ``WorkflowResult.failures`` --
+  the same ``str``-subclass return type as before (it already carried
+  ``n_molecules``/``n_conformers``; this is not a new return type).
+- ``auto3d run``'s summary and ``--json`` output list them under
+  ``failures`` (each entry has a ``name`` and an ``error``).
+- ``smiles2mols()`` logs missing molecules directly, since its
+  ``list[Chem.Mol]`` return has no carrier for a failure list.
+- SDF input is reconciled too, via a new ``find_ids_not_in_sdf`` that reads
+  the expected IDs from the source SDF's ``_Name`` property (``.smi`` input
+  keeps using ``find_smiles_not_in_sdf``).
+
+.. code:: python
+
+   result = main(options)
+   if result.failures:
+       print(f"{len(result.failures)} molecule(s) produced no output:")
+       for mol_id in result.failures:
+           print(f"  {mol_id}")
+
+A known limitation: engine-name validation (``resolve_engine_name``) was
+also tightened this release, but only at the CLI layer (``CLIConfig`` and
+the ``energy``/``optimize``/``thermo`` commands) and inside
+``WorkflowOrchestrator``/``smiles2mols``. Calling ``calc_spe``,
+``opt_geometry``, or ``calc_thermo`` directly from Python with an
+unrecognized ``model_name`` is still unguarded and fails the same opaque
+way it did in 3.x.

--- a/docs/superpowers/plans/2026-07-31-phase4-accounting-diagnosis.md
+++ b/docs/superpowers/plans/2026-07-31-phase4-accounting-diagnosis.md
@@ -1,0 +1,602 @@
+# Phase 4 — Accounting and Diagnosis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A run that loses molecules says so, exits non-zero, and names them; a run that fails to load its model says what actually failed and what to do about it.
+
+**Architecture:** The pipeline was built to *survive* partial failure — per-chunk isolation, per-molecule skips, sentinel-guaranteed queue drains — with no compensating reporting layer. Failure is reliably contained and just as reliably invisible. This phase adds the reporting layer: reconcile inputs against outputs, propagate that into the exit code and the JSON, move model resolution into the parent process where its errors are actionable, and make internal errors debuggable.
+
+**Tech Stack:** Python 3.11+, RDKit, Typer/Rich CLI, pytest.
+
+**Source spec:** `docs/superpowers/specs/2026-07-30-audit-remediation-design.md` §7.
+**Audit manifest:** `.claude/review-manifests/review-2026-07-30-package-audit.md` (C6, C7, C8, M21, M22, M30).
+
+---
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+**Authorship (repository owner's global rules, mechanically enforced):**
+- Commits authored solely by Olexandr Isayev. No `Co-Authored-By`, no `Signed-off-by`, no generated-by footers.
+- No commit message, branch name, PR title or body may mention AI assistance, Claude, Copilot, or any AI tool.
+- Never modify `user.name`, `user.email`, or `commit.gpgsign`.
+
+**Development box limits — hard:**
+- ~2 GB RAM; 8 CUDA devices in active use by other work.
+- **Never run `pytest -m slow`.** **Never load a neural network potential.** Never trigger a model download.
+- `torchani` is not installed. `ase` 3.27.0 is.
+- Only test command: `pytest tests/ -q -rxX -m "not slow"`, or a narrower node ID carrying the same `-m "not slow"`.
+
+**Git discipline:**
+- One new commit per task. **Never `git commit --amend`.**
+- **Never `git checkout`, `git worktree`, `git restore` or `git stash`** — an agent destroyed uncommitted work that way. Apply and revert verification mutations with Edit in both directions.
+- `git add` only the files a task names. Never `git add -A` or `git add .`.
+- Verify each message with `git log -1 --format=%B | cat -A`.
+
+**Release vehicle:** 4.0.0. Breaking changes approved. **B8** (`auto3d run` exits non-zero when molecules are missing) is this phase's planned break.
+
+**Tripwire discipline.** Five markers are owned here. **Three are fast-tier and must be run**; two are slow and first execute in CI.
+
+| Finding | Node ID | Tier | Task |
+|---|---|---|---|
+| M21 | `test_model_preflight.py::TestRegistryNameValidation::test_unknown_registry_name_is_rejected_up_front` | fast | 1 |
+| C8 | `test_model_preflight.py::TestColdCacheDiagnosis::test_network_failure_names_the_network` | fast | 2 |
+| M22 | `test_model_preflight.py::TestColdCacheDiagnosis::test_checksum_mismatch_says_to_delete_the_file` | fast | 2 |
+| C7 | `test_pipeline_e2e.py::TestInputOutputAccounting::test_every_input_is_present_or_reported` | **slow** | 3 |
+| C6 | `test_pipeline_e2e.py::TestExitStatus::test_cli_exits_nonzero_when_molecules_are_missing` | **slow** | 4 |
+
+- The owning task deletes its marker in the same commit. `strict=True` makes a passing xfail a hard failure.
+- **Tasks 3 and 4 own slow tripwires they cannot run.** Each must additionally write a hermetic test of the same logic, so the fix has local evidence.
+- Repository-wide inventory must go **15 → 10**.
+
+**Style:** American spelling. Type hints on new functions. `ruff check src/ tests/` clean before every commit. Match surrounding comment density.
+
+**Verified environment facts — measured on this box, do not re-derive:**
+- `aimnet.calculators.model_registry.resolve_registry_model_name(name) -> str` is a **pure offline dict lookup** against a bundled YAML. Measured: `"aimnet2"` → `aimnet2-wb97m-d3_0`; `"aimnet2-2025"` → `aimnet2-b973c-2025-d3_0`; `"aimnet2-2025x"` → `ValueError: Model aimnet2-2025x not found in the registry.`; `"bogus"` → same; **`"AIMNET"` → ValueError**, so Auto3D's own alias must be mapped to `aimnet2` before resolution.
+- `load_model_registry()` returns a dict with keys `models`, `aliases`, `families`. There are 24 model names and 33 aliases, including `aimnet2`, `aimnet2-2025`, `aimnet2-nse`, `aimnet2-pd`, `aimnet2-rxn`, `aimnet2-b973c`, `aimnet2-wb97m`.
+- `utils/validation.py` currently accepts **any** string beginning `aimnet2` (case-insensitively), which is why `aimnet2-2025x` reaches a worker.
+- `find_smiles_not_in_sdf(smi, sdf) -> list[tuple[str, str]]` lives at `utils/file_ops.py:793`, returns `(mol_id, smiles)` tuples matching its docstring, and has **zero production callers**.
+- `cli/commands/run.py:142` derives `failed_count = max(0, input_count - molecules)`; `:149` hardcodes `failures=[]`.
+- `cli/errors.py:72` `handle_error(error)` takes no verbosity argument and prints only `str(error)`.
+
+---
+
+## File Structure
+
+| File | Change | Task |
+|---|---|---|
+| `src/Auto3D/utils/validation.py` | Registry names resolved, not prefix-matched | 1 |
+| `src/Auto3D/models/preflight.py` | **Create** — parent-process model resolution and diagnosis | 2 |
+| `src/Auto3D/utils/validation.py` | `check_input` calls pre-flight | 2 |
+| `src/Auto3D/workflow.py` | Reconciliation; the three-wrong-reasons message | 2, 3 |
+| `src/Auto3D/auto3D.py` | `smiles2mols` reconciliation | 3 |
+| `src/Auto3D/cli/commands/run.py` | Real `failed_count`, populated `failures`, non-zero exit | 4 |
+| `src/Auto3D/cli/errors.py` | Verbosity-aware error display | 5 |
+| `src/Auto3D/utils/logging_config.py` | Module loggers reach the run log | 6 |
+| `CHANGELOG.md`, `docs/source/migration-4.0.rst` | B8 and the diagnosis changes | 7 |
+
+---
+
+### Task 1: M21 — a typo'd registry name must fail immediately
+
+`utils/validation.py` accepts any `optimizing_engine` beginning with `aimnet2`, so `aimnet2-2025x` passes validation, survives config parsing, and fails inside a worker process where the error is swallowed by `optim_rank_wrapper`'s chunk handler. The registry lookup that would reject it is a pure offline dict read.
+
+**Files:**
+- Modify: `src/Auto3D/utils/validation.py` (the `valid_engines` block, around line 328)
+- Modify: `tests/test_model_preflight.py` (delete the M21 decorator)
+
+**Interfaces:**
+- Produces: `resolve_engine_name(name: str) -> str` in `src/Auto3D/models/preflight.py` — maps Auto3D's `AIMNET` alias onto the registry's `aimnet2` and resolves through `resolve_registry_model_name`, raising `ConfigurationError` with the valid names listed. Task 2 reuses it.
+
+- [ ] **Step 1: Delete the M21 xfail decorator and watch the test fail**
+
+In `tests/test_model_preflight.py`, delete only the decorator whose `reason` begins `M21:`. Keep the body verbatim. Then:
+
+```bash
+pytest tests/test_model_preflight.py -q -rxX -m "not slow"
+```
+
+Record the failure. **This tripwire is fast-tier — you must run it.**
+
+- [ ] **Step 2: Create the resolver**
+
+Create `src/Auto3D/models/preflight.py`:
+
+```python
+"""Parent-process model resolution, so a bad model name fails before forking.
+
+Everything here runs in the process that parses the configuration, before any
+worker is spawned. A name resolved here produces an error the user sees with a
+traceback and a suggestion; the same failure inside a worker is swallowed by
+``optim_rank_wrapper``'s per-chunk handler and surfaces, if at all, as a run
+that quietly produced nothing.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from Auto3D.constants import MODEL_ANI2X, MODEL_ANI2XT
+from Auto3D.exceptions import ConfigurationError
+
+#: Auto3D's historical name for the default AIMNet2 model. The registry does
+#: not know it -- resolve_registry_model_name("AIMNET") raises -- so it is
+#: mapped here rather than leaking Auto3D's vocabulary into aimnet's.
+AIMNET_ALIAS = "AIMNET"
+AIMNET_DEFAULT = "aimnet2"
+
+
+def resolve_engine_name(name: str) -> str:
+    """Resolve an ``optimizing_engine`` value to a concrete model identifier.
+
+    Args:
+        name: An engine name: ``ANI2x``, ``ANI2xt``, ``AIMNET``, an aimnet
+            registry name or alias, or a path to a custom NNP file.
+
+    Returns:
+        The value unchanged for the named engines and custom paths, or the
+        resolved registry model name for an aimnet name or alias.
+
+    Raises:
+        ConfigurationError: If the name is none of those. The message lists
+            the aimnet aliases, because a typo like ``aimnet2-2025x`` is the
+            case this exists to catch and "not found in the registry" alone
+            does not tell the user what they may write instead.
+    """
+    if name in (MODEL_ANI2X, MODEL_ANI2XT):
+        return name
+    if Path(name).exists():
+        return name
+
+    from aimnet.calculators.model_registry import (
+        load_model_registry,
+        resolve_registry_model_name,
+    )
+
+    candidate = AIMNET_DEFAULT if name.upper() == AIMNET_ALIAS else name
+    try:
+        return resolve_registry_model_name(candidate)
+    except ValueError as exc:
+        registry = load_model_registry()
+        aliases = sorted(registry.get("aliases", {}))
+        raise ConfigurationError(
+            f"Unknown optimizing_engine {name!r}. Use {MODEL_ANI2X!r}, "
+            f"{MODEL_ANI2XT!r}, {AIMNET_ALIAS!r}, a path to a custom NNP file, "
+            f"or an aimnet registry name. Registry aliases: "
+            f"{', '.join(aliases)}."
+        ) from exc
+```
+
+Confirm `MODEL_ANI2X` and `MODEL_ANI2XT` exist in `constants.py` with those names before importing them; if they differ, use the real ones and report the difference.
+
+- [ ] **Step 3: Call it from `check_input`**
+
+In `src/Auto3D/utils/validation.py`, replace the prefix-matching block:
+
+```python
+    valid_engines = {"ANI2x", "ANI2xt", "AIMNET"}
+    if (
+        optimizing_engine not in valid_engines
+        and not optimizing_engine.lower().startswith("aimnet2")
+        and not Path(optimizing_engine).exists()
+    ):
+        errors.append(
+            f"optimizing_engine must be one of {valid_engines}, an aimnet registry "
+            f"name (aimnet2, aimnet2-2025, ...), or a valid path to a custom model. "
+            f"Got: {optimizing_engine}"
+        )
+```
+
+with a call to the resolver, appending its message to `errors` rather than raising, so this function keeps collecting every configuration problem before reporting:
+
+```python
+    # Resolve rather than prefix-match: `aimnet2-2025x` starts with "aimnet2"
+    # and so used to pass here, then failed inside a worker where
+    # optim_rank_wrapper's per-chunk handler swallowed it. The registry lookup
+    # is a pure offline dict read against a bundled YAML, so validating costs
+    # nothing.
+    from Auto3D.models.preflight import resolve_engine_name
+
+    try:
+        resolve_engine_name(optimizing_engine)
+    except ConfigurationError as exc:
+        errors.append(str(exc))
+```
+
+Confirm `ConfigurationError` is already imported in that module; add the import if not.
+
+- [ ] **Step 4: Run the tripwire, then the suite**
+
+```bash
+pytest tests/test_model_preflight.py -q -rxX -m "not slow"
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+```
+
+Expected: the M21 test passes, the suite is green, 0 xpassed. If any existing test asserted the old permissive behavior — a config using a name that merely starts with `aimnet2` — that test encoded the defect; update it and say so in your report.
+
+- [ ] **Step 5: Add coverage the tripwire does not have**
+
+Append to `tests/test_model_preflight.py`, in its own class:
+
+```python
+class TestEngineNameResolution:
+    """resolve_engine_name is a pure offline lookup -- no model is loaded."""
+
+    def test_named_engines_pass_through(self):
+        from Auto3D.models.preflight import resolve_engine_name
+
+        assert resolve_engine_name("ANI2x") == "ANI2x"
+        assert resolve_engine_name("ANI2xt") == "ANI2xt"
+
+    def test_auto3d_alias_maps_onto_the_registry(self):
+        """The registry does not know 'AIMNET'; Auto3D maps it to aimnet2."""
+        from Auto3D.models.preflight import resolve_engine_name
+
+        assert resolve_engine_name("AIMNET") == resolve_engine_name("aimnet2")
+
+    def test_a_registry_alias_resolves(self):
+        from Auto3D.models.preflight import resolve_engine_name
+
+        assert resolve_engine_name("aimnet2-2025") == "aimnet2-b973c-2025-d3_0"
+
+    def test_a_typo_names_the_alternatives(self):
+        from Auto3D.exceptions import ConfigurationError
+        from Auto3D.models.preflight import resolve_engine_name
+
+        with pytest.raises(ConfigurationError) as excinfo:
+            resolve_engine_name("aimnet2-2025x")
+        message = str(excinfo.value)
+        assert "aimnet2-2025x" in message
+        assert "aimnet2-2025" in message, f"valid names not listed: {message}"
+
+    def test_a_custom_path_passes_through(self, tmp_path):
+        from Auto3D.models.preflight import resolve_engine_name
+
+        model = tmp_path / "custom.pt"
+        model.write_bytes(b"")
+        assert resolve_engine_name(str(model)) == str(model)
+```
+
+Verify the expected resolved value for `aimnet2-2025` against the installed registry rather than trusting this plan; if it differs, use the real value and report it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Auto3D/models/preflight.py src/Auto3D/utils/validation.py tests/test_model_preflight.py
+git commit -m "fix: resolve registry model names instead of prefix-matching
+
+optimizing_engine accepted any string beginning 'aimnet2', so a typo like
+aimnet2-2025x passed validation, survived config parsing, and failed inside a
+worker process where optim_rank_wrapper's per-chunk handler swallowed it --
+surfacing as a run that quietly produced nothing.
+
+resolve_registry_model_name is a pure offline dict lookup against a bundled
+YAML, so validating the name costs nothing and turns that into an immediate
+error listing the registry aliases. Auto3D's own 'AIMNET' alias is mapped onto
+the registry's 'aimnet2', which the registry does not otherwise know."
+```
+
+---
+
+### Task 2: C8 and M22 — the model must be resolved before forking, and its failures must be actionable
+
+`AIMNet2Adapter.__init__` constructs the model inside the worker, so a cold cache behind a firewall, a corrupt download, or an unwritable cache directory all surface as a swallowed exception and the three-wrong-reasons message. Worse, `aimnet`'s downloader is otherwise sound (`mkstemp`, streamed hashing, `os.replace`, `finally` cleanup) — but a **checksum mismatch on an existing file leaves the bad file in place**, so every subsequent run fails identically, forever, with no hint that deleting one file would fix it.
+
+**Files:**
+- Modify: `src/Auto3D/models/preflight.py`
+- Modify: `src/Auto3D/utils/validation.py`
+- Modify: `src/Auto3D/workflow.py` (the three-wrong-reasons message)
+- Modify: `tests/test_model_preflight.py` (delete the C8 and M22 decorators)
+
+**Interfaces:**
+- Consumes: `resolve_engine_name` from Task 1.
+- Produces: `preflight_model(engine: str, device) -> None` — resolves and constructs the model in the calling process, translating failures into `ModelError` / `DependencyError` with actionable text.
+
+- [ ] **Step 1: Read the two tripwires first**
+
+`test_network_failure_names_the_network` and `test_checksum_mismatch_says_to_delete_the_file` are **fast-tier**, so they run here and they define the contract. Read both before writing anything, and note exactly what strings they require. Write the implementation to satisfy the tests as written; if a test demands something you believe is wrong, report it rather than changing the test.
+
+- [ ] **Step 2: Delete both decorators and run them**
+
+Delete only the decorators whose reasons begin `C8:` and `M22:`. Run:
+
+```bash
+pytest tests/test_model_preflight.py -q -rxX -m "not slow"
+```
+
+Record both failures.
+
+- [ ] **Step 3: Implement `preflight_model`**
+
+Add to `src/Auto3D/models/preflight.py`. The exact exception types and message content must match what the two tripwires assert — read them first. The shape:
+
+```python
+def preflight_model(engine: str, device) -> None:
+    """Resolve and construct the model in this process, before any fork.
+
+    Constructing here converts three failure modes that are otherwise invisible
+    into errors the user can act on: a cold cache with no network, a cached
+    file whose checksum no longer matches, and a cache directory that cannot
+    be written. Inside a worker each of these is caught by
+    ``optim_rank_wrapper``'s per-chunk handler and reported as "no 3D structure
+    converged", which names none of them.
+
+    Raises:
+        ConfigurationError: The engine name is not recognized.
+        ModelError: The model could not be obtained or loaded.
+        DependencyError: A required optional dependency is missing.
+    """
+```
+
+Translate at minimum:
+- a network failure (`requests.exceptions.RequestException` and friends) into text naming the network, the cache directory, and `AIMNET_CACHE_DIR`;
+- a checksum mismatch into text naming **the exact file to delete** — this is M22's whole point, since the bad file otherwise persists;
+- a permission or disk error into text naming the cache directory;
+- a missing optional dependency into `DependencyError`.
+
+Let anything you cannot classify propagate unchanged rather than mislabeling it. Check `src/Auto3D/exceptions.py` for the real exception names before using them.
+
+- [ ] **Step 4: Call it from `check_input`, and only there**
+
+`check_input` runs in the parent process for `main()` and `smiles2mols`. Call `preflight_model` after the configuration errors are collected and reported, so a user with several problems still sees all of them before the model load is attempted.
+
+**Do not call it from the worker.** Confirm by reading that no worker path invokes `check_input`.
+
+- [ ] **Step 5: Replace the three-wrong-reasons message**
+
+In `src/Auto3D/workflow.py`'s `_finalize_output`, the `if not output_files:` branch raises:
+
+```
+The optimization engine did not run, or no 3D structure converged.
+The reason might be one of the following:
+1. Allocated memory is not enough;
+2. The input SMILES encodes invalid chemical structures;
+3. Patience is too small
+```
+
+With pre-flight in place, a model failure can no longer reach here, so the remaining causes are genuinely about the run. Rewrite it to say what is actually knowable: no chunk produced an output file, the model loaded successfully (pre-flight passed), and the likely causes are memory, input validity, or convergence settings — and point at the log for the per-chunk errors that were already recorded. Do not keep a numbered list of guesses that includes a cause now excluded by construction.
+
+- [ ] **Step 6: Run both tripwires, the suite, and commit**
+
+```bash
+pytest tests/test_model_preflight.py -q -rxX -m "not slow"
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+git add src/Auto3D/models/preflight.py src/Auto3D/utils/validation.py src/Auto3D/workflow.py tests/test_model_preflight.py
+git commit -m "fix: resolve and load the model before spawning workers
+
+AIMNet2Adapter constructed the model inside the worker, so a cold cache with
+no network, a corrupt cached file, or an unwritable cache directory all
+surfaced as a swallowed exception and a message offering three causes, none of
+which applied. Resolution and construction now happen in the process that
+parses the configuration, where the failure can name the network, the cache
+directory, AIMNET_CACHE_DIR, and -- for a checksum mismatch -- the exact file
+to delete. aimnet's downloader is otherwise sound, but a mismatch on an
+existing file leaves it in place, so every later run failed identically."
+```
+
+---
+
+### Task 3: C7 — every input must be accounted for
+
+Neither `_finalize_output` nor `smiles2mols` reconciles inputs against outputs. `find_smiles_not_in_sdf` exists at `utils/file_ops.py:793`, is exported, and is tested, with **zero production callers** — the same dead-code shape as C9 in Phase 2.
+
+**Files:**
+- Modify: `src/Auto3D/workflow.py` (`_finalize_output`)
+- Modify: `src/Auto3D/auto3D.py` (`smiles2mols`)
+- Modify: `tests/test_pipeline_e2e.py` (delete the C7 decorator)
+- Modify or create: a fast test module for the hermetic coverage
+
+**Interfaces:**
+- Produces: reconciliation results reachable from the workflow — at minimum a logged, per-molecule report of missing inputs, and a structure Task 4 can read to populate `results.failures`. Decide the carrier (an attribute on the workflow object, a returned structure) and state it in your report, because Task 4 depends on it.
+
+- [ ] **Step 1: Delete the C7 decorator**
+
+Delete only the decorator whose reason begins `C7:`. **This tripwire is slow-marked and needs a loaded potential — do not attempt to run it.** Note that its body reads `getattr(out, "failures", None)`, where `out` is the path string returned by `main()`; read the test carefully and decide whether satisfying it requires changing what `main()` returns. If it does, that is a breaking change and must be recorded for Task 7.
+
+- [ ] **Step 2: Wire reconciliation into `_finalize_output`**
+
+After the output is combined and decoded, compare the original input against the final SDF using `find_smiles_not_in_sdf`, and report every missing molecule by ID. Use the **decoded** output and the **original** input path, not the encoded temp file, or the IDs will not match — verify which paths hold which at that point rather than assuming.
+
+For SDF input, `find_smiles_not_in_sdf` reads a `.smi`; check whether it can be applied and, if not, implement the equivalent for SDF input or scope the reconciliation to SMILES input and say so explicitly in your report and in the code comment. Silently reconciling only one input format would be its own invisible gap.
+
+- [ ] **Step 3: Wire reconciliation into `smiles2mols`**
+
+`smiles2mols` takes a list of SMILES and returns a list of mols. Reconcile on the same basis and report what is missing.
+
+- [ ] **Step 4: Hermetic coverage**
+
+The C7 tripwire cannot run here, so write a fast test that pins the reconciliation logic directly: build a `.smi` and an `.sdf` where a known ID is absent, and assert the reporting path names it. Do not require a real pipeline run.
+
+Also add a test proving `find_smiles_not_in_sdf` now has a production caller — for example that the reconciliation function the workflow calls is the one in `file_ops`, or by asserting on the reported output rather than on the helper in isolation. The point of the finding is that the helper was never called; a test that only exercises the helper would not detect a regression to that state.
+
+- [ ] **Step 5: Suite, lint, commit**
+
+```bash
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+git add <the files you changed>
+git commit -m "fix: reconcile inputs against outputs
+
+find_smiles_not_in_sdf existed, was exported, and was tested, with no
+production caller -- so a molecule that vanished mid-pipeline left no trace in
+the output or anywhere reachable from main()'s return value. Both main() and
+smiles2mols now reconcile their inputs against what was produced and report
+every missing molecule by ID."
+```
+
+---
+
+### Task 4: C6 — losing molecules must not exit 0
+
+`_finalize_output` raises only when **zero** outputs exist, so 9 of 10 failed chunks exits 0 and `auto3d run … --json && next_step` proceeds on a partial run. `cli/commands/run.py:142` derives `failed_count = max(0, input_count - molecules)` — whose `max(0, …)` also absorbs the tautomer case where outputs legitimately exceed inputs — and `:149` hardcodes `failures=[]` with a comment admitting the details "are not yet wired through the workflow."
+
+**Files:**
+- Modify: `src/Auto3D/cli/commands/run.py`
+- Modify: `src/Auto3D/cli/results.py` if the carrier requires it
+- Modify: `tests/test_pipeline_e2e.py` (delete the C6 decorator)
+
+**Interfaces:**
+- Consumes: whatever Task 3 exposes. Read Task 3's report before starting.
+
+- [ ] **Step 1: Delete the C6 decorator**
+
+Delete only the decorator whose reason begins `C6:`. **Slow-marked, needs a potential — do not run it.** After this task, `tests/test_pipeline_e2e.py` must carry zero xfail markers.
+
+- [ ] **Step 2: Replace the derived count and populate the failures**
+
+Use Task 3's reconciliation instead of `max(0, input_count - molecules)`. Record why the old form was wrong in a comment: it inferred failure from a count difference, so it reported zero failures whenever tautomer enumeration produced more outputs than inputs, and it could never name which molecule was lost.
+
+Populate `results.failures` with real `FailedMolecule` entries.
+
+- [ ] **Step 3: Exit non-zero (B8)**
+
+`execute_run` currently ends its `try` with `print_results_summary` and never raises. Raise `SystemExit` with a non-zero code when molecules are missing, **after** printing the summary and the JSON so a `--json` consumer still receives a parseable document describing the failure. Confirm by reading `output_json` that the JSON is written before the exit.
+
+- [ ] **Step 4: Hermetic coverage**
+
+Write a fast test that pins the exit behavior without a pipeline run — construct a `WorkflowResults` with failures and assert the exit path raises non-zero, and one with none and assert it does not. Verify by mutation that removing the exit makes it fail.
+
+- [ ] **Step 5: Suite, lint, commit**
+
+```bash
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+git add <the files you changed>
+git commit -m "fix!: exit non-zero when molecules are missing
+
+_finalize_output raised only when zero outputs existed, so a run that lost 9
+of 10 chunks exited 0 and \`auto3d run --json && next_step\` proceeded on a
+partial result. failed_count was derived as max(0, inputs - outputs), which
+reported zero failures whenever tautomer enumeration produced more outputs
+than inputs and could never name the molecule that was lost; results.failures
+was hardcoded empty.
+
+Both now come from the reconciliation, and a run that lost molecules exits
+non-zero after printing its summary and JSON."
+```
+
+---
+
+### Task 5: M30 — an internal error must be debuggable
+
+`handle_error` takes no verbosity argument, so an unexpected internal error prints a red box containing only `str(error)` — `'ID'` for a missing SDF property — with no file, line, or stack **at any verbosity**. Every CLI entry point funnels through it, so today no Auto3D CLI failure is debuggable without editing source.
+
+**Files:**
+- Modify: `src/Auto3D/cli/errors.py`
+- Modify: every CLI command that calls `handle_error` (find them with grep)
+- Modify or create: a fast test module
+
+- [ ] **Step 1: Thread verbosity through**
+
+Give `handle_error` a `verbose: int = 0` parameter and print a traceback when it is above zero. Every command already accepts `verbose`; pass it. An `Auto3DError` at `verbose=0` should keep its current clean presentation — the hint is the feature — and gain the traceback only when asked. A non-`Auto3DError` is by definition unexpected, so consider whether it should say how to get the traceback even at `verbose=0`; decide and justify in your report.
+
+- [ ] **Step 2: Tests**
+
+Pin: a known `Auto3DError` at `verbose=0` shows the message and hint and no traceback; the same at `verbose=1` shows a traceback; an unexpected `KeyError('ID')` shows something that identifies where it came from. Use Typer's `CliRunner` or call `handle_error` directly, whichever exercises the real path — and say which you chose and why.
+
+- [ ] **Step 3: Suite, lint, commit**
+
+```bash
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+git add <the files you changed>
+git commit -m "fix: show a traceback for internal errors under --verbose
+
+handle_error printed only str(error) at every verbosity, so an unexpected
+internal failure surfaced as a red box containing 'ID' with no file, line or
+stack. Every CLI entry point funnels through it, so no Auto3D CLI failure was
+debuggable without editing source."
+```
+
+---
+
+### Task 6: module warnings must reach the run log
+
+`utils/logging_config.get_logger(__name__)` produces loggers named `Auto3D.*`, while `workflow_workers.py` attaches its `QueueHandler` to a logger named `"auto3d"` — a different, case-distinct tree, not an ancestor. **No warning issued through `get_logger` reaches the run log.** This is not in the audit; it was found during Phase 3, and it belongs here because it is the mechanism by which several of this phase's new diagnostics would otherwise be invisible.
+
+**Files:**
+- Modify: `src/Auto3D/utils/logging_config.py` and/or `src/Auto3D/workflow_workers.py`
+- Modify or create: a fast test module
+
+- [ ] **Step 1: Establish the current behavior with a test**
+
+Write a failing test first: emit a warning through `get_logger("Auto3D.something")`, with a handler attached the way the worker attaches its own, and assert the record is received. Confirm it fails today. **Record that output** — it is the evidence the defect is real, and this task has no tripwire.
+
+- [ ] **Step 2: Fix the tree**
+
+Two candidate fixes: have `get_logger` return loggers under the `auto3d` tree, or have the worker attach to the tree `get_logger` actually uses. Read both modules and choose; the criterion is that a module warning reaches the run log **without** duplicating records for handlers already attached elsewhere. Verify no message is emitted twice — a duplicate-logging regression would be a poor trade.
+
+Check for other handler attachment sites before choosing (`grep -rn "getLogger\|addHandler" src/`).
+
+- [ ] **Step 3: Verify the Phase 3 diagnostics now surface**
+
+Phase 3 added warnings that currently go nowhere — the stereo-change count in `batch_opt/batchopt.py`, the σ default, the multiplicity rejection. Confirm at least one of them now reaches a handler attached the worker's way, and say which you checked.
+
+- [ ] **Step 4: Suite, lint, commit**
+
+```bash
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+git add <the files you changed>
+git commit -m "fix: deliver module warnings to the run log
+
+get_logger(__name__) produced loggers under 'Auto3D.*' while the worker
+attached its QueueHandler to 'auto3d' -- a different, case-distinct tree and
+not an ancestor -- so no warning issued through get_logger ever reached the
+run log. Several diagnostics added in this release, including the
+stereochemistry-change count and the symmetry-number default, were written to
+a logger nothing was listening to."
+```
+
+---
+
+### Task 7: Release documentation
+
+**Files:**
+- Modify: `CHANGELOG.md`, `docs/source/migration-4.0.rst`
+
+**Interfaces:**
+- Consumes: Tasks 1-6. **Read the commits first** (`git log -p` over this phase) and describe what landed. Earlier phases diverged from their plans during review and the docs had to follow the code; expect the same.
+
+- [ ] **Step 1: CHANGELOG**
+
+Lead Breaking Changes with **B8**: `auto3d run` exits non-zero when molecules are missing. Scripts relying on exit 0 with partial output must handle the new code. Note the JSON is still written before the exit.
+
+Then: unknown engine names are rejected up front; the model is loaded before workers spawn, so its failures name the network, the cache directory and the file to delete; `main()`/`smiles2mols` report missing molecules; `--verbose` shows a traceback; module warnings now reach the run log.
+
+Under Fixed, one entry per finding, matching the register of the existing entries.
+
+- [ ] **Step 2: Migration guide**
+
+Add a section on the exit-code change — the one most likely to break a pipeline — and one on the new failure reporting. Match the file's existing RST heading style; underlines must be at least as long as their title, and longer is valid.
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+python -c "import docutils.core, pathlib; docutils.core.publish_doctree(pathlib.Path('docs/source/migration-4.0.rst').read_text())"
+pytest tests/ -q -rxX -m "not slow"
+ruff check src/ tests/
+git add CHANGELOG.md docs/source/migration-4.0.rst
+git commit -m "docs: record the accounting and diagnosis changes for 4.0.0"
+```
+
+A full Sphinx build may fail on a pre-existing missing `nbsphinx`; that is not yours to fix — say so if you hit it.
+
+---
+
+## Phase exit criteria
+
+1. `pytest tests/ -q -rxX -m "not slow"` — all pass, **0 xpassed**, 0 failed.
+2. `grep -rn 'reason="[CM][0-9]' tests/ | wc -l` returns **10**.
+3. `grep -rn 'C6:\|C7:\|C8:\|M21:\|M22:' tests/` returns nothing.
+4. `ruff check src/ tests/` clean.
+5. `grep -rn 'find_smiles_not_in_sdf' src/` shows at least one production caller outside `utils_file.py`'s deprecated shim.
+6. `grep -n 'Patience is too small' src/` returns nothing.
+
+## Known limits of local verification — state these in the final report
+
+- C6 and C7's tripwires are slow-marked and need a loaded potential; CI is their first execution. This is why Tasks 3 and 4 each write hermetic coverage.
+- No end-to-end `auto3d run` happens on this box, so the exit code is verified by unit coverage until CI.
+- The cold-cache and checksum paths are simulated, not reproduced against a real network failure.

--- a/src/Auto3D/auto3D.py
+++ b/src/Auto3D/auto3D.py
@@ -28,7 +28,7 @@ from Auto3D.utils import (
     create_chunk_meta_names,
     reorder_sdf,
 )
-from Auto3D.utils.file_ops import smiles2smi
+from Auto3D.utils.file_ops import find_smiles_not_in_sdf, smiles2smi
 from Auto3D.utils.logging_config import configure_logging, get_logger
 
 # Pipeline workers live in workflow_workers to break the auto3D<->workflow import
@@ -62,7 +62,9 @@ def main(
     Returns:
         A :class:`Auto3D.results.WorkflowResult` -- a ``str`` subclass holding
         the output SDF path (so it works anywhere the path string did) plus the
-        run's ``n_molecules`` / ``n_conformers`` counts.
+        run's ``n_molecules`` / ``n_conformers`` counts and its ``failures``
+        list (input molecule IDs reconciled away as missing from the output,
+        see ``WorkflowOrchestrator._finalize_output``).
 
     Raises:
         SystemExit: If input validation fails or no structures converge.
@@ -89,7 +91,13 @@ def main(
     from Auto3D.results import WorkflowResult
 
     orchestrator = WorkflowOrchestrator(args, progress_callback=progress_callback)
-    return WorkflowResult(orchestrator.run())
+    output_path = orchestrator.run()
+    # getattr, not a direct attribute access: mirrors the defensive read the
+    # CLI already does for n_molecules/n_conformers (cli/commands/run.py), so
+    # a test/mock that swaps in a bare stand-in for the orchestrator (e.g.
+    # test_mp_start_method.py) still gets a valid WorkflowResult instead of an
+    # AttributeError.
+    return WorkflowResult(output_path, failures=getattr(orchestrator, "failures", None))
 
 def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
     """Find low-energy conformers for a list of SMILES.
@@ -175,6 +183,16 @@ def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
                               args.threshold, k=k, window=window)
         _ = rank_engine.run()
         conformers = reorder_sdf(meta["output"], path0)
+
+        # Reconcile inputs against outputs (C7): smiles2mols never runs
+        # encode_ids/decode_ids -- path0 already holds the same (InChIKey-based)
+        # ids that ranking/reorder_sdf wrote to meta["output"] -- so this is
+        # already the right pair to compare, no decoding needed. This call's
+        # own logging is the report; smiles2mols keeps its `list[Chem.Mol]`
+        # return type (unlike main(), nothing here reads a `.failures` carrier
+        # today) so a missing input surfaces in the log rather than silently
+        # nowhere, closing the "zero production callers" gap for this path too.
+        find_smiles_not_in_sdf(path0, meta["output"])
 
         logger.info("Energy unit: Hartree if implicit.")
     return conformers

--- a/src/Auto3D/auto3D.py
+++ b/src/Auto3D/auto3D.py
@@ -142,10 +142,8 @@ def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
         # (C8/M22), before the `optimizing` step below constructs its own copy
         # for real work. A cold cache with no network, a corrupted cached
         # file, or an unwritable cache directory would otherwise surface only
-        # deep inside ranking/optimization as an opaque failure. The device
-        # argument is unused (see ``preflight_model``'s docstring) but kept
-        # for call-site stability.
-        preflight_model(args.optimizing_engine, torch.device("cpu"))
+        # deep inside ranking/optimization as an opaque failure.
+        preflight_model(args.optimizing_engine)
 
         # smi to sdf
         meta = create_chunk_meta_names(path0, tmpdirname)

--- a/src/Auto3D/auto3D.py
+++ b/src/Auto3D/auto3D.py
@@ -130,15 +130,13 @@ def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
         args.input_format = 'smi'
         check_input(args)
 
-        # Resolve and construct the optimizing model HERE (C8/M22), before the
-        # `optimizing` step below constructs its own copy for real work. A
-        # cold cache with no network, a corrupted cached file, or an
-        # unwritable cache directory would otherwise surface only deep inside
-        # ranking/optimization as an opaque failure. cpu is used regardless of
-        # the run's real device: these failure modes (cold cache, checksum
-        # mismatch, unwritable cache dir) are download/cache issues, not
-        # device issues, and cpu avoids contending for GPU memory just to
-        # validate.
+        # Resolve the engine name and verify the model is obtainable HERE
+        # (C8/M22), before the `optimizing` step below constructs its own copy
+        # for real work. A cold cache with no network, a corrupted cached
+        # file, or an unwritable cache directory would otherwise surface only
+        # deep inside ranking/optimization as an opaque failure. The device
+        # argument is unused (see ``preflight_model``'s docstring) but kept
+        # for call-site stability.
         preflight_model(args.optimizing_engine, torch.device("cpu"))
 
         # smi to sdf

--- a/src/Auto3D/auto3D.py
+++ b/src/Auto3D/auto3D.py
@@ -21,6 +21,7 @@ from Auto3D.batch_opt.batchopt import optimizing
 from Auto3D.config import Auto3DOptions
 from Auto3D.exceptions import ConfigurationError
 from Auto3D.isomers import IsomerEngineFactory
+from Auto3D.models.preflight import preflight_model
 from Auto3D.ranking import ranking
 from Auto3D.utils import (
     check_input,
@@ -104,7 +105,11 @@ def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
         List of RDKit Mol objects representing low-energy conformers.
 
     Raises:
-        ConfigurationError: If neither k nor window is specified.
+        ConfigurationError: If neither k nor window is specified, or the
+            optimizing engine name is not recognized.
+        ModelLoadError: If the optimizing model could not be obtained or
+            loaded.
+        DependencyError: If a required optional dependency is missing.
     """
     # Configure PyTorch settings (TF32, cuDNN benchmark)
     from Auto3D.torch_config import TorchConfig, configure_torch
@@ -124,6 +129,17 @@ def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
             )
         args.input_format = 'smi'
         check_input(args)
+
+        # Resolve and construct the optimizing model HERE (C8/M22), before the
+        # `optimizing` step below constructs its own copy for real work. A
+        # cold cache with no network, a corrupted cached file, or an
+        # unwritable cache directory would otherwise surface only deep inside
+        # ranking/optimization as an opaque failure. cpu is used regardless of
+        # the run's real device: these failure modes (cold cache, checksum
+        # mismatch, unwritable cache dir) are download/cache issues, not
+        # device issues, and cpu avoids contending for GPU memory just to
+        # validate.
+        preflight_model(args.optimizing_engine, torch.device("cpu"))
 
         # smi to sdf
         meta = create_chunk_meta_names(path0, tmpdirname)

--- a/src/Auto3D/auto3Dcli.py
+++ b/src/Auto3D/auto3Dcli.py
@@ -69,6 +69,17 @@ def _run_legacy_yaml(yaml_path: str) -> None:
     # Everything below funnels through handle_error so a bad path, malformed YAML,
     # or a runtime failure produces a clean error panel + exit code, never a
     # raw traceback (parity with the modern `run` command).
+    #
+    # This legacy entry point has no `-v/--verbose` flag of its own -- argv
+    # parsing here only recognizes a single positional YAML path (see cli()
+    # above), so there is nowhere to read CLI verbosity from. The YAML's own
+    # `verbose` key already doubles as the logging-verbosity switch below
+    # (configure_logging); reuse that same key as a coarse opt-in for a
+    # traceback on failure too, rather than always/never showing one.
+    # `parameters` stays None until (and unless) the YAML actually loads, so
+    # a failure before that point (bad path, unparsable YAML) falls back to
+    # no traceback instead of raising a secondary NameError here.
+    parameters: dict | None = None
     try:
         import yaml
 
@@ -108,7 +119,8 @@ def _run_legacy_yaml(yaml_path: str) -> None:
         result = main(options)
         console.print(f"\n[green]✓[/green] Output: [cyan]{result}[/cyan]")
     except Exception as e:  # noqa: BLE001 - present every failure as a clean panel
-        handle_error(e)
+        verbose = 1 if isinstance(parameters, dict) and parameters.get("verbose") else 0
+        handle_error(e, verbose=verbose)
 
 
 if __name__ == "__main__":

--- a/src/Auto3D/cli/app.py
+++ b/src/Auto3D/cli/app.py
@@ -32,6 +32,15 @@ InputFile = Annotated[
     ),
 ]
 
+# Same `-v/--verbose` convention as `run`: repeatable count, 0 by default.
+# Threaded explicitly into handle_error (rather than a global/Typer-context)
+# so an unexpected internal error can show a traceback here too, not just in
+# `run` (M30).
+VerboseOption = Annotated[
+    int,
+    typer.Option("-v", "--verbose", count=True, help="Increase verbosity; shows a traceback on unexpected errors."),
+]
+
 # Create main app
 app = typer.Typer(
     name="auto3d",
@@ -246,10 +255,11 @@ def models_test(
     ],
     gpu: Annotated[bool, typer.Option("--gpu/--no-gpu", help="Use GPU when available.")] = True,
     gpu_idx: Annotated[int, typer.Option("--gpu-idx", help="CUDA device index.")] = 0,
+    verbose: VerboseOption = 0,
 ) -> None:
     """Load an engine and run a tiny forward pass to verify it works."""
     from Auto3D.cli.commands.models import execute_models_test
-    execute_models_test(engine=engine, gpu=gpu, gpu_idx=gpu_idx)
+    execute_models_test(engine=engine, gpu=gpu, gpu_idx=gpu_idx, verbose=verbose)
 
 
 @app.command()
@@ -293,10 +303,11 @@ def energy(
     output: OutputOption = None,
     tf32: Tf32Flag = False,
     json_output: JsonFlag = False,
+    verbose: VerboseOption = 0,
 ) -> None:
     """Single-point energy for an SDF (writes an SDF with E_hartree)."""
     from Auto3D.cli.commands.properties import execute_energy
-    execute_energy(input_file, engine, gpu, gpu_idx, output, tf32, json_output)
+    execute_energy(input_file, engine, gpu, gpu_idx, output, tf32, json_output, verbose=verbose)
 
 
 @app.command()
@@ -312,12 +323,13 @@ def optimize(
     batchsize_atoms: Annotated[int, typer.Option("--batchsize-atoms", help="Atoms per optimization batch.")] = 1024,
     tf32: Tf32Flag = False,
     json_output: JsonFlag = False,
+    verbose: VerboseOption = 0,
 ) -> None:
     """Geometry-optimize the structures in an SDF (no enumeration)."""
     from Auto3D.cli.commands.properties import execute_optimize
     execute_optimize(
         input_file, engine, gpu, gpu_idx, output, opt_tol, opt_steps,
-        patience, batchsize_atoms, tf32, json_output,
+        patience, batchsize_atoms, tf32, json_output, verbose=verbose,
     )
 
 
@@ -333,12 +345,13 @@ def thermo(
     opt_steps: Annotated[int, typer.Option("--opt-steps", help="Max pre-optimization steps.")] = 2000,
     tf32: Tf32Flag = False,
     json_output: JsonFlag = False,
+    verbose: VerboseOption = 0,
 ) -> None:
     """Thermochemistry (enthalpy/entropy/Gibbs) for an SDF. Requires the ase extra."""
     from Auto3D.cli.commands.properties import execute_thermo
     execute_thermo(
         input_file, engine, gpu, gpu_idx, output, temperature,
-        opt_tol, opt_steps, tf32, json_output,
+        opt_tol, opt_steps, tf32, json_output, verbose=verbose,
     )
 
 
@@ -352,9 +365,11 @@ def tautomers(
     tauto_window: Annotated[float | None, typer.Option("--tauto-window", help="Keep tautomers within this kcal/mol window.")] = None,
     output: OutputOption = None,
     json_output: JsonFlag = False,
+    verbose: VerboseOption = 0,
 ) -> None:
     """Enumerate tautomers and rank/select the most stable ones."""
     from Auto3D.cli.commands.properties import execute_tautomers
     execute_tautomers(
         input_file, engine, gpu, gpu_idx, tauto_k, tauto_window, output, json_output,
+        verbose=verbose,
     )

--- a/src/Auto3D/cli/commands/models.py
+++ b/src/Auto3D/cli/commands/models.py
@@ -210,7 +210,9 @@ def execute_models_info(engine: str) -> None:
     console.print(Panel(content, title=f"[cyan]{engine_upper}[/cyan]", border_style="blue"))
 
 
-def execute_models_test(engine: str, gpu: bool = True, gpu_idx: int = 0) -> None:
+def execute_models_test(
+    engine: str, gpu: bool = True, gpu_idx: int = 0, verbose: int = 0
+) -> None:
     """Health-check an engine: load it and run one tiny forward pass.
 
     Catches the common environment problems up front -- a missing torchani for
@@ -260,4 +262,4 @@ def execute_models_test(engine: str, gpu: bool = True, gpu_idx: int = 0) -> None
             f"(methane E = {e_ev:.4f} eV, {elapsed:.1f}s incl. load)."
         )
     except Exception as e:  # noqa: BLE001 - present every failure as a clean panel
-        handle_error(e)
+        handle_error(e, verbose=verbose)

--- a/src/Auto3D/cli/commands/properties.py
+++ b/src/Auto3D/cli/commands/properties.py
@@ -18,9 +18,11 @@ from pathlib import Path
 from Auto3D.cli.console import console, print_success
 from Auto3D.cli.errors import handle_error
 from Auto3D.exceptions import ConfigurationError, DependencyError
+from Auto3D.models.preflight import resolve_engine_name
 
 # Engine names offered for shell completion. Free-form registry names and custom
-# model paths are still accepted (validated downstream); this only seeds tab
+# model paths are also accepted -- each command below validates them with
+# ``resolve_engine_name`` before doing any work; this list only seeds tab
 # completion and discoverability.
 KNOWN_ENGINES = [
     "AIMNET", "ANI2x", "ANI2xt",
@@ -47,6 +49,12 @@ def execute_energy(
 ) -> None:
     """Single-point energy: wraps calc_spe."""
     try:
+        # Validate before doing any work: calc_spe passes `engine` straight to
+        # create_model with no CLIConfig/resolve_engine_name gate of its own,
+        # so a typo like 'aimnet2-2025x' would otherwise only fail deep inside
+        # model construction (C11-shaped gap: a guard present in `main()` via
+        # WorkflowOrchestrator._validate_input, absent here).
+        resolve_engine_name(engine)
         from Auto3D.SPE import calc_spe
         out = calc_spe(
             str(input_file), engine, gpu_idx=gpu_idx, use_gpu=gpu,
@@ -64,6 +72,8 @@ def execute_optimize(
 ) -> None:
     """Geometry-only optimization of an existing SDF: wraps opt_geometry."""
     try:
+        # Validate before doing any work -- see execute_energy's comment.
+        resolve_engine_name(engine)
         from Auto3D.ASE.geometry import opt_geometry
         out = opt_geometry(
             str(input_file), engine, gpu_idx=gpu_idx, opt_tol=opt_tol,
@@ -83,6 +93,8 @@ def execute_thermo(
 ) -> None:
     """Thermochemistry (H/S/G): wraps calc_thermo. Requires the `ase` extra."""
     try:
+        # Validate before doing any work -- see execute_energy's comment.
+        resolve_engine_name(engine)
         try:
             from Auto3D.ASE.thermo import calc_thermo
         except ImportError as e:

--- a/src/Auto3D/cli/commands/properties.py
+++ b/src/Auto3D/cli/commands/properties.py
@@ -46,6 +46,7 @@ def _report(output_path: str, command: str, json_output: bool) -> None:
 def execute_energy(
     input_file: Path, engine: str, gpu: bool, gpu_idx: int,
     output: Path | None, allow_tf32: bool, json_output: bool,
+    verbose: int = 0,
 ) -> None:
     """Single-point energy: wraps calc_spe."""
     try:
@@ -62,13 +63,14 @@ def execute_energy(
         )
         _report(out, "energy", json_output)
     except Exception as e:  # noqa: BLE001 - funnel everything to the error panel
-        handle_error(e)
+        handle_error(e, verbose=verbose)
 
 
 def execute_optimize(
     input_file: Path, engine: str, gpu: bool, gpu_idx: int, output: Path | None,
     opt_tol: float, opt_steps: int, patience: int | None, batchsize_atoms: int,
     allow_tf32: bool, json_output: bool,
+    verbose: int = 0,
 ) -> None:
     """Geometry-only optimization of an existing SDF: wraps opt_geometry."""
     try:
@@ -83,13 +85,14 @@ def execute_optimize(
         )
         _report(out, "optimize", json_output)
     except Exception as e:  # noqa: BLE001
-        handle_error(e)
+        handle_error(e, verbose=verbose)
 
 
 def execute_thermo(
     input_file: Path, engine: str, gpu: bool, gpu_idx: int, output: Path | None,
     temperature: float, opt_tol: float, opt_steps: int,
     allow_tf32: bool, json_output: bool,
+    verbose: int = 0,
 ) -> None:
     """Thermochemistry (H/S/G): wraps calc_thermo. Requires the `ase` extra."""
     try:
@@ -114,13 +117,14 @@ def execute_thermo(
         )
         _report(out, "thermo", json_output)
     except Exception as e:  # noqa: BLE001
-        handle_error(e)
+        handle_error(e, verbose=verbose)
 
 
 def execute_tautomers(
     input_file: Path, engine: str, gpu: bool, gpu_idx: str | None,
     tauto_k: int | None, tauto_window: float | None,
     output: Path | None, json_output: bool,
+    verbose: int = 0,
 ) -> None:
     """Tautomer enumeration + stable-tautomer ranking: wraps get_stable_tautomers."""
     try:
@@ -149,4 +153,4 @@ def execute_tautomers(
             out = str(output)
         _report(out, "tautomers", json_output)
     except Exception as e:  # noqa: BLE001
-        handle_error(e)
+        handle_error(e, verbose=verbose)

--- a/src/Auto3D/cli/commands/run.py
+++ b/src/Auto3D/cli/commands/run.py
@@ -10,12 +10,39 @@ from Auto3D.cli.config_schema import CLIConfig, load_yaml_config, merge_configs
 from Auto3D.cli.console import console, print_banner, print_warning
 from Auto3D.cli.errors import handle_error
 from Auto3D.cli.results import (
+    FailedMolecule,
     WorkflowResults,
     output_json,
     print_results_summary,
 )
 from Auto3D.exceptions import Auto3DError
 from Auto3D.utils.logging_config import configure_logging
+
+# A partial run (the process completed, but some input molecules produced no
+# output) is a different failure class than a crash. cli/errors.py's
+# exit_code_for reserves 0 for clean success and 1-5 for exceptions raised
+# before/during the run (1 generic, 2 configuration/input, 3 dependency, 4
+# GPU, 5 model) -- all cases where `handle_error` catches something and the
+# process never reaches a results summary. This path is the opposite: nothing
+# raised, a summary was printed, and the run is still incomplete. Reusing exit
+# code 1 would make that indistinguishable from a genuine crash to a calling
+# shell script (`auto3d run --json && next_step`), which is exactly the
+# silent-partial-run defect (C6/B8) this constant closes. 6 extends the
+# existing convention with the next unused code rather than inventing an
+# unrelated scheme.
+EXIT_PARTIAL_SUCCESS = 6
+
+
+def _exit_if_incomplete(results: WorkflowResults) -> None:
+    """Raise SystemExit(EXIT_PARTIAL_SUCCESS) if the run lost any molecules.
+
+    Callers must invoke this only after the results have already been printed
+    or emitted as JSON (see execute_run) -- a `--json` consumer must still
+    receive a parseable document describing the failure before the process
+    exits non-zero.
+    """
+    if results.failed_count > 0:
+        raise SystemExit(EXIT_PARTIAL_SUCCESS)
 
 
 def execute_run(
@@ -127,36 +154,50 @@ def execute_run(
 
         elapsed = time.time() - start_time
 
-        # main() returns a WorkflowResult (a path str carrying the counts), so we
-        # read them off the result instead of re-opening the output SDF here.
-        # getattr keeps the old graceful (0, 0) if a caller/mocks ever hand back a
-        # plain str instead of a WorkflowResult.
-        from Auto3D.cli.results import count_input_molecules
+        # main() returns a WorkflowResult (a path str carrying the counts and
+        # the reconciled failure list), so we read everything off the result
+        # instead of re-opening the output SDF or re-deriving a count here.
+        # getattr keeps the old graceful defaults if a caller/mock ever hands
+        # back a plain str instead of a WorkflowResult.
         molecules = getattr(output_path, "n_molecules", 0)
         conformers = getattr(output_path, "n_conformers", 0)
-        # Failures = input molecules that produced no conformer. Per-molecule
-        # failure *details* are not yet wired through the workflow, but the count
-        # is recoverable as inputs minus produced molecules so the summary no
-        # longer always reports zero failures.
-        input_count = count_input_molecules(config.path) if config.path else 0
-        failed_count = max(0, input_count - molecules)
+        # `failures` is Task 3's reconciliation carrier: the input molecule
+        # IDs that WorkflowOrchestrator._finalize_output could not find in
+        # the output SDF. This replaces the old `max(0, input_count -
+        # molecules)` derivation, which was wrong two ways: the `max(0, ...)`
+        # silently floored to zero whenever tautomer enumeration made
+        # `molecules` legitimately exceed the input count (more outputs than
+        # inputs is not a failure), and even when the arithmetic was right it
+        # was only ever a count -- it could never say *which* molecule was
+        # lost, so `results.failures` was hardcoded to `[]` regardless.
+        # `missing_ids` is one entry per input molecule absent from the
+        # output, independent of how many conformers it would have produced,
+        # so a molecule that generated 3 conformers is still exactly one
+        # success and never appears here.
+        missing_ids: list[str] = list(getattr(output_path, "failures", []) or [])
+        failed_count = len(missing_ids)
         results = WorkflowResults(
             success_count=molecules,
             failed_count=failed_count,
             total_conformers=conformers,
             output_path=str(output_path) if output_path else "N/A",
             elapsed_seconds=elapsed,
-            failures=[],
+            failures=[
+                FailedMolecule(name=mol_id, error="no conformer generated (missing from output)")
+                for mol_id in missing_ids
+            ],
         )
 
-        # Output results. Per-molecule failure *details* are not yet wired through
-        # the workflow (results.failures is always empty), so we report the count
-        # via the summary but do not promise a detail list that cannot exist.
+        # Output results before deciding whether to exit non-zero, so a
+        # --json consumer always receives a parseable document -- even on a
+        # run that is about to signal partial failure (C6/B8).
         if json_output:
             output_json(results)
         elif not quiet:
             console.print()
             print_results_summary(results)
+
+        _exit_if_incomplete(results)
 
     except Auto3DError as e:
         handle_error(e)

--- a/src/Auto3D/cli/commands/run.py
+++ b/src/Auto3D/cli/commands/run.py
@@ -200,6 +200,6 @@ def execute_run(
         _exit_if_incomplete(results)
 
     except Auto3DError as e:
-        handle_error(e)
+        handle_error(e, verbose=verbose)
     except Exception as e:
-        handle_error(e)
+        handle_error(e, verbose=verbose)

--- a/src/Auto3D/cli/config_schema.py
+++ b/src/Auto3D/cli/config_schema.py
@@ -22,6 +22,8 @@ from Auto3D.constants import (
     DEFAULT_PATIENCE,
     DEFAULT_RMSD_THRESHOLD,
 )
+from Auto3D.exceptions import ConfigurationError
+from Auto3D.models.preflight import resolve_engine_name
 
 
 class CLIConfig(BaseModel):
@@ -83,18 +85,22 @@ class CLIConfig(BaseModel):
     @field_validator("optimizing_engine")
     @classmethod
     def _validate_engine(cls, v: str) -> str:
-        from pathlib import Path
-        if Path(v).exists():
-            return v
-        if v.upper() in {"AIMNET", "ANI2X", "ANI2XT"}:
-            return v
-        if v.lower().startswith("aimnet2"):  # any aimnet registry alias
-            return v
-        raise ValueError(
-            f"Unknown optimizing_engine '{v}'. Use AIMNET, ANI2x, ANI2xt, an "
-            f"aimnet registry name (e.g. aimnet2, aimnet2-2025, aimnet2-nse), "
-            f"or a path to a custom model file."
-        )
+        """Reject engine names the registry doesn't recognize.
+
+        Delegates to ``resolve_engine_name`` -- the same single source of
+        truth used by ``check_valid_configuration`` and (after this fix) the
+        auxiliary ``energy``/``optimize``/``thermo`` CLI commands -- instead
+        of re-implementing a prefix match here. The prefix match this
+        replaced (``v.lower().startswith("aimnet2")``) accepted any typo
+        sharing that prefix, e.g. ``aimnet2-2025x``, which then survived
+        config parsing and failed later inside a spawned worker where the
+        error is swallowed.
+        """
+        try:
+            resolve_engine_name(v)
+        except ConfigurationError as exc:
+            raise ValueError(str(exc)) from exc
+        return v
 
     @field_validator("tauto_engine", "isomer_engine", mode="before")
     @classmethod

--- a/src/Auto3D/cli/errors.py
+++ b/src/Auto3D/cli/errors.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from rich.panel import Panel
+from rich.traceback import Traceback
 
 from Auto3D.cli.console import error_console
 from Auto3D.exceptions import (
@@ -69,11 +70,17 @@ def get_error_hint(error: Auto3DError) -> str | None:
     return None
 
 
-def handle_error(error: Exception) -> None:
+def handle_error(error: Exception, verbose: int = 0) -> None:
     """Handle an error with Rich formatting.
 
     Args:
         error: The error to handle.
+        verbose: CLI verbosity level (the ``-v``/``--verbose`` count). At 0,
+            a known ``Auto3DError`` still gets only its clean message + hint
+            -- that panel *is* the intended, actionable presentation. Any
+            value above 0 additionally prints a full traceback to stderr, so
+            an internal failure (a bare ``KeyError('ID')`` from a missing SDF
+            property, say) is debuggable without editing source (M30).
     """
     if isinstance(error, Auto3DError):
         error_type = type(error).__name__.replace("Error", " Error")
@@ -89,10 +96,28 @@ def handle_error(error: Exception) -> None:
             border_style="red",
         ))
     else:
+        # Anything that isn't an Auto3DError is by definition unexpected --
+        # an internal bug, not a recognized user-facing failure mode. Before
+        # this fix the panel showed only `str(error)`, so a missing-property
+        # KeyError rendered as a bare, unactionable 'ID'. Always name the
+        # exception type and always point at --verbose, even at verbose=0:
+        # the user has nothing to act on otherwise, and nothing worth
+        # reporting in a bug (see get_error_hint's docstring for the
+        # Auto3DError case, which already has a real hint).
         error_console.print(Panel(
-            f"[red]{error}[/red]",
-            title="[red]Error[/red]",
+            f"[red]{type(error).__name__}: {error}[/red]"
+            "\n\n[dim]Run with -v/--verbose for a full traceback.[/dim]",
+            title="[red]Unexpected Error[/red]",
             border_style="red",
         ))
+
+    if verbose > 0:
+        # A fixed, generous width avoids the traceback panel wrapping at
+        # whatever narrow width the ambient terminal/pipe happens to report
+        # (source lines and file paths get split across lines otherwise).
+        error_console.print(
+            Traceback.from_exception(type(error), error, error.__traceback__),
+            width=200,
+        )
 
     raise SystemExit(exit_code_for(error))

--- a/src/Auto3D/models/preflight.py
+++ b/src/Auto3D/models/preflight.py
@@ -8,12 +8,39 @@ that quietly produced nothing.
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import requests
 
 from Auto3D.constants import DEFAULT_AIMNET_MODEL, MODEL_AIMNET, MODEL_ANI2X, MODEL_ANI2XT
 from Auto3D.exceptions import ConfigurationError, ModelLoadError
+
+
+def _cache_dir_for_message() -> str:
+    """Return the model cache directory path as a string, for error messages only.
+
+    Mirrors the path resolution in
+    ``aimnet.calculators.model_registry.get_cache_dir`` (``AIMNET_CACHE_DIR``
+    env var, falling back to ``~/.cache/aimnet``) but -- unlike that
+    function -- never calls ``os.makedirs``, so it cannot itself raise.
+
+    This must be computed before entering the ``try`` in ``preflight_model``
+    and passed into every ``except`` handler as a plain string. Calling the
+    real ``get_cache_dir()`` from inside a handler double-faults whenever the
+    failure being diagnosed *is* an uncreatable cache directory:
+    ``get_registry_model_path`` reaches that same directory via
+    ``create_assets_dir() -> get_cache_dir() -> os.makedirs(...)``, so naming
+    the directory by calling ``get_cache_dir()`` again just re-runs the
+    identical failing ``os.makedirs`` call, raising a second, unhandled
+    ``PermissionError`` instead of the intended ``ModelLoadError`` -- losing
+    the ``AIMNET_CACHE_DIR`` hint and the ``Auto3DError`` -> exit-code mapping
+    along with it.
+    """
+    cache_dir = os.environ.get("AIMNET_CACHE_DIR")
+    if cache_dir is None:
+        cache_dir = os.path.join(str(Path.home()), ".cache", "aimnet")
+    return cache_dir
 
 
 def resolve_engine_name(name: str) -> str:
@@ -57,7 +84,7 @@ def resolve_engine_name(name: str) -> str:
         ) from exc
 
 
-def preflight_model(engine: str, device) -> None:
+def preflight_model(engine: str) -> None:
     """Resolve the engine name and verify the model is obtainable, before any fork.
 
     This used to *construct* the full model here (see git history), which
@@ -98,10 +125,6 @@ def preflight_model(engine: str, device) -> None:
 
     Args:
         engine: The configured ``optimizing_engine`` value.
-        device: Unused. Kept so existing call sites do not need to change --
-            path-only verification has no notion of "device", but a future
-            check that does need one is a plausible extension of this
-            function's contract.
 
     Raises:
         ConfigurationError: The engine name is not recognized.
@@ -118,6 +141,11 @@ def preflight_model(engine: str, device) -> None:
     # (pure, offline) functions importable without pulling in the model stack.
     from aimnet.calculators.model_registry import get_registry_model_path
 
+    # Resolved as a plain string before the try, and reused in every handler
+    # below -- never call the real get_cache_dir() from inside a handler (see
+    # _cache_dir_for_message's docstring for why that double-faults).
+    cache_dir = _cache_dir_for_message()
+
     try:
         get_registry_model_path(resolved)
     except ValueError as exc:
@@ -126,32 +154,27 @@ def preflight_model(engine: str, device) -> None:
         # shaped like a ValueError is not ours to explain.
         if "checksum" not in str(exc).lower():
             raise
-        from aimnet.calculators.model_registry import get_cache_dir
 
         raise ModelLoadError(
             f"The cached model file for optimizing_engine={engine!r} failed a "
             f"checksum check: {exc}. The cached copy is corrupted, and "
             "aimnet will keep failing on it identically on every future run "
             "until it is removed -- delete the file named above from the "
-            f"cache directory ({get_cache_dir()!r}; override with "
+            f"cache directory ({cache_dir!r}; override with "
             "AIMNET_CACHE_DIR) and rerun; it will be re-downloaded "
             "automatically."
         ) from exc
     except (ConnectionError, TimeoutError, requests.exceptions.RequestException) as exc:
-        from aimnet.calculators.model_registry import get_cache_dir
-
         raise ModelLoadError(
             f"Could not download the model for optimizing_engine={engine!r}: "
             f"a network error occurred ({exc}). Check network connectivity, "
-            f"or pre-populate the cache directory ({get_cache_dir()!r}; "
+            f"or pre-populate the cache directory ({cache_dir!r}; "
             "override with AIMNET_CACHE_DIR) with the required file from a "
             "machine that has network access."
         ) from exc
     except OSError as exc:
-        from aimnet.calculators.model_registry import get_cache_dir
-
         raise ModelLoadError(
             "Could not read or write the model cache directory for "
-            f"optimizing_engine={engine!r} ({get_cache_dir()!r}; override "
+            f"optimizing_engine={engine!r} ({cache_dir!r}; override "
             f"with AIMNET_CACHE_DIR): {exc}"
         ) from exc

--- a/src/Auto3D/models/preflight.py
+++ b/src/Auto3D/models/preflight.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import requests
+
 from Auto3D.constants import MODEL_ANI2X, MODEL_ANI2XT
-from Auto3D.exceptions import ConfigurationError
+from Auto3D.exceptions import ConfigurationError, DependencyError, ModelLoadError
 
 #: Auto3D's historical name for the default AIMNet2 model. The registry does
 #: not know it -- resolve_registry_model_name("AIMNET") raises -- so it is
@@ -58,4 +60,85 @@ def resolve_engine_name(name: str) -> str:
             f"{MODEL_ANI2XT!r}, {AIMNET_ALIAS!r}, a path to a custom NNP file, "
             f"or an aimnet registry name. Registry aliases: "
             f"{', '.join(aliases)}."
+        ) from exc
+
+
+def preflight_model(engine: str, device) -> None:
+    """Resolve and construct the model in this process, before any fork.
+
+    Constructing here converts three failure modes that are otherwise invisible
+    into errors the user can act on: a cold cache with no network, a cached
+    file whose checksum no longer matches, and a cache directory that cannot
+    be written. Inside a worker each of these is caught by
+    ``optim_rank_wrapper``'s per-chunk handler and reported as "no 3D structure
+    converged", which names none of them.
+
+    Only the failure modes below are translated. Anything else -- a corrupt
+    checkpoint's own load error, a custom NNP raising some unrelated exception,
+    an out-of-memory error -- is deliberately left to propagate unchanged:
+    guessing a label for an error this function cannot positively identify
+    would be worse than the plain traceback.
+
+    Args:
+        engine: The configured ``optimizing_engine`` value.
+        device: Device to construct the model on. Preflight only needs the
+            model to construct successfully, not to run on the real device
+            the pipeline will use, so callers may pass ``torch.device("cpu")``
+            to avoid contending for GPU memory during validation.
+
+    Raises:
+        ConfigurationError: The engine name is not recognized.
+        ModelLoadError: The model could not be obtained or loaded -- a network
+            failure while downloading it, a checksum mismatch on the cached
+            file, or a cache directory that cannot be read or written.
+        DependencyError: A required optional dependency (e.g. TorchANI for
+            ANI2x) is not installed.
+    """
+    resolved = resolve_engine_name(engine)
+
+    # Deferred: only needed on this call path, and keeps the module's other
+    # (pure, offline) functions importable without pulling in the model stack.
+    from Auto3D.model_factory import create_model
+
+    try:
+        create_model(resolved, device, use_cache=False)
+    except ImportError as exc:
+        raise DependencyError(
+            f"optimizing_engine={engine!r} requires an optional dependency "
+            f"that is not installed: {exc}"
+        ) from exc
+    except ValueError as exc:
+        # aimnet's own cache-validation raises a plain ValueError for a
+        # checksum mismatch (model_registry._validate_sha256); anything else
+        # shaped like a ValueError is not ours to explain.
+        if "checksum" not in str(exc).lower():
+            raise
+        from aimnet.calculators.model_registry import get_cache_dir
+
+        raise ModelLoadError(
+            f"The cached model file for optimizing_engine={engine!r} failed a "
+            f"checksum check: {exc}. The cached copy is corrupted, and "
+            "aimnet will keep failing on it identically on every future run "
+            "until it is removed -- delete the file named above from the "
+            f"cache directory ({get_cache_dir()!r}; override with "
+            "AIMNET_CACHE_DIR) and rerun; it will be re-downloaded "
+            "automatically."
+        ) from exc
+    except (ConnectionError, TimeoutError, requests.exceptions.RequestException) as exc:
+        from aimnet.calculators.model_registry import get_cache_dir
+
+        raise ModelLoadError(
+            f"Could not download the model for optimizing_engine={engine!r}: "
+            f"a network error occurred ({exc}). Check network connectivity, "
+            f"or pre-populate the cache directory ({get_cache_dir()!r}; "
+            "override with AIMNET_CACHE_DIR) with the required file from a "
+            "machine that has network access."
+        ) from exc
+    except OSError as exc:
+        from aimnet.calculators.model_registry import get_cache_dir
+
+        raise ModelLoadError(
+            "Could not read or write the model cache directory for "
+            f"optimizing_engine={engine!r} ({get_cache_dir()!r}; override "
+            f"with AIMNET_CACHE_DIR): {exc}"
         ) from exc

--- a/src/Auto3D/models/preflight.py
+++ b/src/Auto3D/models/preflight.py
@@ -1,0 +1,61 @@
+"""Parent-process model resolution, so a bad model name fails before forking.
+
+Everything here runs in the process that parses the configuration, before any
+worker is spawned. A name resolved here produces an error the user sees with a
+traceback and a suggestion; the same failure inside a worker is swallowed by
+``optim_rank_wrapper``'s per-chunk handler and surfaces, if at all, as a run
+that quietly produced nothing.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from Auto3D.constants import MODEL_ANI2X, MODEL_ANI2XT
+from Auto3D.exceptions import ConfigurationError
+
+#: Auto3D's historical name for the default AIMNet2 model. The registry does
+#: not know it -- resolve_registry_model_name("AIMNET") raises -- so it is
+#: mapped here rather than leaking Auto3D's vocabulary into aimnet's.
+AIMNET_ALIAS = "AIMNET"
+AIMNET_DEFAULT = "aimnet2"
+
+
+def resolve_engine_name(name: str) -> str:
+    """Resolve an ``optimizing_engine`` value to a concrete model identifier.
+
+    Args:
+        name: An engine name: ``ANI2x``, ``ANI2xt``, ``AIMNET``, an aimnet
+            registry name or alias, or a path to a custom NNP file.
+
+    Returns:
+        The value unchanged for the named engines and custom paths, or the
+        resolved registry model name for an aimnet name or alias.
+
+    Raises:
+        ConfigurationError: If the name is none of those. The message lists
+            the aimnet aliases, because a typo like ``aimnet2-2025x`` is the
+            case this exists to catch and "not found in the registry" alone
+            does not tell the user what they may write instead.
+    """
+    if name in (MODEL_ANI2X, MODEL_ANI2XT):
+        return name
+    if Path(name).exists():
+        return name
+
+    from aimnet.calculators.model_registry import (
+        load_model_registry,
+        resolve_registry_model_name,
+    )
+
+    candidate = AIMNET_DEFAULT if name.upper() == AIMNET_ALIAS else name
+    try:
+        return resolve_registry_model_name(candidate)
+    except ValueError as exc:
+        registry = load_model_registry()
+        aliases = sorted(registry.get("aliases", {}))
+        raise ConfigurationError(
+            f"Unknown optimizing_engine {name!r}. Use {MODEL_ANI2X!r}, "
+            f"{MODEL_ANI2XT!r}, {AIMNET_ALIAS!r}, a path to a custom NNP file, "
+            f"or an aimnet registry name. Registry aliases: "
+            f"{', '.join(aliases)}."
+        ) from exc

--- a/src/Auto3D/models/preflight.py
+++ b/src/Auto3D/models/preflight.py
@@ -12,14 +12,8 @@ from pathlib import Path
 
 import requests
 
-from Auto3D.constants import MODEL_ANI2X, MODEL_ANI2XT
-from Auto3D.exceptions import ConfigurationError, DependencyError, ModelLoadError
-
-#: Auto3D's historical name for the default AIMNet2 model. The registry does
-#: not know it -- resolve_registry_model_name("AIMNET") raises -- so it is
-#: mapped here rather than leaking Auto3D's vocabulary into aimnet's.
-AIMNET_ALIAS = "AIMNET"
-AIMNET_DEFAULT = "aimnet2"
+from Auto3D.constants import DEFAULT_AIMNET_MODEL, MODEL_AIMNET, MODEL_ANI2X, MODEL_ANI2XT
+from Auto3D.exceptions import ConfigurationError, ModelLoadError
 
 
 def resolve_engine_name(name: str) -> str:
@@ -49,7 +43,7 @@ def resolve_engine_name(name: str) -> str:
         resolve_registry_model_name,
     )
 
-    candidate = AIMNET_DEFAULT if name.upper() == AIMNET_ALIAS else name
+    candidate = DEFAULT_AIMNET_MODEL if name.upper() == MODEL_AIMNET else name
     try:
         return resolve_registry_model_name(candidate)
     except ValueError as exc:
@@ -57,21 +51,37 @@ def resolve_engine_name(name: str) -> str:
         aliases = sorted(registry.get("aliases", {}))
         raise ConfigurationError(
             f"Unknown optimizing_engine {name!r}. Use {MODEL_ANI2X!r}, "
-            f"{MODEL_ANI2XT!r}, {AIMNET_ALIAS!r}, a path to a custom NNP file, "
+            f"{MODEL_ANI2XT!r}, {MODEL_AIMNET!r}, a path to a custom NNP file, "
             f"or an aimnet registry name. Registry aliases: "
             f"{', '.join(aliases)}."
         ) from exc
 
 
 def preflight_model(engine: str, device) -> None:
-    """Resolve and construct the model in this process, before any fork.
+    """Resolve the engine name and verify the model is obtainable, before any fork.
 
-    Constructing here converts three failure modes that are otherwise invisible
-    into errors the user can act on: a cold cache with no network, a cached
-    file whose checksum no longer matches, and a cache directory that cannot
-    be written. Inside a worker each of these is caught by
-    ``optim_rank_wrapper``'s per-chunk handler and reported as "no 3D structure
-    converged", which names none of them.
+    This used to *construct* the full model here (see git history), which
+    reliably converted the same three failure modes into diagnosable errors
+    but paid for it with a real model build -- ~9s and hundreds of MB, six
+    times over in the fast test suite alone once tests started reaching this
+    path unmocked (wall time 20s -> 75s, peak RSS 1.38GB on a 2GB box). The
+    three failure modes it exists to catch -- a cold cache with no network, a
+    cached file whose checksum no longer matches, and a cache directory that
+    cannot be written -- are all raised by obtaining the model's on-disk path
+    (``aimnet.calculators.model_registry.get_registry_model_path``, which
+    downloads on a cache miss, verifies the checksum, and returns the path),
+    without ever loading the checkpoint into a model. Measured warm: ~28ms.
+    Inside a worker each of these is caught by ``optim_rank_wrapper``'s
+    per-chunk handler and reported as "no 3D structure converged", which names
+    none of them -- this function's job is to catch them here instead, in the
+    parent, before any worker is forked.
+
+    ANI2x, ANI2xt, and custom NNP paths are not aimnet registry models, so
+    there is no cache/download/checksum step to preflight for them: ANI2xt's
+    weights are bundled in the package; ANI2x's torchani dependency and a
+    custom NNP path's loadability are already checked by ``check_input``
+    (utils/validation.py), which always runs before this. This function is a
+    no-op for those engines.
 
     Only the failure modes below are translated. Anything else -- a corrupt
     checkpoint's own load error, a custom NNP raising some unrelated exception,
@@ -79,34 +89,37 @@ def preflight_model(engine: str, device) -> None:
     guessing a label for an error this function cannot positively identify
     would be worse than the plain traceback.
 
+    Not caught by this: a file that downloads and checksums correctly but that
+    torch cannot actually load (a truncated write that still happens to match
+    a stale checksum, an incompatible pickle protocol, etc.). That failure
+    mode only surfaces once a worker actually loads the checkpoint. Accepted
+    here because C8 (cold cache/network) and M22 (checksum mismatch) are both
+    about obtaining the file, not about what is inside it.
+
     Args:
         engine: The configured ``optimizing_engine`` value.
-        device: Device to construct the model on. Preflight only needs the
-            model to construct successfully, not to run on the real device
-            the pipeline will use, so callers may pass ``torch.device("cpu")``
-            to avoid contending for GPU memory during validation.
+        device: Unused. Kept so existing call sites do not need to change --
+            path-only verification has no notion of "device", but a future
+            check that does need one is a plausible extension of this
+            function's contract.
 
     Raises:
         ConfigurationError: The engine name is not recognized.
-        ModelLoadError: The model could not be obtained or loaded -- a network
-            failure while downloading it, a checksum mismatch on the cached
-            file, or a cache directory that cannot be read or written.
-        DependencyError: A required optional dependency (e.g. TorchANI for
-            ANI2x) is not installed.
+        ModelLoadError: The model could not be obtained -- a network failure
+            while downloading it, a checksum mismatch on the cached file, or
+            a cache directory that cannot be read or written.
     """
     resolved = resolve_engine_name(engine)
 
+    if resolved in (MODEL_ANI2X, MODEL_ANI2XT) or Path(resolved).exists():
+        return
+
     # Deferred: only needed on this call path, and keeps the module's other
     # (pure, offline) functions importable without pulling in the model stack.
-    from Auto3D.model_factory import create_model
+    from aimnet.calculators.model_registry import get_registry_model_path
 
     try:
-        create_model(resolved, device, use_cache=False)
-    except ImportError as exc:
-        raise DependencyError(
-            f"optimizing_engine={engine!r} requires an optional dependency "
-            f"that is not installed: {exc}"
-        ) from exc
+        get_registry_model_path(resolved)
     except ValueError as exc:
         # aimnet's own cache-validation raises a plain ValueError for a
         # checksum mismatch (model_registry._validate_sha256); anything else

--- a/src/Auto3D/results.py
+++ b/src/Auto3D/results.py
@@ -5,6 +5,12 @@ output SDF path (so every existing caller -- ``Path(out)``, ``open(out)``,
 ``print(out)``, string ops -- keeps working unchanged) but also exposes the
 molecule/conformer counts of the run. The counts are computed lazily on first
 access and cached, so callers that only need the path pay nothing.
+
+It also carries ``failures``: the input molecule IDs that ``WorkflowOrchestrator``
+reconciled away against the output SDF and found missing (C7). Unlike the
+counts, this cannot be recomputed lazily from the output path alone -- it
+depends on the original input, which the orchestrator already compared during
+``_finalize_output`` -- so it is passed in explicitly at construction.
 """
 from __future__ import annotations
 
@@ -43,6 +49,22 @@ class WorkflowResult(str):
     string the pipeline historically returned. ``n_molecules`` / ``n_conformers``
     are read from the output SDF lazily and cached.
     """
+
+    failures: list[str]
+
+    def __new__(cls, value: str, failures: list[str] | None = None) -> WorkflowResult:
+        """Construct the result.
+
+        Args:
+            value: The output SDF path (the string value of this instance).
+            failures: Input molecule IDs with no corresponding output structure,
+                as reconciled by ``WorkflowOrchestrator._finalize_output``.
+                Defaults to an empty list so any existing caller that builds a
+                ``WorkflowResult`` from just a path keeps working.
+        """
+        obj = super().__new__(cls, value)
+        obj.failures = list(failures) if failures else []
+        return obj
 
     @cached_property
     def _counts(self) -> tuple[int, int]:

--- a/src/Auto3D/utils/file_ops.py
+++ b/src/Auto3D/utils/file_ops.py
@@ -820,7 +820,14 @@ def find_smiles_not_in_sdf(smi: str, sdf: str) -> list[tuple[str, str]]:
         if mol is None:
             logger.warning("Skipping molecule at index %d: failed to parse", i)
             continue
-        sdf_data.append(mol.GetProp("_Name"))
+        name = mol.GetProp("_Name")
+        # decode_ids keeps a "@tautN" suffix on tautomer-enumerated conformers
+        # (see decode_ids), but the .smi input has only the base id. Strip it
+        # the same way reorder_sdf/count_output do, or every tautomer-derived
+        # molecule would be misreported as missing.
+        if "@taut" in name:
+            name = name.split("@taut")[0]
+        sdf_data.append(name)
     sdf_data = list(set(sdf_data))
 
     # Find molecules without 3D structures
@@ -836,5 +843,67 @@ def find_smiles_not_in_sdf(smi: str, sdf: str) -> list[tuple[str, str]]:
             logger.warning(f"{mol_id} {smiles_str}")
     else:
         logger.info("Every SMILES has at least an 3D structure in the SDF file.")
+
+    return bad
+
+
+def find_ids_not_in_sdf(source_sdf: str, sdf: str) -> list[str]:
+    """Find molecule IDs from an SDF input that have no 3D structure in the output SDF.
+
+    The SDF-input counterpart to :func:`find_smiles_not_in_sdf`. That function
+    reads its expected-IDs list from a ``.smi`` file, which does not exist when
+    the pipeline's input is itself an SDF file; this reads the same expected-IDs
+    list from the source SDF's ``_Name`` property instead, so SDF-input runs get
+    the same input/output reconciliation SMILES-input runs do.
+
+    Args:
+        source_sdf: Path to the original input SDF file (pre-encoding IDs).
+        sdf: Path to the output SDF file (decoded IDs).
+
+    Returns:
+        List of input molecule IDs with no corresponding structure in ``sdf``.
+
+    Example:
+        >>> missing = find_ids_not_in_sdf("input.sdf", "output.sdf")
+        >>> for mol_id in missing:
+        ...     print(f"Failed: {mol_id}")
+    """
+    # Find all input molecule IDs
+    source_ids: list[str] = []
+    suppl = Chem.SDMolSupplier(source_sdf, removeHs=False)
+    for i, mol in enumerate(suppl):
+        if mol is None:
+            logger.warning("Skipping molecule at index %d: failed to parse", i)
+            continue
+        source_ids.append(mol.GetProp("_Name").strip())
+
+    # Get all molecule names from the output SDF
+    sdf_ids: set[str] = set()
+    mols = Chem.SDMolSupplier(sdf)
+    for i, mol in enumerate(mols):
+        if mol is None:
+            logger.warning("Skipping molecule at index %d: failed to parse", i)
+            continue
+        name = mol.GetProp("_Name")
+        if "@taut" in name:
+            name = name.split("@taut")[0]
+        sdf_ids.add(name)
+
+    # Find molecules without 3D structures, preserving source order and
+    # de-duplicating (an id can appear once per tautomer/isomer conformer
+    # group in some callers, though not in the raw source SDF).
+    bad: list[str] = []
+    seen: set[str] = set()
+    for mol_id in source_ids:
+        if mol_id not in sdf_ids and mol_id not in seen:
+            bad.append(mol_id)
+            seen.add(mol_id)
+
+    if bad:
+        logger.warning("The following input IDs have no 3D structure in the SDF file.")
+        for mol_id in bad:
+            logger.warning(mol_id)
+    else:
+        logger.info("Every input molecule has at least one 3D structure in the SDF file.")
 
     return bad

--- a/src/Auto3D/utils/logging_config.py
+++ b/src/Auto3D/utils/logging_config.py
@@ -15,6 +15,19 @@ _loggers: dict[str, logging.Logger] = {}
 def get_logger(name: str) -> logging.Logger:
     """Get a logger for the given module name.
 
+    Returns a logger named after ``name`` (typically ``Auto3D.<module>``,
+    since callers pass ``__name__``), so it propagates to the "Auto3D" root
+    logger that :func:`configure_logging` attaches a stderr handler to.
+
+    A run's on-disk log (Auto3D.log) is fed separately, through a
+    multiprocessing queue: ``Auto3D.workflow_workers`` attaches a
+    ``QueueHandler`` onto BOTH this "Auto3D" tree and the lowercase "auto3d"
+    tree that ``Auto3D.workflow``, ``Auto3D.utils.chemistry`` and one warning
+    in ``Auto3D.batch_opt.batchopt`` log through directly -- "auto3d" and
+    "Auto3D" are case-distinct, unrelated sibling trees under root, so a
+    warning from a logger returned here now reaches the run log too, without
+    disturbing anything that already logged through the lowercase tree.
+
     Args:
         name: Module name (typically __name__).
 

--- a/src/Auto3D/utils/validation.py
+++ b/src/Auto3D/utils/validation.py
@@ -24,6 +24,7 @@ from Auto3D.exceptions import (
     ModelLoadError,
 )
 from Auto3D.models.loading import load_custom_nnp
+from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.utils.logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -327,8 +328,6 @@ def check_valid_configuration(
     # optim_rank_wrapper's per-chunk handler swallowed it. The registry lookup
     # is a pure offline dict read against a bundled YAML, so validating costs
     # nothing.
-    from Auto3D.models.preflight import resolve_engine_name
-
     try:
         resolve_engine_name(optimizing_engine)
     except ConfigurationError as exc:

--- a/src/Auto3D/utils/validation.py
+++ b/src/Auto3D/utils/validation.py
@@ -322,20 +322,17 @@ def check_valid_configuration(
                 if idx >= torch.cuda.device_count():
                     errors.append(f"GPU index {idx} is invalid. Available GPUs: {torch.cuda.device_count()}")
 
-    # Check optimizing_engine. Besides the named engines, any name starting with
-    # "aimnet2" is a valid AIMNet registry model (aimnet2-2025, aimnet2-nse,
-    # aimnet2-pd, ...) resolved lazily by model_factory, matching the CLI schema.
-    valid_engines = {"ANI2x", "ANI2xt", "AIMNET"}
-    if (
-        optimizing_engine not in valid_engines
-        and not optimizing_engine.lower().startswith("aimnet2")
-        and not Path(optimizing_engine).exists()
-    ):
-        errors.append(
-            f"optimizing_engine must be one of {valid_engines}, an aimnet registry "
-            f"name (aimnet2, aimnet2-2025, ...), or a valid path to a custom model. "
-            f"Got: {optimizing_engine}"
-        )
+    # Resolve rather than prefix-match: `aimnet2-2025x` starts with "aimnet2"
+    # and so used to pass here, then failed inside a worker where
+    # optim_rank_wrapper's per-chunk handler swallowed it. The registry lookup
+    # is a pure offline dict read against a bundled YAML, so validating costs
+    # nothing.
+    from Auto3D.models.preflight import resolve_engine_name
+
+    try:
+        resolve_engine_name(optimizing_engine)
+    except ConfigurationError as exc:
+        errors.append(str(exc))
 
     # Check isomer_engine
     valid_isomer_engines = {"rdkit", "omega"}

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -10,11 +10,14 @@ from logging.handlers import QueueHandler
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import torch
+
 import Auto3D
 from Auto3D.chunk_manager import ChunkManager
 from Auto3D.config import Auto3DOptions, optimizer_worker_indices
 from Auto3D.exceptions import ConfigurationError, FileFormatError, OptimizationError
 from Auto3D.model_factory import ModelFactory
+from Auto3D.models.preflight import preflight_model
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import check_input, check_valid_configuration, reorder_sdf
 from Auto3D.utils.file_ops import decode_ids, encode_ids
@@ -120,9 +123,20 @@ class WorkflowOrchestrator:
     def _validate_input(self) -> None:
         """Validate input configuration and prepare encoded input file.
 
+        Also resolves and constructs the optimizing model (see
+        ``preflight_model``), so a bad model name, a cold cache with no
+        network, a corrupted cached file, or an unwritable cache directory
+        all fail here -- before any worker is forked -- instead of surfacing
+        as an opaque failure deep inside a spawned worker.
+
         Raises:
-            ConfigurationError: If path is None or k/window not specified.
+            ConfigurationError: If path is None, k/window not specified, or
+                the configuration (including the optimizing engine name) is
+                otherwise invalid.
             FileFormatError: If input file format is not supported.
+            ModelLoadError: If the optimizing model could not be obtained or
+                loaded.
+            DependencyError: If a required optional dependency is missing.
         """
         if self.config.path is None:
             raise ConfigurationError("Please specify the input file path.")
@@ -179,6 +193,18 @@ class WorkflowOrchestrator:
             )
 
         check_input(self.config)
+
+        # Resolve and construct the optimizing model HERE, in the parent,
+        # before any worker is forked (C8/M22). Every worker builds its own
+        # copy of the model regardless (spawned processes share no memory
+        # with the parent), so this construction is purely diagnostic: a cold
+        # cache with no network, a corrupted cached file, or an unwritable
+        # cache directory would otherwise surface only inside
+        # optim_rank_wrapper's blanket per-chunk except, as an opaque "no 3D
+        # structure converged". cpu is used regardless of the run's real
+        # device -- these failure modes are download/cache issues, not device
+        # issues, and cpu avoids contending for GPU memory just to validate.
+        preflight_model(self.config.optimizing_engine, torch.device("cpu"))
 
     def _setup_job_directory(self) -> None:
         """Create the job directory for output files."""
@@ -404,12 +430,17 @@ class WorkflowOrchestrator:
         output_files = list(self.job_dir.glob("job*/*_3d.sdf"))
 
         if not output_files:
+            log_path = self.job_dir / "Auto3D.log"
             raise OptimizationError(
-                "The optimization engine did not run, or no 3D structure converged.\n"
-                "The reason might be one of the following:\n"
-                "1. Allocated memory is not enough;\n"
-                "2. The input SMILES encodes invalid chemical structures;\n"
-                "3. Patience is too small"
+                "No chunk produced a 3D structure output file, so no 3D "
+                "structure converged. The model itself loaded successfully "
+                "(pre-flight validation passed before any chunk was "
+                "processed), so this is not a model-loading problem. Likely "
+                "causes: insufficient memory for the batch size used, input "
+                "SMILES that do not encode valid chemical structures, or "
+                "optimization settings (opt_steps/patience) too aggressive "
+                f"for these molecules. See {log_path} for the per-chunk "
+                "errors already recorded during this run."
             )
 
         # Combine output data

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -20,7 +20,12 @@ from Auto3D.model_factory import ModelFactory
 from Auto3D.models.preflight import preflight_model
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import check_input, check_valid_configuration, reorder_sdf
-from Auto3D.utils.file_ops import decode_ids, encode_ids
+from Auto3D.utils.file_ops import (
+    decode_ids,
+    encode_ids,
+    find_ids_not_in_sdf,
+    find_smiles_not_in_sdf,
+)
 from Auto3D.utils.logging_config import get_logger
 from Auto3D.workflow_workers import (
     isomer_wrapper,
@@ -68,6 +73,10 @@ class WorkflowOrchestrator:
         self.job_dir: Path = Path()
         self.input_path: Path = Path()
         self.id_mapping: dict[str, str] = {}
+        # Input molecule IDs reconciled away as missing from the final output
+        # (C7), populated by _finalize_output. Read by main() to build the
+        # WorkflowResult.failures carrier.
+        self.failures: list[str] = []
         self.logging_queue: Queue[LogRecord | None] | None = None
         self.logger: logging.Logger | None = None
         self._logger_p: mp.Process | None = None
@@ -473,10 +482,55 @@ class WorkflowOrchestrator:
         if self.logger:
             self.logger.info(f"Output path: {path_output}")
 
+        # Reconcile inputs against outputs (C7): a molecule that vanished
+        # mid-pipeline must leave a trace. Compare the ORIGINAL input
+        # (self.config.path -- untouched, user-facing IDs) against the
+        # DECODED output (path_output), not self.input_path (the encoded temp
+        # file, whose IDs are encode_ids' numeric indices) or path_combined
+        # (still numeric) -- either of those would make every molecule look
+        # missing.
+        self._reconcile_output(path_output)
+
         # Clear model cache to free GPU memory
         ModelFactory.clear_cache()
 
         return path_output
+
+    def _reconcile_output(self, path_output: str) -> None:
+        """Compare the original input against the final output SDF (C7).
+
+        Populates ``self.failures`` with every input molecule ID absent from
+        ``path_output``, and logs them (both to the module logger and, when
+        available, this run's own Auto3D.log). ``main()`` reads
+        ``self.failures`` off the orchestrator to build the returned
+        ``WorkflowResult.failures``.
+
+        Args:
+            path_output: Path to the final, decoded output SDF.
+        """
+        if self.config.input_format == "smi":
+            missing = find_smiles_not_in_sdf(self.config.path, path_output)
+            self.failures = [mol_id for mol_id, _smiles in missing]
+        elif self.config.input_format == "sdf":
+            # find_smiles_not_in_sdf reads its expected-IDs list from a .smi
+            # file, which does not exist for SDF input; find_ids_not_in_sdf is
+            # the SDF-native equivalent (reads _Name directly from the source
+            # SDF), so SDF input gets the same reconciliation coverage instead
+            # of silently skipping it.
+            self.failures = find_ids_not_in_sdf(self.config.path, path_output)
+        else:
+            # _validate_input already rejects any other extension before this
+            # point is ever reached.
+            self.failures = []
+
+        if self.failures:
+            msg = (
+                f"{len(self.failures)} input molecule(s) produced no output "
+                f"and were not reported anywhere else: {sorted(self.failures)}"
+            )
+            logger.warning(msg)
+            if self.logger:
+                self.logger.warning(msg)
 
     def _log_timing(self, start_time: float) -> None:
         """Log pipeline execution time.

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -10,8 +10,6 @@ from logging.handlers import QueueHandler
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import torch
-
 import Auto3D
 from Auto3D.chunk_manager import ChunkManager
 from Auto3D.config import Auto3DOptions, optimizer_worker_indices
@@ -211,9 +209,8 @@ class WorkflowOrchestrator:
         # cold cache with no network, a corrupted cached file, or an
         # unwritable cache directory would otherwise surface only inside
         # optim_rank_wrapper's blanket per-chunk except, as an opaque "no 3D
-        # structure converged". The device argument is unused (see
-        # ``preflight_model``'s docstring) but kept for call-site stability.
-        preflight_model(self.config.optimizing_engine, torch.device("cpu"))
+        # structure converged".
+        preflight_model(self.config.optimizing_engine)
 
     def _setup_job_directory(self) -> None:
         """Create the job directory for output files."""
@@ -459,9 +456,18 @@ class WorkflowOrchestrator:
             combined_data.extend(file_path.read_text().splitlines(keepends=True))
 
         if not any(line.strip() == "$$$$" for line in combined_data):
+            log_path = self.job_dir / "Auto3D.log"
             raise OptimizationError(
-                "No 3D structure converged. None of the input molecules produced "
-                "an optimized conformer. Check input validity, memory, and patience settings."
+                "No 3D structure converged. Every chunk produced an output "
+                "file, but none of them contain a converged structure. The "
+                "model was already verified obtainable before any chunk was "
+                "processed (pre-flight passed), ruling out a cold cache, "
+                "network failure, or corrupted download as the cause. "
+                "Likely causes: every input molecule failed geometry "
+                "optimization (opt_steps/patience too aggressive for these "
+                "molecules), or the energy window/top-k filtering removed "
+                f"all conformers. See {log_path} for the per-chunk errors "
+                "already recorded during this run."
             )
 
         # Write combined output

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -123,11 +123,12 @@ class WorkflowOrchestrator:
     def _validate_input(self) -> None:
         """Validate input configuration and prepare encoded input file.
 
-        Also resolves and constructs the optimizing model (see
-        ``preflight_model``), so a bad model name, a cold cache with no
-        network, a corrupted cached file, or an unwritable cache directory
-        all fail here -- before any worker is forked -- instead of surfacing
-        as an opaque failure deep inside a spawned worker.
+        Also resolves the optimizing engine name and verifies the model is
+        obtainable (see ``preflight_model``), so a bad model name, a cold
+        cache with no network, a corrupted cached file, or an unwritable
+        cache directory all fail here -- before any worker is forked --
+        instead of surfacing as an opaque failure deep inside a spawned
+        worker.
 
         Raises:
             ConfigurationError: If path is None, k/window not specified, or
@@ -194,16 +195,15 @@ class WorkflowOrchestrator:
 
         check_input(self.config)
 
-        # Resolve and construct the optimizing model HERE, in the parent,
-        # before any worker is forked (C8/M22). Every worker builds its own
-        # copy of the model regardless (spawned processes share no memory
-        # with the parent), so this construction is purely diagnostic: a cold
-        # cache with no network, a corrupted cached file, or an unwritable
-        # cache directory would otherwise surface only inside
+        # Resolve the engine name and verify the model is obtainable HERE, in
+        # the parent, before any worker is forked (C8/M22). Every worker
+        # builds its own copy of the model regardless (spawned processes
+        # share no memory with the parent), so this is purely diagnostic: a
+        # cold cache with no network, a corrupted cached file, or an
+        # unwritable cache directory would otherwise surface only inside
         # optim_rank_wrapper's blanket per-chunk except, as an opaque "no 3D
-        # structure converged". cpu is used regardless of the run's real
-        # device -- these failure modes are download/cache issues, not device
-        # issues, and cpu avoids contending for GPU memory just to validate.
+        # structure converged". The device argument is unused (see
+        # ``preflight_model``'s docstring) but kept for call-site stability.
         preflight_model(self.config.optimizing_engine, torch.device("cpu"))
 
     def _setup_job_directory(self) -> None:
@@ -433,11 +433,12 @@ class WorkflowOrchestrator:
             log_path = self.job_dir / "Auto3D.log"
             raise OptimizationError(
                 "No chunk produced a 3D structure output file, so no 3D "
-                "structure converged. The model itself loaded successfully "
-                "(pre-flight validation passed before any chunk was "
-                "processed), so this is not a model-loading problem. Likely "
-                "causes: insufficient memory for the batch size used, input "
-                "SMILES that do not encode valid chemical structures, or "
+                "structure converged. The model was already verified "
+                "obtainable before any chunk was processed (pre-flight "
+                "passed), ruling out a cold cache, network failure, or "
+                "corrupted download as the cause. Likely causes: "
+                "insufficient memory for the batch size used, input SMILES "
+                "that do not encode valid chemical structures, or "
                 "optimization settings (opt_steps/patience) too aggressive "
                 f"for these molecules. See {log_path} for the per-chunk "
                 "errors already recorded during this run."

--- a/src/Auto3D/workflow_workers.py
+++ b/src/Auto3D/workflow_workers.py
@@ -32,6 +32,42 @@ if TYPE_CHECKING:
 
     from Auto3D.config import Auto3DOptions
 
+# Both logger trees a module warning must reach the run log through.
+#
+# Auto3D.utils.logging_config.get_logger(__name__) produces loggers named
+# "Auto3D.*" (matching each module's real __name__, e.g. "Auto3D.ASE.thermo").
+# Several call sites instead log through logging.getLogger("auto3d")
+# directly -- lowercase -- to work around the fact that "Auto3D.*" is a
+# different, case-distinct tree with no ancestor relationship to "auto3d"
+# (Auto3D.workflow's self.logger, Auto3D.utils.chemistry's module logger, the
+# stereochemistry-change warning in Auto3D.batch_opt.batchopt). Attaching a
+# QueueHandler onto BOTH trees here -- writing to the very same queue -- lets
+# get_logger(__name__) warnings reach the run log too, without touching any
+# of the call sites above that already rely on "auto3d" working: "auto3d" and
+# "Auto3D" are unrelated siblings under the root logger (dotted-name lookup
+# is exact-prefix and case-sensitive), so a single log call is only ever
+# routed through one of them and nothing is ever delivered twice.
+_RUN_LOG_LOGGER_NAMES = ("auto3d", "Auto3D")
+
+
+def _attach_run_log_handlers(
+    logging_queue: Queue[LogRecord | None],
+) -> list[tuple[str, logging.Handler]]:
+    """Attach a run-log QueueHandler onto every tree it must reach.
+
+    Returns the ``(logger_name, handler)`` pairs added, so a caller (chiefly
+    tests) can remove them again; production callers can ignore the return
+    value since these handlers live for the worker process's lifetime.
+    """
+    added: list[tuple[str, logging.Handler]] = []
+    for logger_name in _RUN_LOG_LOGGER_NAMES:
+        tree_logger = logging.getLogger(logger_name)
+        handler = QueueHandler(logging_queue)
+        tree_logger.addHandler(handler)
+        tree_logger.setLevel(logging.INFO)
+        added.append((logger_name, handler))
+    return added
+
 
 def isomer_wrapper(
     chunk_info: list[tuple[str, str]],
@@ -49,8 +85,7 @@ def isomer_wrapper(
     """
     #prepare logging
     logger = logging.getLogger("auto3d")
-    logger.addHandler(QueueHandler(logging_queue))
-    logger.setLevel(logging.INFO)
+    _attach_run_log_handlers(logging_queue)
 
     tautomer_processor = TautomerProcessor(args)
 
@@ -117,8 +152,7 @@ def optim_rank_wrapper(
 ) -> list[list[Chem.Mol]]:
     #prepare logging
     logger = logging.getLogger("auto3d")
-    logger.addHandler(QueueHandler(logging_queue))
-    logger.setLevel(logging.INFO)
+    _attach_run_log_handlers(logging_queue)
 
     conformers = []
     while True:

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -283,6 +283,121 @@ def test_json_output_is_pure_json(runner, tmp_path_cwd, monkeypatch):
     json.loads(result.stdout)  # must not raise
 
 
+def test_json_output_is_written_before_nonzero_exit_when_molecules_missing(
+    runner, tmp_path_cwd, monkeypatch
+):
+    """C6/B8: a run that loses a molecule must still emit parseable JSON, then
+    exit non-zero.
+
+    Hermetic: `Auto3D.auto3D.main` is monkeypatched to return a
+    `WorkflowResult` carrying a non-empty `failures` list (Task 3's
+    reconciliation carrier), so this exercises the full `execute_run` ->
+    `output_json` -> `_exit_if_incomplete` path without a pipeline run or a
+    loaded potential.
+    """
+    import json
+
+    from Auto3D.cli.app import app
+
+    smi = tmp_path_cwd / "in.smi"
+    smi.write_text("CCO mol1\nCCCO mol2\n")
+
+    import Auto3D.auto3D as a3d
+    out = tmp_path_cwd / "in_out.sdf"
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+    with Chem.SDWriter(str(out)) as w:
+        m = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        AllChem.EmbedMolecule(m, randomSeed=1)
+        m.SetProp("_Name", "mol1")
+        w.write(m)
+    from Auto3D.results import WorkflowResult
+    # mol2 has no corresponding output structure -- a lost molecule.
+    monkeypatch.setattr(
+        a3d, "main", lambda options: WorkflowResult(str(out), failures=["mol2"])
+    )
+
+    result = runner.invoke(app, ["run", str(smi), "--json"])
+
+    assert result.exit_code != 0, (
+        f"exited 0 despite a reported failure; output:\n{result.output}"
+    )
+    # Slice from the first '{': on this box, a one-time CUDA/device-library
+    # init banner (unrelated to Auto3D, triggered by whichever test first
+    # touches CUDA in the pytest process) can land on real stdout ahead of
+    # our JSON when this test runs in isolation. That banner contains no
+    # brace, so this only strips ambient noise -- it does not weaken the
+    # assertion that our own JSON is present, parseable, and written before
+    # SystemExit.
+    stdout = result.stdout
+    data = json.loads(stdout[stdout.index("{"):])  # must not raise
+    assert data["success"] is False
+    assert data["failed"] == 1
+    assert data["molecules"] == 1
+    assert [f["name"] for f in data["failures"]] == ["mol2"]
+
+
+def test_no_nonzero_exit_when_no_molecules_missing(runner, tmp_path_cwd, monkeypatch):
+    """A complete run (no reconciled failures) must keep exiting 0."""
+    from Auto3D.cli.app import app
+
+    smi = tmp_path_cwd / "in.smi"
+    smi.write_text("CCO mol1\n")
+
+    import Auto3D.auto3D as a3d
+    out = tmp_path_cwd / "in_out.sdf"
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+    with Chem.SDWriter(str(out)) as w:
+        m = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        AllChem.EmbedMolecule(m, randomSeed=1)
+        m.SetProp("_Name", "mol1")
+        w.write(m)
+    from Auto3D.results import WorkflowResult
+    monkeypatch.setattr(a3d, "main", lambda options: WorkflowResult(str(out)))
+
+    result = runner.invoke(app, ["run", str(smi), "--json"])
+    assert result.exit_code == 0
+
+
+# Unit tests for the exit-code decision itself (Auto3D.cli.commands.run),
+# pinned without going through the CLI or a pipeline run at all.
+
+def test_exit_if_incomplete_raises_nonzero_when_failures_present():
+    from Auto3D.cli.commands.run import EXIT_PARTIAL_SUCCESS, _exit_if_incomplete
+    from Auto3D.cli.results import FailedMolecule, WorkflowResults
+
+    results = WorkflowResults(
+        success_count=1,
+        failed_count=1,
+        total_conformers=1,
+        output_path="out.sdf",
+        elapsed_seconds=0.1,
+        failures=[FailedMolecule(name="mol2", error="missing from output")],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        _exit_if_incomplete(results)
+    assert exc_info.value.code == EXIT_PARTIAL_SUCCESS
+    assert EXIT_PARTIAL_SUCCESS != 0
+
+
+def test_exit_if_incomplete_does_not_raise_when_no_failures():
+    from Auto3D.cli.commands.run import _exit_if_incomplete
+    from Auto3D.cli.results import WorkflowResults
+
+    results = WorkflowResults(
+        success_count=2,
+        failed_count=0,
+        total_conformers=2,
+        output_path="out.sdf",
+        elapsed_seconds=0.1,
+        failures=[],
+    )
+
+    _exit_if_incomplete(results)  # must not raise
+
+
 # Error handling tests
 
 def test_error_hint_configuration_error():

--- a/tests/test_cli_config_schema.py
+++ b/tests/test_cli_config_schema.py
@@ -104,6 +104,21 @@ def test_config_rejects_garbage_engine():
         CLIConfig(path="x.smi", optimizing_engine="not-a-model-or-path")
 
 
+def test_config_rejects_registry_name_typo():
+    """M21: 'aimnet2-2025x' shares the 'aimnet2' prefix with a real registry
+    name, so the old prefix-match validator (`v.lower().startswith("aimnet2")`)
+    accepted it. Verified live before this fix:
+    CLIConfig(path=Path("x.smi"), optimizing_engine="aimnet2-2025x") did not
+    raise. The validator now delegates to resolve_engine_name, which performs
+    a real registry lookup instead of a prefix match."""
+    from pydantic import ValidationError
+
+    from Auto3D.cli.config_schema import CLIConfig
+
+    with pytest.raises(ValidationError, match="aimnet2-2025x"):
+        CLIConfig(path=Path("x.smi"), optimizing_engine="aimnet2-2025x")
+
+
 def test_merge_cli_overrides():
     """CLI overrides should take precedence."""
     from Auto3D.cli.config_schema import CLIConfig, merge_configs

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,204 @@
+# tests/test_cli_errors.py
+"""Tests for M30: an internal (non-Auto3DError) CLI failure must be
+debuggable without editing source.
+
+Before this fix, `handle_error` took no verbosity argument and printed only
+`str(error)` at every verbosity -- an unexpected `KeyError('ID')` (e.g. from a
+missing SDF property) rendered as a bare red box reading `'ID'`, with no file,
+line, or stack, no matter how many `-v` a user passed (there was nowhere for
+them to go).
+
+Two layers of coverage:
+- Direct calls to `handle_error` pin its formatting contract (message, hint,
+  traceback presence/absence) cheaply, without a full CLI invocation.
+- `CliRunner` invocations pin that `-v/--verbose` actually reaches
+  `handle_error` through each command's real wiring -- a `handle_error` that
+  works correctly in isolation but is never passed the CLI's verbosity would
+  still pass the direct tests above and silently ship broken.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from Auto3D.cli.app import app
+from Auto3D.cli.errors import handle_error
+from Auto3D.exceptions import ConfigurationError
+
+runner = CliRunner()
+
+
+# --- direct handle_error tests: formatting contract --------------------------
+
+def test_auto3derror_verbose0_shows_message_and_hint_no_traceback(capsys):
+    """The existing clean presentation for a known Auto3DError is the
+    feature, and must not change at verbose=0."""
+    with pytest.raises(SystemExit) as exc_info:
+        handle_error(ConfigurationError("bad config"), verbose=0)
+    assert exc_info.value.code == 2  # ConfigurationError -> 2 (unchanged mapping)
+
+    captured = capsys.readouterr()
+    assert "bad config" in captured.err
+    assert "config init" in captured.err  # get_error_hint's hint text
+    assert "Traceback" not in captured.err
+
+
+def test_auto3derror_verbose1_shows_traceback(capsys):
+    """The same known error, at verbose=1, must additionally show a
+    traceback -- the hint/message presentation is unchanged, just extended."""
+    try:
+        raise ConfigurationError("bad config")
+    except ConfigurationError as e:
+        with pytest.raises(SystemExit) as exc_info:
+            handle_error(e, verbose=1)
+    assert exc_info.value.code == 2  # mapping still unchanged at verbose=1
+
+    captured = capsys.readouterr()
+    assert "bad config" in captured.err
+    assert "config init" in captured.err
+    assert "Traceback" in captured.err
+    assert "ConfigurationError" in captured.err
+
+
+def test_unexpected_error_verbose0_identifies_type_and_points_to_verbose(capsys):
+    """Judgment call: even at verbose=0, an unexpected (non-Auto3DError)
+    failure must name the exception type and say how to get more, because
+    the bare message alone ('ID') gives the user nothing to act on."""
+    with pytest.raises(SystemExit) as exc_info:
+        handle_error(KeyError("ID"), verbose=0)
+    assert exc_info.value.code == 1  # unmapped -> generic exit code, unchanged
+
+    captured = capsys.readouterr()
+    assert "KeyError" in captured.err
+    assert "'ID'" in captured.err
+    assert "Traceback" not in captured.err
+    assert "-v" in captured.err or "--verbose" in captured.err
+
+
+def test_unexpected_error_verbose1_traceback_identifies_origin(capsys):
+    """Pinned scenario from the brief: an unexpected KeyError('ID') must, at
+    verbose=1, produce something that identifies where it came from -- the
+    failing function name and the file it lives in, not just the message."""
+    def _raise_keyerror_id():
+        d: dict = {}
+        return d["ID"]
+
+    try:
+        _raise_keyerror_id()
+    except KeyError as e:
+        with pytest.raises(SystemExit) as exc_info:
+            handle_error(e, verbose=1)
+    assert exc_info.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "Traceback" in captured.err
+    assert "KeyError" in captured.err
+    assert "_raise_keyerror_id" in captured.err  # names the failing frame
+    assert "test_cli_errors" in captured.err  # names the file it's in
+
+
+def test_handle_error_default_verbose_is_zero(capsys):
+    """Existing call sites (and the pre-existing direct test in
+    test_cli_app.py) call handle_error with no verbose argument at all; the
+    default must keep today's no-traceback behavior."""
+    with pytest.raises(SystemExit):
+        handle_error(KeyError("ID"))
+    captured = capsys.readouterr()
+    assert "Traceback" not in captured.err
+
+
+# --- CliRunner: verbosity threads through each command's real wiring --------
+
+def _raise_keyerror_id(*args, **kwargs):
+    raise KeyError("ID")
+
+
+def test_run_verbose_flag_reaches_handle_error(tmp_path, monkeypatch):
+    """`auto3d run` funnels an unexpected internal error through handle_error
+    only if `-v` actually reaches it via execute_run's own `verbose` param."""
+    import Auto3D.auto3D as a3d
+
+    smi = tmp_path / "in.smi"
+    smi.write_text("CCO mol1\n")
+    monkeypatch.setattr(a3d, "main", _raise_keyerror_id)
+
+    quiet = runner.invoke(app, ["run", str(smi), "--k", "1", "--no-gpu", "--quiet"])
+    assert quiet.exit_code == 1
+    assert "Traceback" not in quiet.stdout
+    assert "Traceback" not in quiet.stderr
+    assert "KeyError" in quiet.stderr
+
+    verbose = runner.invoke(
+        app, ["run", str(smi), "--k", "1", "--no-gpu", "--quiet", "-v"]
+    )
+    assert verbose.exit_code == 1
+    # Judgment call: error_console is stderr-bound, so the traceback must
+    # never land on stdout -- Task 4 made --json stdout load-bearing for a
+    # partial-run consumer, and a stray traceback there would corrupt it.
+    assert "Traceback" not in verbose.stdout
+    assert "Traceback" in verbose.stderr
+    assert "_raise_keyerror_id" in verbose.stderr
+
+
+def test_run_json_stdout_stays_clean_on_unexpected_error_with_verbose(
+    tmp_path, monkeypatch
+):
+    """Same pin as above, specifically with --json: the traceback (stderr)
+    must never contaminate the --json stdout stream."""
+    import Auto3D.auto3D as a3d
+
+    smi = tmp_path / "in.smi"
+    smi.write_text("CCO mol1\n")
+    monkeypatch.setattr(a3d, "main", _raise_keyerror_id)
+
+    res = runner.invoke(app, ["run", str(smi), "--k", "1", "--no-gpu", "--json", "-v"])
+    assert res.exit_code == 1
+    assert "Traceback" not in res.stdout
+    assert "Traceback" in res.stderr
+
+
+def test_energy_verbose_flag_reaches_handle_error(tmp_path):
+    """A properties.py command: these had no verbosity option at all before
+    this change, so this pins the newly-added wiring specifically."""
+    sdf = tmp_path / "mols.sdf"
+    sdf.write_text("")
+
+    with patch("Auto3D.SPE.calc_spe", side_effect=KeyError("ID")):
+        quiet = runner.invoke(app, ["energy", str(sdf), "--no-gpu"])
+    assert quiet.exit_code == 1
+    assert "Traceback" not in quiet.stderr
+
+    with patch("Auto3D.SPE.calc_spe", side_effect=KeyError("ID")):
+        verbose = runner.invoke(app, ["energy", str(sdf), "--no-gpu", "-v"])
+    assert verbose.exit_code == 1
+    assert "Traceback" not in verbose.stdout
+    assert "Traceback" in verbose.stderr
+
+
+def test_models_test_verbose_flag_reaches_handle_error(monkeypatch):
+    """`models test` also gained -v in this change; a DependencyError is a
+    known Auto3DError, so verbose=1 must add a traceback on top of the
+    existing clean panel (not replace it)."""
+    from Auto3D.exceptions import DependencyError
+
+    def _boom(*a, **k):
+        raise DependencyError("torchani not installed")
+
+    monkeypatch.setattr(
+        "Auto3D.model_factory.get_device",
+        lambda *a, **k: __import__("torch").device("cpu"),
+    )
+    monkeypatch.setattr("Auto3D.model_factory.create_model", _boom)
+
+    quiet = runner.invoke(app, ["models", "test", "ANI2x", "--no-gpu"])
+    assert quiet.exit_code == 3  # DependencyError -> 3, unchanged mapping
+    assert "Traceback" not in quiet.stderr
+    assert "torchani not installed" in quiet.stderr
+
+    verbose = runner.invoke(app, ["models", "test", "ANI2x", "--no-gpu", "-v"])
+    assert verbose.exit_code == 3
+    assert "torchani not installed" in verbose.stderr
+    assert "Traceback" not in verbose.stdout
+    assert "Traceback" in verbose.stderr

--- a/tests/test_cli_property_commands.py
+++ b/tests/test_cli_property_commands.py
@@ -86,6 +86,59 @@ def test_thermo_without_ase_raises_dependency_error(sdf, monkeypatch):
     assert "Traceback" not in res.output
 
 
+# --- engine-name validation (M21 / C11) --------------------------------------
+#
+# calc_spe/opt_geometry/calc_thermo pass `engine` straight to create_model with
+# no CLIConfig/resolve_engine_name gate of their own; the docstring comment
+# above KNOWN_ENGINES used to claim this was "validated downstream" without
+# that ever being verified. It was not: before this fix, none of these three
+# commands rejected a typo'd registry name (e.g. 'aimnet2-2025x') until it
+# failed deep inside model construction. Each API function is mocked here so
+# a real NNP is never constructed; `m.assert_not_called()` confirms the
+# rejection happens before the mocked call, i.e. before any work is done.
+
+def test_energy_rejects_unknown_engine_before_doing_any_work(sdf):
+    with patch("Auto3D.SPE.calc_spe") as m:
+        res = runner.invoke(
+            app, ["energy", str(sdf), "--no-gpu", "--engine", "aimnet2-2025x"]
+        )
+    assert res.exit_code == 2  # ConfigurationError -> exit 2
+    assert "aimnet2-2025x" in res.output
+    m.assert_not_called()
+
+
+def test_optimize_rejects_unknown_engine_before_doing_any_work(sdf):
+    with patch("Auto3D.ASE.geometry.opt_geometry") as m:
+        res = runner.invoke(
+            app, ["optimize", str(sdf), "--no-gpu", "--engine", "aimnet2-2025x"]
+        )
+    assert res.exit_code == 2  # ConfigurationError -> exit 2
+    assert "aimnet2-2025x" in res.output
+    m.assert_not_called()
+
+
+def test_thermo_rejects_unknown_engine_before_doing_any_work(sdf):
+    with patch("Auto3D.ASE.thermo.calc_thermo") as m:
+        res = runner.invoke(
+            app, ["thermo", str(sdf), "--no-gpu", "--engine", "aimnet2-2025x"]
+        )
+    assert res.exit_code == 2  # ConfigurationError -> exit 2
+    assert "aimnet2-2025x" in res.output
+    m.assert_not_called()
+
+
+def test_tautomers_rejects_unknown_engine_before_doing_any_work(smi):
+    """tautomers already routes optimizing_engine through CLIConfig, so this
+    was not part of the M21 gap -- confirming it stays closed."""
+    with patch("Auto3D.tautomer.get_stable_tautomers") as m:
+        res = runner.invoke(
+            app, ["tautomers", str(smi), "--no-gpu", "--engine", "aimnet2-2025x"]
+        )
+    assert res.exit_code != 0
+    assert "aimnet2-2025x" in res.output
+    m.assert_not_called()
+
+
 def test_exit_code_mapping():
     from Auto3D.cli.errors import exit_code_for
     from Auto3D.exceptions import (

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import logging
+import queue
 import sys
 
-from Auto3D.utils.logging_config import configure_logging
+from Auto3D.utils.logging_config import configure_logging, get_logger
 
 
 def test_configure_logging_uses_stderr_not_stdout():
@@ -29,3 +30,108 @@ def test_configure_logging_uses_stderr_not_stdout():
         assert sys.stdout not in streams
     finally:
         auto3d_logger.handlers = saved
+
+
+def test_get_logger_warning_reaches_worker_style_handler():
+    """A warning issued through get_logger(__name__) must reach a handler
+    attached the way Auto3D.workflow_workers attaches its own -- that is the
+    actual mechanism the run log (Auto3D.log) is built from.
+
+    get_logger(__name__) produces loggers named "Auto3D.*" (matching each
+    module's real __name__). Before the fix, Auto3D.workflow_workers attached
+    its QueueHandler only to a logger named "auto3d" -- a different,
+    case-distinct tree with no ancestor relationship to "Auto3D.*" -- so a
+    warning issued through get_logger never reached it. This exercises the
+    real worker helper (not a hand copy of its logic) so it can't drift from
+    production behavior.
+    """
+    from Auto3D.workflow_workers import _attach_run_log_handlers
+
+    q: queue.Queue = queue.Queue()
+    added = _attach_run_log_handlers(q)
+    try:
+        mod_logger = get_logger("Auto3D.test_logging_config_worker_reach")
+        mod_logger.setLevel(logging.INFO)
+        mod_logger.warning("module warning for the run log")
+        assert not q.empty(), (
+            "a warning issued through get_logger never reached a handler "
+            "attached the way the worker attaches its own"
+        )
+        record = q.get_nowait()
+        assert record.getMessage() == "module warning for the run log"
+    finally:
+        for logger_name, handler in added:
+            logging.getLogger(logger_name).removeHandler(handler)
+
+
+def test_run_log_handlers_do_not_duplicate_records():
+    """A single warning must be delivered exactly once through the run-log
+    queue, and exactly once via root propagation.
+
+    Auto3D.workflow_workers._attach_run_log_handlers attaches a QueueHandler
+    to both the "auto3d" and "Auto3D" trees. If those trees were not the
+    disjoint siblings they're assumed to be (e.g. one accidentally an
+    ancestor of the other, or the same tree handled twice), a single
+    get_logger warning would show up more than once here.
+    """
+    from Auto3D.workflow_workers import _attach_run_log_handlers
+
+    q: queue.Queue = queue.Queue()
+    added = _attach_run_log_handlers(q)
+
+    root_records: list[logging.LogRecord] = []
+    root_handler = logging.Handler()
+    root_handler.emit = root_records.append  # type: ignore[method-assign]
+    root_logger = logging.getLogger()
+    root_logger.addHandler(root_handler)
+    try:
+        mod_logger = get_logger("Auto3D.test_logging_config_dedup")
+        mod_logger.setLevel(logging.INFO)
+        mod_logger.warning("only once")
+
+        queued = []
+        while not q.empty():
+            queued.append(q.get_nowait())
+        assert len(queued) == 1, f"expected exactly one queued record, got {len(queued)}"
+        assert len(root_records) == 1, (
+            f"expected exactly one record via root propagation, got {len(root_records)}"
+        )
+    finally:
+        root_logger.removeHandler(root_handler)
+        for logger_name, handler in added:
+            logging.getLogger(logger_name).removeHandler(handler)
+
+
+def test_symmetry_number_default_warning_reaches_run_log():
+    """End-to-end proof for one of the Phase 3 diagnostics this defect
+    swallowed: the sigma=1 default warning in Auto3D.ASE.thermo.
+
+    Attaches a handler the way Auto3D.workflow_workers attaches its own and
+    confirms the warning actually arrives once _symmetry_number is exercised
+    directly -- no NNP and no ASE optimizer needed, just an RDKit mol with no
+    'symmetry_number' property.
+    """
+    from rdkit import Chem
+
+    import Auto3D.ASE.thermo as thermo
+    from Auto3D.workflow_workers import _attach_run_log_handlers
+
+    q: queue.Queue = queue.Queue()
+    added = _attach_run_log_handlers(q)
+    saved_warned_flag = thermo._symmetry_default_warned
+    thermo._symmetry_default_warned = False
+    try:
+        mol = Chem.MolFromSmiles("O")
+        assert mol is not None
+        sigma = thermo._symmetry_number(mol)
+        assert sigma == 1
+
+        queued = []
+        while not q.empty():
+            queued.append(q.get_nowait())
+        assert len(queued) == 1, f"expected exactly one queued record, got {len(queued)}"
+        assert "symmetry_number" in queued[0].getMessage()
+    finally:
+        thermo._symmetry_default_warned = saved_warned_flag
+        for logger_name, handler in added:
+            logging.getLogger(logger_name).removeHandler(handler)

--- a/tests/test_model_preflight.py
+++ b/tests/test_model_preflight.py
@@ -77,13 +77,6 @@ class TestRegistryNameValidation:
 class TestColdCacheDiagnosis:
     """A model that cannot be fetched must say so, not blame the user's chemistry."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C8: AIMNet2Adapter.__init__ (models/adapter.py:239) has no "
-        "try/except and runs inside optim_rank_wrapper's blanket except "
-        "(workflow_workers.py), so a ConnectionError becomes "
-        "WorkflowOrchestrator._finalize_output's 'no 3D structure converged'",
-    )
     def test_network_failure_names_the_network(self, isolated_input, monkeypatch):
         """An offline cold cache must produce a model/network error, not a chemistry one.
 
@@ -160,12 +153,6 @@ class TestColdCacheDiagnosis:
             "the three-wrong-reasons message leaked into a model-load failure"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="M22: aimnet's _maybe_download_asset raises on a checksum "
-        "mismatch and leaves the bad file in place, so every later run fails "
-        "identically forever; Auto3D adds no hint about deleting it",
-    )
     def test_checksum_mismatch_says_to_delete_the_file(self, isolated_input, monkeypatch):
         """A corrupted cache entry must name the file and tell the user to remove it.
 

--- a/tests/test_model_preflight.py
+++ b/tests/test_model_preflight.py
@@ -33,13 +33,25 @@ The two ``TestColdCacheDiagnosis`` tests must stay sensitive to a fix landing
 at EITHER of two layers, since the natural fix for C8/M22 is a parent-side
 pre-flight in ``WorkflowOrchestrator._validate_input`` (workers run in
 separate spawned processes with no access to the parent's in-memory model or
-cache, so that is the only place a pre-flight check can usefully live) -- but
-today no such pre-flight exists, so the failure only surfaces deeper, in
-``optim_rank_wrapper`` + ``_finalize_output``. Each test therefore tries
-``_validate_input()`` first and asserts on whatever it raises; only if that
-passes through harmlessly (today's behavior) does it fall through to the
+cache, so that is the only place a pre-flight check can usefully live). Each
+test therefore tries ``_validate_input()`` first and asserts on whatever it
+raises; only if that passes through harmlessly does it fall through to the
 worker chain. This keeps the tripwire falsifiable regardless of which layer a
 future fix targets.
+
+That parent-side pre-flight (``Auto3D.models.preflight.preflight_model``) now
+exists and is called from ``_validate_input``, so both tests are expected to
+be caught at the first (parent-side) layer today -- the worker-chain fallback
+below is exercised only if a future change removes or bypasses that call.
+``preflight_model`` verifies the model is obtainable by calling
+``aimnet.calculators.model_registry.get_registry_model_path`` (it no longer
+constructs an ``AIMNet2Calculator`` -- that used to build a full model just to
+validate it, which is what made the fast suite build a real AIMNet2 model on
+every test in this class). That is therefore the genuine interception point
+these two tests must patch, by the same "re-resolved every call" reasoning
+the second bullet above gives for ``AIMNet2Calculator``: ``preflight_model``
+does ``from aimnet.calculators.model_registry import get_registry_model_path``
+INSIDE the function, so the module attribute is what a monkeypatch must target.
 """
 from __future__ import annotations
 
@@ -80,17 +92,19 @@ class TestColdCacheDiagnosis:
     def test_network_failure_names_the_network(self, isolated_input, monkeypatch):
         """An offline cold cache must produce a model/network error, not a chemistry one.
 
-        The stated fix for C8 is to pre-flight the model in the parent
-        process before spawning workers (the only sane place, since workers
-        run in separate spawned processes with no access to the parent's
-        in-memory state). So this test must observe a fix landing EITHER
-        there (``WorkflowOrchestrator._validate_input``) OR left as today,
-        deeper in the worker (``optim_rank_wrapper`` + ``_finalize_output``).
-        It tries the parent-side path first; today that passes through
-        harmlessly (``check_input`` never constructs a model), so it falls
-        through to the worker chain, where the failure is actually swallowed.
+        The fix for C8 is a pre-flight in the parent process before spawning
+        workers (the only sane place, since workers run in separate spawned
+        processes with no access to the parent's in-memory state):
+        ``preflight_model`` (called from ``WorkflowOrchestrator._validate_input``)
+        verifies the model is obtainable via
+        ``aimnet.calculators.model_registry.get_registry_model_path`` -- so
+        that is the call to patch, not ``AIMNet2Calculator`` construction
+        (which this no longer reaches; see the module docstring). The test
+        still tries the parent-side path first and falls through to the
+        worker chain only if that passes through harmlessly, so it stays
+        falsifiable if a future change bypasses the parent-side pre-flight.
         """
-        import aimnet.calculators as aimnet_calculators
+        import aimnet.calculators.model_registry as model_registry
 
         from Auto3D import workflow_workers as ww
 
@@ -99,7 +113,7 @@ class TestColdCacheDiagnosis:
         def no_network(*a, **k):
             raise ConnectionError("Temporary failure in name resolution")
 
-        monkeypatch.setattr(aimnet_calculators, "AIMNet2Calculator", no_network)
+        monkeypatch.setattr(model_registry, "get_registry_model_path", no_network)
 
         chunk_path = isolated_input("smiles2.smi")
         args = Auto3DOptions(path=chunk_path, k=1, use_gpu=False)
@@ -119,10 +133,11 @@ class TestColdCacheDiagnosis:
             )
             return
 
-        # No parent-side pre-flight exists today (C8): _validate_input()
-        # passed through harmlessly. The failure only surfaces once the
-        # worker attempts to construct the model, and even then it is
-        # swallowed by optim_rank_wrapper's blanket except.
+        # Unreachable today: the parent-side pre-flight (patched above) always
+        # raises first, so this only runs if a future change bypasses it --
+        # in which case the failure only surfaces once the worker attempts to
+        # construct the model, and even then it is swallowed by
+        # optim_rank_wrapper's blanket except.
         job_root = Path(chunk_path).parent
         job_dir = job_root / "job1"
         job_dir.mkdir()
@@ -132,9 +147,8 @@ class TestColdCacheDiagnosis:
         q.put("Done")
         logq: queue_mod.Queue = queue_mod.Queue()
 
-        # optim_rank_wrapper's blanket except swallows the ConnectionError
-        # today (C8) -- this must not raise, matching the current (buggy)
-        # behavior, and no *_3d.sdf is ever written for job1.
+        # optim_rank_wrapper's blanket except would swallow the ConnectionError
+        # here -- this must not raise, and no *_3d.sdf is ever written for job1.
         result = ww.optim_rank_wrapper(args, q, logq, gpu_idx=0)
         assert result == []
 
@@ -156,13 +170,13 @@ class TestColdCacheDiagnosis:
     def test_checksum_mismatch_says_to_delete_the_file(self, isolated_input, monkeypatch):
         """A corrupted cache entry must name the file and tell the user to remove it.
 
-        Same two-layer shape as ``test_network_failure_names_the_network``:
-        try the parent-side pre-flight first (``_validate_input``), which
-        passes through harmlessly today, then fall through to the worker
-        chain where the real (buggy) swallow happens. This way a fix landing
-        at either layer is observed and can legitimately XPASS.
+        Same shape as ``test_network_failure_names_the_network``: the parent-
+        side pre-flight (``_validate_input`` -> ``preflight_model`` ->
+        ``get_registry_model_path``) is patched and expected to catch this,
+        with the worker-chain code below kept only as a fallback for a future
+        change that bypasses the parent-side pre-flight.
         """
-        import aimnet.calculators as aimnet_calculators
+        import aimnet.calculators.model_registry as model_registry
 
         from Auto3D import workflow_workers as ww
 
@@ -171,7 +185,7 @@ class TestColdCacheDiagnosis:
         def bad_checksum(*a, **k):
             raise ValueError("Checksum mismatch for aimnet2_wb97m_0.pt")
 
-        monkeypatch.setattr(aimnet_calculators, "AIMNet2Calculator", bad_checksum)
+        monkeypatch.setattr(model_registry, "get_registry_model_path", bad_checksum)
 
         chunk_path = isolated_input("smiles2.smi")
         args = Auto3DOptions(path=chunk_path, k=1, use_gpu=False)
@@ -188,10 +202,11 @@ class TestColdCacheDiagnosis:
             )
             return
 
-        # No parent-side pre-flight exists today (M22): _validate_input()
-        # passed through harmlessly; the failure only surfaces once the
-        # worker attempts to construct the model, and even then it is
-        # swallowed by optim_rank_wrapper's blanket except.
+        # Unreachable today: the parent-side pre-flight (patched above) always
+        # raises first, so this only runs if a future change bypasses it --
+        # in which case the failure only surfaces once the worker attempts to
+        # construct the model, and even then it is swallowed by
+        # optim_rank_wrapper's blanket except.
         job_root = Path(chunk_path).parent
         job_dir = job_root / "job1"
         job_dir.mkdir()
@@ -228,10 +243,16 @@ class TestEngineNameResolution:
         assert resolve_engine_name("ANI2xt") == "ANI2xt"
 
     def test_auto3d_alias_maps_onto_the_registry(self):
-        """The registry does not know 'AIMNET'; Auto3D maps it to aimnet2."""
+        """The registry does not know 'AIMNET'; Auto3D maps it to aimnet2.
+
+        Pinned against the concrete resolved value rather than comparing two
+        calls to the same function -- that comparison would still pass even if
+        resolve_engine_name had a constant-return bug (e.g. always returning
+        its input unchanged, or always returning the same fixed string).
+        """
         from Auto3D.models.preflight import resolve_engine_name
 
-        assert resolve_engine_name("AIMNET") == resolve_engine_name("aimnet2")
+        assert resolve_engine_name("AIMNET") == "aimnet2-wb97m-d3_0"
 
     def test_a_registry_alias_resolves(self):
         from Auto3D.models.preflight import resolve_engine_name

--- a/tests/test_model_preflight.py
+++ b/tests/test_model_preflight.py
@@ -57,13 +57,6 @@ from Auto3D.workflow import WorkflowOrchestrator
 class TestRegistryNameValidation:
     """A typo'd registry model name must fail during validation, not in a worker."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="M21: utils/validation.py:329-333 accepts any string starting "
-        "with 'aimnet2' without consulting the registry, so "
-        "WorkflowOrchestrator._validate_input never raises for a typo'd name "
-        "-- the failure only surfaces later, inside the spawned worker",
-    )
     def test_unknown_registry_name_is_rejected_up_front(self, isolated_input):
         """--engine aimnet2-2025x must fail validation and name valid options."""
         args = Auto3DOptions(
@@ -236,3 +229,41 @@ class TestColdCacheDiagnosis:
         assert any(w in message for w in ("delete", "remove", "aimnet_cache_dir")), (
             f"no recovery guidance in: {exc.value}"
         )
+
+
+class TestEngineNameResolution:
+    """resolve_engine_name is a pure offline lookup -- no model is loaded."""
+
+    def test_named_engines_pass_through(self):
+        from Auto3D.models.preflight import resolve_engine_name
+
+        assert resolve_engine_name("ANI2x") == "ANI2x"
+        assert resolve_engine_name("ANI2xt") == "ANI2xt"
+
+    def test_auto3d_alias_maps_onto_the_registry(self):
+        """The registry does not know 'AIMNET'; Auto3D maps it to aimnet2."""
+        from Auto3D.models.preflight import resolve_engine_name
+
+        assert resolve_engine_name("AIMNET") == resolve_engine_name("aimnet2")
+
+    def test_a_registry_alias_resolves(self):
+        from Auto3D.models.preflight import resolve_engine_name
+
+        assert resolve_engine_name("aimnet2-2025") == "aimnet2-b973c-2025-d3_0"
+
+    def test_a_typo_names_the_alternatives(self):
+        from Auto3D.exceptions import ConfigurationError
+        from Auto3D.models.preflight import resolve_engine_name
+
+        with pytest.raises(ConfigurationError) as excinfo:
+            resolve_engine_name("aimnet2-2025x")
+        message = str(excinfo.value)
+        assert "aimnet2-2025x" in message
+        assert "aimnet2-2025" in message, f"valid names not listed: {message}"
+
+    def test_a_custom_path_passes_through(self, tmp_path):
+        from Auto3D.models.preflight import resolve_engine_name
+
+        model = tmp_path / "custom.pt"
+        model.write_bytes(b"")
+        assert resolve_engine_name(str(model)) == str(model)

--- a/tests/test_model_preflight.py
+++ b/tests/test_model_preflight.py
@@ -55,13 +55,14 @@ INSIDE the function, so the module attribute is what a monkeypatch must target.
 """
 from __future__ import annotations
 
+import os
 import queue as queue_mod
 from pathlib import Path
 
 import pytest
 
 from Auto3D.config import Auto3DOptions
-from Auto3D.exceptions import Auto3DError
+from Auto3D.exceptions import Auto3DError, ModelLoadError
 from Auto3D.model_factory import ModelFactory
 from Auto3D.workflow import WorkflowOrchestrator
 
@@ -275,3 +276,65 @@ class TestEngineNameResolution:
         model = tmp_path / "custom.pt"
         model.write_bytes(b"")
         assert resolve_engine_name(str(model)) == str(model)
+
+
+class TestUnwritableCacheDirectory:
+    """A cache directory that cannot be created must be named, not double-faulted.
+
+    ``preflight_model`` names the cache directory in each of its three error
+    messages. The directory string is resolved once, before the ``try``
+    (``Auto3D.models.preflight._cache_dir_for_message``), specifically so
+    that naming it never re-invokes anything that can fail. The bug this
+    guards against: naming the directory by calling the real
+    ``aimnet.calculators.model_registry.get_cache_dir()`` from *inside* an
+    ``except`` handler re-runs that function's own ``os.makedirs`` -- and
+    when the failure being diagnosed *is* an uncreatable cache directory,
+    that re-invocation fails identically, double-faulting into a raw,
+    unhandled ``PermissionError`` instead of the intended ``ModelLoadError``.
+
+    Reproduced genuinely, with no aimnet internals mocked: ``AIMNET_CACHE_DIR``
+    points under a real ``0500`` (read+execute, no write) directory owned by
+    this same non-root test process, so ``os.makedirs`` fails with a real
+    ``PermissionError`` inside ``get_registry_model_path -> create_assets_dir
+    -> get_cache_dir``. That failure happens before ``get_registry_model_path``
+    ever reaches its download step (``load_model_registry`` and
+    ``resolve_registry_model_name`` are both offline dict/YAML reads that run
+    first), so this never risks a network call or a model load -- only a
+    directory-creation failure.
+    """
+
+    @pytest.fixture
+    def unwritable_cache_parent(self, tmp_path):
+        """A 0500 directory to point ``AIMNET_CACHE_DIR`` underneath.
+
+        Teardown restores write permission unconditionally -- including when
+        the test body fails or raises -- so pytest's own ``tmp_path`` cleanup
+        can still remove it. A failing test must never leave an undeletable
+        directory behind.
+        """
+        parent = tmp_path / "unwritable"
+        parent.mkdir()
+        parent.chmod(0o500)
+        try:
+            yield parent
+        finally:
+            parent.chmod(0o700)
+
+    def test_unwritable_cache_dir_raises_model_load_error_naming_it(
+        self, unwritable_cache_parent, monkeypatch
+    ):
+        """AIMNET_CACHE_DIR under an unwritable parent must raise ModelLoadError, not PermissionError."""
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            pytest.skip("root bypasses directory permission bits")
+
+        from Auto3D.models.preflight import preflight_model
+
+        cache_dir = unwritable_cache_parent / "aimnet"
+        monkeypatch.setenv("AIMNET_CACHE_DIR", str(cache_dir))
+
+        with pytest.raises(ModelLoadError) as excinfo:
+            preflight_model("AIMNET")
+
+        message = str(excinfo.value)
+        assert "AIMNET_CACHE_DIR" in message, f"no cache-dir hint in: {message}"
+        assert str(cache_dir) in message, f"the directory itself is not named: {message}"

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -162,12 +162,6 @@ class TestInputOutputAccounting:
 class TestExitStatus:
     """Losing molecules must not exit 0."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C6: execute_run ends its try block with print_results_summary and "
-        "never raises SystemExit on failed_count > 0, so `auto3d run --json && "
-        "next_step` proceeds on a partial run",
-    )
     def test_cli_exits_nonzero_when_molecules_are_missing(self, job_dir):
         """auto3d run must signal partial failure through its exit code."""
         from typer.testing import CliRunner

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -32,11 +32,6 @@ def _input_ids(smi_path: str) -> set[str]:
 class TestInputOutputAccounting:
     """No input may vanish without being reported."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C7: neither _finalize_output nor smiles2mols reconciles inputs "
-        "against outputs; find_smiles_not_in_sdf has zero production callers",
-    )
     def test_every_input_is_present_or_reported(self, job_dir):
         """Each input ID must appear in the output or in a reported failure list.
 

--- a/tests/test_utils_file_ops.py
+++ b/tests/test_utils_file_ops.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 
 import pytest
+from rdkit import Chem
 
 from Auto3D.utils.file_ops import (
     smiles2smi,
@@ -19,6 +20,7 @@ from Auto3D.utils.file_ops import (
     decode_ids,
     reorder_sdf,
     count_sdf,
+    find_ids_not_in_sdf,
     find_smiles_not_in_sdf,
     iter_smi_records,
 )
@@ -1132,6 +1134,97 @@ def test_housekeeping_omega_sweep_is_per_file_robust(tmp_path, monkeypatch):
     # Exactly one of the two logfiles must have been successfully moved.
     moved = list(dest.glob("oeomega_*.log"))
     assert len(moved) == 1, f"Expected 1 moved file, got {[f.name for f in moved]}"
+
+
+class TestFindSmilesNotInSdfTautStripping:
+    """C7: a decoded '@tautN' suffix must not cause a false "missing" report."""
+
+    def test_taut_suffixed_output_name_matches_base_smi_id(self, tmp_path):
+        """decode_ids keeps 'id@tautN' on tautomer conformers; the .smi only
+        has the base id, so find_smiles_not_in_sdf must strip the suffix
+        before comparing or every tautomer-derived molecule is misreported."""
+        smi = tmp_path / "in.smi"
+        smi.write_text("CCO mol_a\n")
+
+        sdf = tmp_path / "out.sdf"
+        writer = Chem.SDWriter(str(sdf))
+        writer.write(_make_mol("mol_a@taut0"))
+        writer.close()
+
+        bad = find_smiles_not_in_sdf(str(smi), str(sdf))
+        assert bad == [], f"mol_a wrongly reported missing: {bad}"
+
+
+class TestFindIdsNotInSdf:
+    """find_ids_not_in_sdf: the SDF-input counterpart to find_smiles_not_in_sdf."""
+
+    def test_missing_id_is_reported(self, tmp_path):
+        """An id present in the source SDF but absent from the output SDF is reported."""
+        source = tmp_path / "source.sdf"
+        writer = Chem.SDWriter(str(source))
+        for name in ["mol_a", "mol_b"]:
+            writer.write(_make_mol(name))
+        writer.close()
+
+        out = tmp_path / "out.sdf"
+        writer = Chem.SDWriter(str(out))
+        writer.write(_make_mol("mol_a"))  # mol_b never produced a structure
+        writer.close()
+
+        bad = find_ids_not_in_sdf(str(source), str(out))
+        assert bad == ["mol_b"]
+
+    def test_no_missing_ids_returns_empty_list(self, tmp_path):
+        """Every source id present in the output -> nothing reported."""
+        source = tmp_path / "source.sdf"
+        writer = Chem.SDWriter(str(source))
+        for name in ["mol_a", "mol_b"]:
+            writer.write(_make_mol(name))
+        writer.close()
+
+        out = tmp_path / "out.sdf"
+        writer = Chem.SDWriter(str(out))
+        for name in ["mol_b", "mol_a"]:
+            writer.write(_make_mol(name))
+        writer.close()
+
+        assert find_ids_not_in_sdf(str(source), str(out)) == []
+
+    def test_taut_suffixed_output_name_matches_base_id(self, tmp_path):
+        """Same '@tautN' stripping as find_smiles_not_in_sdf, for SDF input."""
+        source = tmp_path / "source.sdf"
+        writer = Chem.SDWriter(str(source))
+        writer.write(_make_mol("mol_a"))
+        writer.close()
+
+        out = tmp_path / "out.sdf"
+        writer = Chem.SDWriter(str(out))
+        writer.write(_make_mol("mol_a@taut1"))
+        writer.close()
+
+        assert find_ids_not_in_sdf(str(source), str(out)) == []
+
+    def test_skips_none_records_on_both_sides(self, tmp_path, monkeypatch):
+        """A None record (unparseable) in either SDF must not crash or miscount."""
+        import Auto3D.utils.file_ops as file_ops
+
+        valid_source = _make_mol("mol_a")
+        calls = {"n": 0}
+
+        def fake_supplier(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return [valid_source, None]  # source SDF
+            return [None, _make_mol("mol_a")]  # output SDF
+
+        monkeypatch.setattr(file_ops.Chem, "SDMolSupplier", fake_supplier)
+
+        source = tmp_path / "source.sdf"
+        source.write_text("placeholder")
+        out = tmp_path / "out.sdf"
+        out.write_text("placeholder")
+
+        assert find_ids_not_in_sdf(str(source), str(out)) == []
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -501,10 +501,21 @@ def test_smiles2mols_uses_args_threshold(monkeypatch):
             return None
 
     class _StubRank:
-        def __init__(self, *args, **kwargs):
-            pass
+        def __init__(self, in_f, out_f, *args, **kwargs):
+            self._out_f = out_f
 
         def run(self):
+            # find_smiles_not_in_sdf (C7 reconciliation, now wired into
+            # smiles2mols) reads this file, so it must be a real SDF -- the
+            # real ranking.run() always writes one, even a valid empty one
+            # would still not parse (RDKit rejects a 0-byte SDF), so write
+            # the one molecule this test actually asks for.
+            from rdkit import Chem
+
+            with Chem.SDWriter(self._out_f) as w:
+                mol = Chem.MolFromSmiles("CCO")
+                mol.SetProp("_Name", "stub")
+                w.write(mol)
             return []
 
     monkeypatch.setattr(
@@ -533,3 +544,250 @@ def test_orchestrator_input_format_single_source_of_truth(tmp_path):
     orch._validate_input()
     assert orch.config.input_format == "smi"
     assert not hasattr(orch, "input_format")
+
+
+def _encoded_mol(encoded_id):
+    """A minimal mol shaped like decode_ids expects: numeric _Name + ID."""
+    from rdkit import Chem
+
+    mol = Chem.MolFromSmiles("C")
+    mol.SetProp("_Name", str(encoded_id))
+    mol.SetProp("ID", f"{encoded_id}_conf1")
+    return mol
+
+
+class TestFinalizeOutputReconciliation:
+    """C7: _finalize_output must compare input against output and report gaps.
+
+    These pin the reconciliation wired into _finalize_output/_reconcile_output
+    directly (the real production call site), rather than only exercising
+    find_smiles_not_in_sdf/find_ids_not_in_sdf in isolation -- that is exactly
+    what would fail to catch a regression back to "zero production callers".
+    """
+
+    def test_smi_input_reports_missing_id_and_sets_failures(self, tmp_path, caplog):
+        """mol_c (encoded id 2) never produced a chunk output -> reported."""
+        import logging
+
+        from rdkit import Chem
+
+        from Auto3D.config import Auto3DOptions
+        from Auto3D.workflow import WorkflowOrchestrator
+
+        orig_smi = tmp_path / "orig.smi"
+        # Original (decoded) ids -- this, not the encoded temp file, is what
+        # reconciliation must compare against.
+        orig_smi.write_text("C mol_a\nC mol_b\nC mol_c\n")
+
+        config = Auto3DOptions(path=str(orig_smi), k=1, use_gpu=False)
+        config.input_format = "smi"
+        orch = WorkflowOrchestrator(config)
+        orch.job_dir = tmp_path
+        orch.input_path = tmp_path / "orig_encoded.smi"
+        orch.input_path.write_text("C 0\nC 1\nC 2\n")
+        orch.id_mapping = {"mol_a": 0, "mol_b": 1, "mol_c": 2}
+        orch.logger = None
+
+        job = tmp_path / "job1"
+        job.mkdir()
+        combined = job / "orig_encoded_3d.sdf"
+        with Chem.SDWriter(str(combined)) as w:
+            for encoded_id in (0, 1):  # id 2 (mol_c) never converged
+                w.write(_encoded_mol(encoded_id))
+
+        with caplog.at_level(logging.WARNING):
+            path_output = orch._finalize_output(start_time=0.0)
+
+        assert orch.failures == ["mol_c"], orch.failures
+        assert any("mol_c" in r.message for r in caplog.records), (
+            "the missing id was not logged anywhere"
+        )
+
+        produced = {
+            m.GetProp("_Name") for m in Chem.SDMolSupplier(path_output) if m is not None
+        }
+        assert produced == {"mol_a", "mol_b"}
+
+    def test_smi_input_reports_no_failures_when_everything_present(self, tmp_path):
+        """No false positives when every input molecule made it to the output."""
+        from rdkit import Chem
+
+        from Auto3D.config import Auto3DOptions
+        from Auto3D.workflow import WorkflowOrchestrator
+
+        orig_smi = tmp_path / "orig.smi"
+        orig_smi.write_text("C mol_a\nC mol_b\n")
+
+        config = Auto3DOptions(path=str(orig_smi), k=1, use_gpu=False)
+        config.input_format = "smi"
+        orch = WorkflowOrchestrator(config)
+        orch.job_dir = tmp_path
+        orch.input_path = tmp_path / "orig_encoded.smi"
+        orch.input_path.write_text("C 0\nC 1\n")
+        orch.id_mapping = {"mol_a": 0, "mol_b": 1}
+        orch.logger = None
+
+        job = tmp_path / "job1"
+        job.mkdir()
+        combined = job / "orig_encoded_3d.sdf"
+        with Chem.SDWriter(str(combined)) as w:
+            for encoded_id in (0, 1):
+                w.write(_encoded_mol(encoded_id))
+
+        orch._finalize_output(start_time=0.0)
+        assert orch.failures == []
+
+    def test_sdf_input_reports_missing_id_and_sets_failures(self, tmp_path):
+        """SDF input must be reconciled too, not silently skipped (C7 scope)."""
+        from rdkit import Chem
+
+        from Auto3D.config import Auto3DOptions
+        from Auto3D.workflow import WorkflowOrchestrator
+
+        orig_sdf = tmp_path / "orig.sdf"
+        with Chem.SDWriter(str(orig_sdf)) as w:
+            for name in ("mol_a", "mol_b", "mol_c"):
+                mol = Chem.MolFromSmiles("C")
+                mol.SetProp("_Name", name)
+                w.write(mol)
+
+        config = Auto3DOptions(path=str(orig_sdf), k=1, use_gpu=False)
+        config.input_format = "sdf"
+        orch = WorkflowOrchestrator(config)
+        orch.job_dir = tmp_path
+        orch.input_path = tmp_path / "orig_encoded.sdf"
+        with Chem.SDWriter(str(orch.input_path)) as w:
+            for encoded_id in (0, 1, 2):
+                w.write(_encoded_mol(encoded_id))
+        orch.id_mapping = {"mol_a": 0, "mol_b": 1, "mol_c": 2}
+        orch.logger = None
+
+        job = tmp_path / "job1"
+        job.mkdir()
+        combined = job / "orig_encoded_3d.sdf"
+        with Chem.SDWriter(str(combined)) as w:
+            for encoded_id in (0, 1):  # id 2 (mol_c) never converged
+                w.write(_encoded_mol(encoded_id))
+
+        orch._finalize_output(start_time=0.0)
+        assert orch.failures == ["mol_c"], orch.failures
+
+    def test_workflow_uses_the_canonical_file_ops_reconciliation_functions(self):
+        """Guard against a regression to a hand-rolled duplicate: workflow.py
+        must call the exact functions tested in test_utils_file_ops.py, not a
+        reimplementation that could silently diverge from them."""
+        import Auto3D.utils.file_ops as file_ops
+        import Auto3D.workflow as workflow
+
+        assert workflow.find_smiles_not_in_sdf is file_ops.find_smiles_not_in_sdf
+        assert workflow.find_ids_not_in_sdf is file_ops.find_ids_not_in_sdf
+
+
+def test_main_propagates_orchestrator_failures_into_workflow_result(monkeypatch, tmp_path):
+    """main() must surface WorkflowOrchestrator.failures on its returned
+    WorkflowResult -- the carrier a later CLI fix reads to populate
+    results.failures and drive a non-zero exit code. Wires main() end-to-end
+    without a real pipeline run: WorkflowOrchestrator.run() (the isomer/optim/
+    finalize phases) is stubbed, but the WorkflowResult construction and the
+    getattr(out, "failures", ...) contract the C7 tripwire relies on are real.
+    """
+    from Auto3D.auto3D import main
+    from Auto3D.config import Auto3DOptions
+    from Auto3D.results import WorkflowResult
+    from Auto3D.workflow import WorkflowOrchestrator
+
+    fake_output = str(tmp_path / "out.sdf")
+
+    def fake_run(self):
+        self.failures = ["mol_c"]
+        return fake_output
+
+    monkeypatch.setattr(WorkflowOrchestrator, "run", fake_run)
+
+    smi = tmp_path / "in.smi"
+    smi.write_text("C mol_a\nC mol_b\nC mol_c\n")
+    args = Auto3DOptions(path=str(smi), k=1, use_gpu=False)
+
+    result = main(args)
+
+    assert isinstance(result, WorkflowResult)
+    assert str(result) == fake_output
+    assert result.failures == ["mol_c"]
+    # getattr access, exactly as the C7 tripwire and the CLI use it.
+    assert getattr(result, "failures", None) == ["mol_c"]
+
+
+def test_smiles2mols_calls_find_smiles_not_in_sdf_and_reports_missing(
+    monkeypatch, caplog
+):
+    """smiles2mols must reconcile its SMILES input against what it produced,
+    the same way main()/_finalize_output do, and the report must name the
+    molecule that vanished -- proven against the real find_smiles_not_in_sdf,
+    not a stand-in, so a regression to zero callers would fail this test."""
+    import logging
+
+    import Auto3D.auto3D as auto3D_mod
+    from Auto3D.config import Auto3DOptions
+    from rdkit import Chem
+    from rdkit.Chem import inchi
+
+    ethanol_id = inchi.MolToInchiKey(Chem.MolFromSmiles("CCO"))
+    written: dict[str, str] = {}
+
+    class _StubIsomerEngine:
+        def run(self):
+            return None
+
+    def _capture_create(**kwargs):
+        return _StubIsomerEngine()
+
+    class _StubOpt:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def run(self):
+            return None
+
+    class _StubRank:
+        def __init__(self, in_f, out_f, threshold, k=None, window=None):
+            written["out_f"] = out_f
+
+        def run(self):
+            # Only ethanol "converges"; propanol vanishes mid-pipeline with no
+            # trace other than what reconciliation now reports.
+            with Chem.SDWriter(written["out_f"]) as w:
+                mol = Chem.MolFromSmiles("CCO")
+                mol.SetProp("_Name", ethanol_id)
+                w.write(mol)
+            return []
+
+    monkeypatch.setattr(
+        auto3D_mod.IsomerEngineFactory, "create", staticmethod(_capture_create)
+    )
+    monkeypatch.setattr(auto3D_mod, "optimizing", _StubOpt)
+    monkeypatch.setattr(auto3D_mod, "ranking", _StubRank)
+    monkeypatch.setattr(auto3D_mod, "reorder_sdf", lambda *a, **k: [])
+
+    calls = []
+    real_find = auto3D_mod.find_smiles_not_in_sdf
+
+    def spy(smi_path, sdf_path):
+        result = real_find(smi_path, sdf_path)
+        calls.append((smi_path, sdf_path, result))
+        return result
+
+    monkeypatch.setattr(auto3D_mod, "find_smiles_not_in_sdf", spy)
+
+    args = Auto3DOptions(k=1, use_gpu=False)
+    with caplog.at_level(logging.WARNING):
+        auto3D_mod.smiles2mols(["CCO", "CCC"], args)
+
+    assert calls, (
+        "find_smiles_not_in_sdf was never called by smiles2mols -- regression "
+        "to zero production callers (C7)"
+    )
+    _smi_path, _sdf_path, bad = calls[0]
+    missing_ids = [mol_id for mol_id, _smi in bad]
+    assert ethanol_id not in missing_ids
+    assert len(missing_ids) == 1
+    assert any(missing_ids[0] in r.message for r in caplog.records)


### PR DESCRIPTION
Closes **C6, C7, C8** (Critical) plus **M21, M22, M30**, and one defect not in the audit. Fourth phase of the 4.0.0 remediation.

## Root cause

The pipeline was architected to *survive* partial failure — per-chunk isolation, per-molecule skips, sentinel-guaranteed queue drains — with no compensating reporting layer. Failure was reliably contained and just as reliably invisible.

## What was wrong

- **C6** — `_finalize_output` raised only when *zero* outputs existed, so 9 of 10 failed chunks exited 0 and `auto3d run --json && next_step` proceeded on a partial run. `failed_count` was `max(0, inputs - outputs)`, which also absorbed the tautomer case where outputs legitimately exceed inputs and could never name the molecule lost; `failures` was hardcoded `[]` with a comment admitting the details "are not yet wired through the workflow."
- **C7** — nothing reconciled inputs against outputs. `find_smiles_not_in_sdf` was exported and tested with **zero production callers** — the same dead-code shape as C9 in Phase 2.
- **C8** — the model was constructed inside worker processes, so a cold cache behind a firewall, a corrupt download or an unwritable cache directory all surfaced as a swallowed exception plus a message offering three causes, none applicable.
- **M21** — engine names were prefix-matched, so `aimnet2-2025x` passed validation and failed in a worker where the error was swallowed.
- **M22** — a checksum mismatch leaves the bad file in place, so every subsequent run failed identically forever with no hint that deleting one file would fix it.
- **M30** — `handle_error` printed only `str(error)` at every verbosity, so an internal `KeyError('ID')` was the entire diagnostic. Every CLI entry point funnels through it.
- **Not in the audit** — `get_logger(__name__)` emits under `Auto3D.*` while the worker's handler was attached to `auto3d`: a different, case-distinct tree. No module warning ever reached the run log, including several diagnostics added earlier in this release.

## Notable decisions

**Pre-flight verifies the model path, not a constructed model.** An earlier version constructed it, which made the fast suite build a real AIMNet2 six times (20 s → 75 s) — and since the fast CI jobs restore no model cache, they would have downloaded. `get_registry_model_path` catches cold cache, network failure, checksum mismatch and permission errors in ~28 ms without loading weights.

**The exit code is 6**, extending `cli/errors.py`'s existing 0–5 convention so a partial run is distinguishable from a crash. It is raised only *after* the JSON and summary are printed, so a `--json` consumer still receives a parseable document describing the failure.

**Module warnings reach the run log by attaching to both trees.** Neither simple fix worked: two modules already log through both a `get_logger` logger and a raw `auto3d` call as a pre-existing workaround, while two others bypass `get_logger` entirely. Renaming would double-log the first pair; moving the attachment would break the second.

## Verification

818 passed, 9 skipped, 10 xfailed, **0 xpassed**, 0 failed; ruff clean. Marker inventory 15 → 10; the survivors belong to Phases 5 and 6 only.

## Known limits, stated rather than hidden

- The engine guard stops at the CLI layer. `calc_spe` / `opt_geometry` / `calc_thermo` remain unguarded for scripted users — the C11 shape, still an open tripwire. The guard moves into those functions when C11 lands.
- Path-only verification does not catch a file that downloads and checksums correctly but that torch cannot load.
- Warnings fired purely in the main process, outside `chunk_manager` / `workflow.py`, still miss the file log.
- C6 and C7's tripwires are slow-marked and need a loaded potential, so each fix also carries hermetic coverage; CI is their first execution.
