### PR TITLE
Unify configuration validation across every entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,8 @@ dmypy.json
 
 # Local coding-assistant instructions (developer-specific, not part of the package)
 /CLAUDE.md
+
+# Local scratch workspace for staged refactoring work: progress ledgers,
+# task briefs, generated diffs and review reports. Not part of the package.
+# The plans themselves are tracked, under docs/superpowers/plans/.
+/.superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are `k>=1`, `window>0`, `mpi_np>=1`, `opt_steps>=1`,
   `convergence_threshold>0`, `patience>=1`, `threshold>0`,
   `batchsize_atoms>=1`, `memory>=1`, `capacity>=1`, and `max_confs>=1`.
-  `None`/`False` still mean "not specified" and are not rejected. One
-  additional change beyond these bounds: `k=0` was a silent "unset" sentinel
+  `None`/`False` still mean "not specified" and are not rejected, but **only**
+  for the four optional fields with a genuine "unset" meaning -- `k`,
+  `window`, `memory`, and `max_confs` (`Auto3D.config.SENTINEL_FIELDS`). The
+  other seven bounds above (`mpi_np`, `opt_steps`, `convergence_threshold`,
+  `patience`, `threshold`, `batchsize_atoms`, `capacity`) always have a
+  concrete default and have no "unset" state to opt into, so `None`/`False`
+  now raise there too, on both entry points -- closing the same
+  entry-point-dependent gap this release closes everywhere else
+  (`Auto3DOptions(path="x.smi", threshold=None)` used to be silently accepted
+  while `CLIConfig(path=Path("x.smi"), threshold=None)` always rejected it).
+  One additional change beyond these bounds: `k=0` was a silent "unset" sentinel
   accepted only by `Auto3DOptions` (`CLIConfig` already rejected it via
   `Field(ge=1)`); it is now rejected on both, for parity, not because it is
   one of the newly-added bounds. Separately, the legacy `auto3d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outputs existed at all, so a run that silently lost 9 of 10 chunks -- to
   memory pressure, a crashed worker, or any other per-chunk failure -- still
   printed a results summary and exited `0`, indistinguishable from complete
-  success to a calling shell script (`auto3d run --json && next_step`). The
-  results summary and, with `--json`, the JSON document are still printed
-  *before* the process exits -- a scripted consumer always receives a
-  parseable description of what happened, even on the run that is about to
-  signal failure. `6` (`EXIT_PARTIAL_SUCCESS`) extends `cli/errors.py`'s
+  success to a calling shell script (`auto3d run --json && next_step`). When
+  the run *completes* but is missing molecules, the results summary and, with
+  `--json`, the JSON document are still printed *before* the process exits
+  `6` -- a scripted consumer checking for that exit code always receives a
+  parseable description of what was missing. This guarantee is specific to
+  that partial-success path: if `main()` raises instead of returning (a
+  crash, not a partial run), no JSON is emitted at all -- the process exits
+  `1`-`5` via `handle_error`'s panel on stderr, same as before. `6`
+  (`EXIT_PARTIAL_SUCCESS`) extends `cli/errors.py`'s
   existing `0`-`5` exit-code convention (`2` configuration/input, `3`
   dependency, `4` GPU, `5` model) with the next unused code, rather than
   reusing `1` and making a partial run indistinguishable from a crash.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,106 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **Configuration bounds are now enforced on every entry point.** A single
+  `FIELD_BOUNDS` table in `config.py` is now consulted by both
+  `Auto3DOptions.__post_init__` and `CLIConfig`'s model validator, so a config
+  that used to be silently accepted on one path now raises a
+  `ConfigurationError`/`ValidationError` on all of them (Python API, `auto3d
+  run -c`, and the legacy `auto3d parameters.yaml`). This closes real gaps,
+  not just theoretical ones: `threshold=-1` silently disabled duplicate-
+  conformer removal in 3.x while the output was presented as deduplicated,
+  `convergence_threshold=0` made the optimizer treat every step as unstable
+  and burn the full step budget, and `max_confs=0` produced zero conformers
+  for every molecule (`max_confs` had no lower bound on any path before this
+  release). If a 3.x run used any of these values, its output was not what it
+  appeared to be -- recompute rather than trust it. The newly-enforced bounds
+  are `k>=1`, `window>0`, `mpi_np>=1`, `opt_steps>=1`,
+  `convergence_threshold>0`, `patience>=1`, `threshold>0`,
+  `batchsize_atoms>=1`, `memory>=1`, `capacity>=1`, and `max_confs>=1`.
+  `None`/`False` still mean "not specified" and are not rejected. One
+  additional change beyond these bounds: `k=0` was a silent "unset" sentinel
+  accepted only by `Auto3DOptions` (`CLIConfig` already rejected it via
+  `Field(ge=1)`); it is now rejected on both, for parity, not because it is
+  one of the newly-added bounds. Separately, the legacy `auto3d
+  parameters.yaml` entry point now constructs a `CLIConfig` instead of
+  building `Auto3DOptions` directly, so `extra="forbid"` reaches it for the
+  first time: a stray key that used to be ignored now raises (an existing
+  `docs/legacy-v2/tauto.yaml` example with a stale `tauto_k`/`tauto_window`
+  key already failed before this change with a bare `TypeError`; it still
+  fails, now with a field-named `pydantic.ValidationError`).
+
+- **`k` and `window` can no longer be set together.** They are alternative
+  conformer-selection strategies and `ConformerRanker.run` only ever consulted
+  one of them (`if self.k: ... elif self.window: ...`), so setting both meant
+  `k` silently won and `window` was inert. Both `Auto3DOptions`/`CLIConfig`
+  (via the shared bounds check) and `ConformerRanker.run` itself now raise if
+  both are specified. **The shipped `thorough` preset set both** (`k: 10,
+  window: 5.0`) -- since `k` always won, every user of `-p thorough` has only
+  ever gotten top-10 selection, and `window: 5.0` never took effect. The
+  preset now sets only `k: 10`, preserving exactly what users of that preset
+  actually got, rather than silently switching them to window-based selection
+  as part of an unrelated bug fix. A previously-generated `thorough.yaml` on
+  disk still has both keys and will now raise until one is removed.
+
+- **`smiles2mols` raises on options it cannot honor, instead of silently
+  ignoring them.** `enumerate_tautomer`, `isomer_engine`, and `mode_oe` were
+  all accepted and silently had no effect (`smiles2mols` has no tautomer step
+  and hardcodes the RDKit isomer engine); it now raises `ConfigurationError`
+  naming the option and pointing at `main()` for tautomer enumeration or a
+  non-RDKit isomer engine. `smiles2mols` now also calls
+  `check_valid_configuration` (the GPU/engine/path checks it previously
+  skipped entirely), catching a bad configuration up front instead of failing
+  deep inside a worker. Separately, `smiles2mols` no longer mutates the
+  caller's `Auto3DOptions` object in place (it copies it
+  via `dataclasses.replace` on entry) -- previously it overwrote the caller's
+  own `path` and `input_format` fields, which could leave the caller holding a
+  config whose `path` pointed into a temporary directory `smiles2mols` had
+  already deleted. `WorkflowOrchestrator.run()` makes the same copy for the
+  same reason.
+
+- **GPU requested but unavailable is now fatal at every entry point.**
+  `use_gpu=True` on a CPU-only box used to behave three different ways
+  depending on how you called Auto3D: `main()` and `smiles2mols` raised
+  `ConfigurationError` (with an unrelated "config init" hint), while `auto3d
+  energy`/`optimize`/`thermo` silently fell back to CPU through
+  `model_factory.get_device` with no error and no warning at all -- a user
+  who asked for GPU and got CPU results had no way to know. A single
+  `check_gpu_requested` helper is now the one place this is decided: it
+  raises `GPUError` (naming `--no-gpu`), and every entry point calls it before
+  any work starts. `model_factory.get_device` itself is unchanged and still
+  silently returns a CPU device -- the fatal check is enforced by its
+  callers, not by the device picker.
+
+- **`auto3d validate` now rejects exactly what the runner rejects.**
+  `validate_smiles_file` never required an ID column, so an ID-less line
+  passed validation and then failed the actual run with a hint telling the
+  user to run the validator that had just approved it. `validate` now
+  requires the same SMILES+ID pair `encode_ids`/`iter_smi_records` do.
+  Comment-line handling was also inconsistent (`validate` skipped `#`-prefixed
+  lines; the runner did not) and is now consistent both ways: `#`-prefixed
+  lines are skipped by both `validate` and the runner (`iter_smi_records`,
+  `check_smi_format`) -- a SMILES token can never start with `#`, so this
+  cannot misclassify real data.
+
+- **Four exception classes with no raise sites were deleted**:
+  `ModelNotFoundError`, `ConvergenceError`, `IsomerEnumerationError`,
+  `TautomerEnumerationError`. Each failure they were meant to describe already
+  happens today through a different, already-relied-upon type
+  (`ConfigurationError`/`ModelLoadError` for a bad or unobtainable model,
+  `OptimizationError` directly for "no 3D structure converged") or through a
+  soft per-molecule warn-and-skip path (isomer/tautomer enumeration), never
+  through these classes. Anyone catching them by name must stop; catch the
+  type that is actually raised instead.
+
+- **`DependencyError` now carries `dependency_name`.** None of its four raise
+  sites set one, so `cli/errors.py`'s install-hint lookup (keyed on
+  `openeye`/`torchani`/`ase`) was unreachable and every dependency failure
+  showed "Install the missing dependency: unknown" regardless of which
+  package was actually missing. All four raise sites now name their
+  dependency, so the real install hint (e.g. `pip install torchani`) finally
+  reaches the user. `DependencyError(message)` without a name still falls
+  back to `"unknown"` rather than crashing the hint lookup.
+
 - **`auto3d run` exits non-zero (code `6`) when input molecules are missing
   from the output.** `_finalize_output` previously raised only when *zero*
   outputs existed at all, so a run that silently lost 9 of 10 chunks -- to
@@ -156,6 +256,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   misspelled arguments were silently ignored.
 
 ### Fixed
+
+- **`calc_spe`, `opt_geometry`, and `calc_thermo` now reject molecules ANI2x/
+  ANI2xt cannot represent.** The element-set/charge guard (elements outside
+  {H, C, N, O, F, S, Cl}, or nonzero formal charge) was only ever inlined
+  inside `check_smi_format`/`check_sdf_format`, reachable solely through
+  `check_input` -- i.e. only from `main()` and `smiles2mols`. The three
+  single-purpose API functions never called it: a carboxylate (or any other
+  charged or out-of-set species) handed to `calc_spe`/`opt_geometry`/
+  `calc_thermo` with `optimizing_engine="ANI2x"`/`"ANI2xt"` was silently
+  evaluated as its neutral form, giving energies and forces wrong by tens of
+  kcal/mol -- and, for `opt_geometry`, an optimized output geometry that is
+  therefore also wrong, not just its reported energy. The guard is now
+  extracted into `utils/validation.py`'s `check_engine_supports_molecules`
+  and called from all three functions before any model inference.
+
+- **A duplicate InChIKey no longer loses one of the two inputs it was meant to
+  preserve.** `smiles2smi` disambiguates two inputs that collapse to the same
+  standard InChIKey by renaming the second to `f"{inchikey}_2"` specifically
+  so it survives instead of being silently deduplicated away. Three separate
+  places downstream then grouped names on the text before the *first*
+  underscore and mapped `KEY_2` straight back to `KEY`: `ranking.py`'s
+  conformer grouping, and `utils/stereochemistry.py`'s `remove_enantiomers`
+  and `amend_configuration` -- the latter two run before conformer embedding
+  even happens, so with `k=1` the second molecule vanished well before
+  ranking ever saw it, and fixing `ranking.py` alone would not have been
+  sufficient. All three now recover the full assigned id (`ranking.py` via a
+  new `species_id()` helper that strips exactly the two trailing
+  `<isomer>_<conformer>` components; the two `stereochemistry.py` sites via
+  the analogous one-component strip, since only the isomer index has been
+  appended at that earlier stage). **Residual, disclosed rather than fixed:**
+  with `enumerate_isomer=False` *and* an InChIKey collision, the SMILES path
+  appends only one trailing component (no isomer index), so a name like
+  `KEY_2_0` is genuinely ambiguous between "species `KEY_2` conformer 0" and
+  "species `KEY` isomer 2 conformer 0" -- this narrow combination still
+  mis-groups, exactly as before this fix, and is not pinned by any test.
+
+- **Three `select_tautomers` configuration errors, and one `check_sdf_format`
+  input error, are now typed exceptions instead of bare `ValueError`.**
+  `select_tautomers`'s "both k and window given", "k<1", and "neither k nor
+  window given" checks now raise `ConfigurationError`, closing a gap the
+  CLI-level guard in `execute_tautomers` did not cover for direct Python API
+  callers. `check_sdf_format`'s empty-molecule-ID check now raises
+  `InputValidationError`, matching `check_smi_format`'s handling of the
+  identical defect (an asymmetry between the two that had gone unfixed).
 
 - **ANI2xt species conversion in the thermochemistry and health-check paths** -
   ANI2xt is constructed with `periodic_table_index=False` everywhere, so it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   first time: a stray key that used to be ignored now raises (an existing
   `docs/legacy-v2/tauto.yaml` example with a stale `tauto_k`/`tauto_window`
   key already failed before this change with a bare `TypeError`; it still
-  fails, now with a field-named `pydantic.ValidationError`).
+  fails, now with an `Auto3D.exceptions.ConfigurationError` whose message
+  names the offending keys). Note the exception type: every `CLIConfig` the
+  CLI builds goes through `build_cli_config`, which translates pydantic's
+  `ValidationError` into `ConfigurationError` so the message keeps the field
+  names while the type stays inside Auto3D's own hierarchy -- an
+  `except Auto3DError` clause catches it, and the CLI reports it as a
+  configuration problem (exit code 2, with a hint) rather than an
+  "Unexpected Error" (exit code 1). Constructing `CLIConfig(...)` directly,
+  bypassing that helper, still raises the raw pydantic `ValidationError`.
 
 - **`k` and `window` can no longer be set together.** They are alternative
   conformer-selection strategies and `ConformerRanker.run` only ever consulted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,13 +69,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GPU requested but unavailable is now fatal at every entry point.**
   `use_gpu=True` on a CPU-only box used to behave three different ways
   depending on how you called Auto3D: `main()` and `smiles2mols` raised
-  `ConfigurationError` (with an unrelated "config init" hint), while `auto3d
+  `ConfigurationError` (with an unrelated "config init" hint); `auto3d
   energy`/`optimize`/`thermo` silently fell back to CPU through
-  `model_factory.get_device` with no error and no warning at all -- a user
-  who asked for GPU and got CPU results had no way to know. A single
-  `check_gpu_requested` helper is now the one place this is decided: it
-  raises `GPUError` (naming `--no-gpu`), and every entry point calls it before
-  any work starts. `model_factory.get_device` itself is unchanged and still
+  `model_factory.get_device` with no error and no warning at all; and
+  `auto3d models test --gpu` had the identical silent fallback through its
+  own call site, while the three single-purpose API functions `calc_spe`,
+  `opt_geometry`, and `calc_thermo` were guarded only at their CLI wrappers --
+  calling any of them directly from a script, with no CLI involved, bypassed
+  the guard entirely. A user -- or a scripted caller who never goes through
+  the CLI -- who asked for GPU and got CPU results had no way to know. A
+  single `check_gpu_requested` helper is now the one place this is decided:
+  it raises `GPUError` (naming `--no-gpu`), and every entry point --
+  `check_input`, `check_valid_configuration`, the CLI commands, and
+  `calc_spe`/`opt_geometry`/`calc_thermo` themselves -- calls it before any
+  work starts. `model_factory.get_device` itself is unchanged and still
   silently returns a CPU device -- the fatal check is enforced by its
   callers, not by the device picker.
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -83,13 +83,9 @@ Custom exception classes for error handling:
    Auto3D.exceptions.ConfigurationError
    Auto3D.exceptions.InputValidationError
    Auto3D.exceptions.ModelError
-   Auto3D.exceptions.ModelNotFoundError
    Auto3D.exceptions.ModelLoadError
    Auto3D.exceptions.NumericalError
    Auto3D.exceptions.OptimizationError
-   Auto3D.exceptions.ConvergenceError
-   Auto3D.exceptions.IsomerEnumerationError
-   Auto3D.exceptions.TautomerEnumerationError
    Auto3D.exceptions.FileFormatError
    Auto3D.exceptions.DependencyError
    Auto3D.exceptions.GPUError

--- a/docs/source/generated/Auto3D.exceptions.ConvergenceError.rst
+++ b/docs/source/generated/Auto3D.exceptions.ConvergenceError.rst
@@ -1,6 +1,0 @@
-﻿Auto3D.exceptions.ConvergenceError
-==================================
-
-.. currentmodule:: Auto3D.exceptions
-
-.. autoexception:: ConvergenceError

--- a/docs/source/generated/Auto3D.exceptions.IsomerEnumerationError.rst
+++ b/docs/source/generated/Auto3D.exceptions.IsomerEnumerationError.rst
@@ -1,6 +1,0 @@
-﻿Auto3D.exceptions.IsomerEnumerationError
-========================================
-
-.. currentmodule:: Auto3D.exceptions
-
-.. autoexception:: IsomerEnumerationError

--- a/docs/source/generated/Auto3D.exceptions.ModelNotFoundError.rst
+++ b/docs/source/generated/Auto3D.exceptions.ModelNotFoundError.rst
@@ -1,6 +1,0 @@
-﻿Auto3D.exceptions.ModelNotFoundError
-====================================
-
-.. currentmodule:: Auto3D.exceptions
-
-.. autoexception:: ModelNotFoundError

--- a/docs/source/generated/Auto3D.exceptions.TautomerEnumerationError.rst
+++ b/docs/source/generated/Auto3D.exceptions.TautomerEnumerationError.rst
@@ -1,6 +1,0 @@
-﻿Auto3D.exceptions.TautomerEnumerationError
-==========================================
-
-.. currentmodule:: Auto3D.exceptions
-
-.. autoexception:: TautomerEnumerationError

--- a/docs/source/migration-4.0.rst
+++ b/docs/source/migration-4.0.rst
@@ -282,13 +282,17 @@ shell script (``auto3d run --json && next_step``).
 
 4.0 exits ``6`` whenever any input molecule produced no output. The results
 summary and, with ``--json``, the JSON document are still printed *before*
-that exit -- a scripted consumer always receives a parseable description of
-what happened, even on the run that is about to signal failure. ``6``
-(``EXIT_PARTIAL_SUCCESS``) extends the exit codes ``cli/errors.py`` already
-used for exceptions raised before or during the run (``0`` success, ``1``
-generic, ``2`` configuration/input, ``3`` dependency, ``4`` GPU, ``5``
-model) with the next unused code, rather than reusing ``1`` and making a
-partial run indistinguishable from a crash.
+that exit -- a scripted consumer checking for exit ``6`` always receives a
+parseable description of what was missing. This guarantee is specific to
+that partial-success path: it holds because the run *completed* and
+``main()`` returned a result to report. If ``main()`` raises instead of
+returning -- a crash, not a partial run -- no JSON is emitted at all; the
+process exits ``1``-``5`` via the same ``handle_error`` panel on stderr as
+any other failure. ``6`` (``EXIT_PARTIAL_SUCCESS``) extends the exit codes
+``cli/errors.py`` already used for exceptions raised before or during the
+run (``0`` success, ``1`` generic, ``2`` configuration/input, ``3``
+dependency, ``4`` GPU, ``5`` model) with the next unused code, rather than
+reusing ``1`` and making a partial run indistinguishable from a crash.
 
 If your pipeline currently checks only ``$? -eq 0`` -- or chains
 ``auto3d run --json && next_step`` -- a run with partial output now stops

--- a/docs/source/migration-4.0.rst
+++ b/docs/source/migration-4.0.rst
@@ -341,14 +341,39 @@ Legacy YAML now rejects unknown keys
 The legacy ``auto3d parameters.yaml`` entry point now builds a ``CLIConfig``
 (the same schema ``auto3d run -c`` uses) instead of constructing
 ``Auto3DOptions`` directly, so ``extra="forbid"`` now applies to it. A key
-your YAML file carries that ``CLIConfig`` does not recognize now raises a
-field-named ``pydantic.ValidationError`` instead of being silently ignored.
-This was never truly silent -- an unrecognized key already raised a bare
-``TypeError`` from ``Auto3DOptions``'s constructor before this release -- but
-the message is now specific rather than generic, and it now matches what
-``auto3d run -c`` has always done for the same mistake. (One stale example in
-the repository, ``docs/legacy-v2/tauto.yaml``, carries keys from a removed
-feature and fails both before and after this change.)
+your YAML file carries that ``CLIConfig`` does not recognize now raises
+``Auto3D.exceptions.ConfigurationError``, naming the offending key, instead
+of being silently ignored. This was never truly silent -- an unrecognized key
+already raised a bare ``TypeError`` from ``Auto3DOptions``'s constructor
+before this release -- but the message is now specific rather than generic,
+and it now matches what ``auto3d run -c`` has always done for the same
+mistake. (One stale example in the repository, ``docs/legacy-v2/tauto.yaml``,
+carries keys from a removed feature and fails both before and after this
+change.)
+
+Catch ``ConfigurationError``, not ``pydantic.ValidationError``. Pydantic is
+what detects the unknown key, but every ``CLIConfig`` the CLI builds is
+constructed through ``Auto3D.cli.config_schema.build_cli_config``, which
+translates ``ValidationError`` into ``ConfigurationError`` -- keeping the
+field-named message while putting the exception inside Auto3D's own
+hierarchy, so ``except Auto3DError`` catches it and the CLI reports a
+configuration problem (exit code 2, with a hint) rather than an "Unexpected
+Error" (exit code 1):
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   from Auto3D.cli.config_schema import load_yaml_config
+   from Auto3D.exceptions import ConfigurationError
+
+   try:
+       config = load_yaml_config(Path("my_params.yaml"))
+   except ConfigurationError as exc:
+       print(f"bad config: {exc}")
+
+Constructing ``CLIConfig(...)`` directly, bypassing that helper, still raises
+the raw pydantic ``ValidationError``.
 
 GPU requested but unavailable is now fatal everywhere
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/migration-4.0.rst
+++ b/docs/source/migration-4.0.rst
@@ -268,6 +268,166 @@ threonine) keeps two surviving diastereomers, so the same ``max_confs=12``
 does produce up to 24 there. A stereoisomer ETKDG cannot embed is now named in
 a logged warning instead of disappearing from the output with no trace.
 
+Configuration and validation changes
+-------------------------------------
+
+Numeric bounds are now enforced on every entry point
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A single ``FIELD_BOUNDS`` table now backs both ``Auto3DOptions.__post_init__``
+and ``CLIConfig``'s model validator, so the Python API, ``auto3d run -c``, and
+the legacy ``auto3d parameters.yaml`` all reject the same out-of-range values
+the same way. Before this release, several of these values were accepted
+everywhere and silently produced results that did not match what they
+appeared to be:
+
+- ``threshold=-1`` (or any negative value) disabled duplicate-conformer
+  removal entirely, while the output SDF looked exactly like a deduplicated
+  one.
+- ``convergence_threshold=0`` made the optimizer treat every step as
+  unstable, so it burned the full ``opt_steps`` budget on every conformer
+  instead of stopping early once actually converged.
+- ``max_confs=0`` produced zero conformers for every molecule (``max_confs``
+  had no lower bound on any path before this release).
+
+If a run used any of these values, treat its output as suspect and recompute
+rather than assume it means what it appears to. The full set of bounds now
+enforced: ``k >= 1``, ``window > 0``, ``mpi_np >= 1``, ``opt_steps >= 1``,
+``convergence_threshold > 0``, ``patience >= 1``, ``threshold > 0``,
+``batchsize_atoms >= 1``, ``memory >= 1``, ``capacity >= 1``, and
+``max_confs >= 1``. ``None``/``False`` still mean "not specified" and are not
+rejected.
+
+A related, narrower change: ``k=0`` used to be accepted by ``Auto3DOptions``
+as a silent "unset" sentinel (``CLIConfig`` already rejected it via
+``Field(ge=1)``). It is now rejected on both, for parity between the two --
+this is a real behavior change beyond the bounds above, not a consequence of
+them.
+
+``Auto3DOptions(path="in.smi", k=1, threshold=-1)`` and
+``Auto3DOptions(path="in.smi", k=1, convergence_threshold=0)`` were both
+accepted in 3.x, silently producing the results described above; both now
+raise ``ConfigurationError`` immediately, before a run starts.
+
+``k`` and ``window`` together now raise; the ``thorough`` preset changed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``k`` (top-k selection) and ``window`` (energy-window selection) are
+alternative conformer-selection strategies, and ``ConformerRanker.run`` only
+ever consulted one of them (``if self.k: ... elif self.window: ...``), so
+setting both meant ``k`` silently won and ``window`` had no effect.
+``Auto3DOptions``/``CLIConfig`` and ``ConformerRanker.run`` itself now raise
+if both are set.
+
+**The shipped ``thorough`` preset set both** (``k: 10, window: 5.0``).
+Because ``k`` always won, every user who selected ``-p thorough`` has only
+ever gotten top-10 selection -- ``window: 5.0`` never took effect. The preset
+now sets only ``k: 10``, which preserves exactly what those users were
+already getting, rather than silently switching them to window-based
+selection under the same preset name. If you generated a ``thorough.yaml``
+config file before this release, it still has both keys and will now raise;
+delete one of the two.
+
+Legacy YAML now rejects unknown keys
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The legacy ``auto3d parameters.yaml`` entry point now builds a ``CLIConfig``
+(the same schema ``auto3d run -c`` uses) instead of constructing
+``Auto3DOptions`` directly, so ``extra="forbid"`` now applies to it. A key
+your YAML file carries that ``CLIConfig`` does not recognize now raises a
+field-named ``pydantic.ValidationError`` instead of being silently ignored.
+This was never truly silent -- an unrecognized key already raised a bare
+``TypeError`` from ``Auto3DOptions``'s constructor before this release -- but
+the message is now specific rather than generic, and it now matches what
+``auto3d run -c`` has always done for the same mistake. (One stale example in
+the repository, ``docs/legacy-v2/tauto.yaml``, carries keys from a removed
+feature and fails both before and after this change.)
+
+GPU requested but unavailable is now fatal everywhere
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``use_gpu=True`` on a machine with no visible CUDA device used to behave
+three different ways depending on the entry point:
+
+- ``main()`` and ``smiles2mols`` raised ``ConfigurationError``, but showed the
+  CLI's unrelated "config init" hint.
+- ``auto3d energy``/``optimize``/``thermo`` silently fell back to CPU through
+  ``model_factory.get_device``, with no error and no warning at all.
+
+A user who asked for GPU and got CPU results from the second group had no way
+to know their "GPU" run was actually computed on CPU. A single
+``check_gpu_requested`` helper is now the one place this is decided: every
+entry point calls it before doing any work, and it always raises ``GPUError``
+(exit code ``4``), naming ``--no-gpu``/``use_gpu=False`` as the fix.
+``model_factory.get_device`` itself still silently returns a CPU device when
+asked -- the fatal check is enforced by its callers, not by the device
+picker, so a direct call to ``get_device`` is unaffected.
+
+``smiles2mols`` raises on options it cannot honor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``smiles2mols`` has no tautomer-enumeration step and hardcodes the RDKit
+isomer engine, but previously accepted ``enumerate_tautomer=True``,
+a non-``"rdkit"`` ``isomer_engine``, and ``mode_oe`` without effect or
+warning. It now raises ``ConfigurationError`` naming the option and pointing
+at ``main()`` for tautomer enumeration or a non-RDKit isomer engine.
+``smiles2mols`` also now calls ``check_valid_configuration`` -- the same
+GPU/engine/path checks ``main()`` has always run -- so a bad configuration is
+caught up front instead of failing deep inside a worker process.
+
+``smiles2mols(["CCO"], Auto3DOptions(k=1, enumerate_tautomer=True))`` used to
+run and silently skip tautomer enumeration; it now raises
+``ConfigurationError`` instead. ``mode_oe`` gets no separate check: it is
+only ever read when ``isomer_engine == "omega"``, so rejecting a non-RDKit
+``isomer_engine`` already covers the only case where it could matter.
+
+Separately, ``smiles2mols`` no longer mutates the ``Auto3DOptions`` object
+you pass it -- it copies it (``dataclasses.replace``) on entry before setting
+its own internal ``path``/``input_format``. Previously it overwrote your
+object's ``path`` and ``input_format`` fields in place, which could leave you
+holding a config whose ``path`` pointed at a temporary directory
+``smiles2mols`` had already deleted. ``WorkflowOrchestrator.run()`` (used by
+``main()``) makes the same defensive copy for the same reason, so a shared
+``Auto3DOptions`` object can now safely be reused across two separate runs.
+
+``auto3d validate`` now agrees with the runner
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``auto3d validate`` previously approved SMILES files the runner then rejected:
+``validate_smiles_file`` never required an ID column, while
+``encode_ids``/``iter_smi_records`` always have, so an ID-less line passed
+validation and then failed the actual run -- whose error hint told you to run
+the validator that had just approved it. ``validate`` now requires the same
+SMILES+ID pair the runner does.
+
+The two also disagreed on ``#``-prefixed comment lines: ``validate`` skipped
+them, the runner did not. Both now skip them consistently (``validate``,
+``iter_smi_records``, and ``check_smi_format``) -- a SMILES token can never
+begin with ``#``, so this cannot misclassify real data either way.
+
+Exception hierarchy changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Four exception classes with no raise sites anywhere in the codebase are
+removed: ``ModelNotFoundError``, ``ConvergenceError``,
+``IsomerEnumerationError``, ``TautomerEnumerationError``. Each failure they
+were meant to describe already happens today through a different type that is
+actually raised and actually relied on (``ConfigurationError``/
+``ModelLoadError`` for a bad or unobtainable model, ``OptimizationError``
+directly for "no 3D structure converged") or through a soft per-molecule
+warn-and-skip path (isomer/tautomer enumeration). If you catch any of these
+four by name, update the ``except`` clause to the type that is actually
+raised -- there is no replacement class.
+
+``DependencyError`` gained a ``dependency_name`` attribute. None of its four
+raise sites set one before this release, so the CLI's install-hint lookup
+(keyed on ``openeye``/``torchani``/``ase``) was unreachable and every
+dependency failure showed "Install the missing dependency: unknown"
+regardless of which package was actually missing. All four raise sites now
+name their dependency, so the real hint (e.g. ``pip install torchani``)
+reaches the user. Code that constructs ``DependencyError`` directly can pass
+``dependency_name=...``; omitting it still falls back to ``"unknown"``.
+
 CLI behavior changes
 --------------------
 

--- a/docs/source/migration-4.0.rst
+++ b/docs/source/migration-4.0.rst
@@ -353,15 +353,25 @@ three different ways depending on the entry point:
   CLI's unrelated "config init" hint.
 - ``auto3d energy``/``optimize``/``thermo`` silently fell back to CPU through
   ``model_factory.get_device``, with no error and no warning at all.
+- ``auto3d models test --gpu`` had the identical silent fallback through its
+  own, separate call site, and the three single-purpose API functions
+  ``calc_spe``, ``opt_geometry``, and ``calc_thermo`` were guarded only at
+  their CLI wrappers in ``cli/commands/properties.py`` -- calling any of them
+  directly from a script, with no CLI involved at all, bypassed the guard
+  entirely and hit the same silent fallback.
 
-A user who asked for GPU and got CPU results from the second group had no way
-to know their "GPU" run was actually computed on CPU. A single
-``check_gpu_requested`` helper is now the one place this is decided: every
-entry point calls it before doing any work, and it always raises ``GPUError``
-(exit code ``4``), naming ``--no-gpu``/``use_gpu=False`` as the fix.
-``model_factory.get_device`` itself still silently returns a CPU device when
-asked -- the fatal check is enforced by its callers, not by the device
-picker, so a direct call to ``get_device`` is unaffected.
+A user -- or a scripted caller who never goes through the CLI -- who asked
+for GPU and got CPU results from the second or third group had no way to
+know their "GPU" run was actually computed on CPU. A single
+``check_gpu_requested`` helper is now the one place this is decided:
+``check_input``, ``check_valid_configuration``, the ``energy``/``optimize``/
+``thermo`` and ``models test`` CLI commands, and ``calc_spe``/
+``opt_geometry``/``calc_thermo`` themselves all call it before doing any
+work, and it always raises ``GPUError`` (exit code ``4``), naming
+``--no-gpu``/``use_gpu=False`` as the fix. ``model_factory.get_device``
+itself still silently returns a CPU device when asked -- the fatal check is
+enforced by its callers, not by the device picker, so a direct call to
+``get_device`` is unaffected.
 
 ``smiles2mols`` raises on options it cannot honor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/migration-4.0.rst
+++ b/docs/source/migration-4.0.rst
@@ -296,7 +296,14 @@ enforced: ``k >= 1``, ``window > 0``, ``mpi_np >= 1``, ``opt_steps >= 1``,
 ``convergence_threshold > 0``, ``patience >= 1``, ``threshold > 0``,
 ``batchsize_atoms >= 1``, ``memory >= 1``, ``capacity >= 1``, and
 ``max_confs >= 1``. ``None``/``False`` still mean "not specified" and are not
-rejected.
+rejected, but only for the four optional fields with a genuine "unset"
+meaning: ``k``, ``window``, ``memory``, and ``max_confs``
+(``Auto3D.config.SENTINEL_FIELDS``). The other seven bounds above always have
+a concrete default and have no "unset" state to opt into, so ``None``/
+``False`` are rejected there too, identically on both entry points --
+``Auto3DOptions(path="in.smi", threshold=None)`` used to be silently accepted
+while ``CLIConfig(path=Path("in.smi"), threshold=None)`` always rejected it;
+both now raise.
 
 A related, narrower change: ``k=0`` used to be accepted by ``Auto3DOptions``
 as a silent "unset" sentinel (``CLIConfig`` already rejected it via

--- a/docs/superpowers/plans/2026-07-31-phase5-validation-unification.md
+++ b/docs/superpowers/plans/2026-07-31-phase5-validation-unification.md
@@ -1,0 +1,330 @@
+# Phase 5 — Validation Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The same configuration is validated identically through every entry point, and no option is accepted that the code cannot honor.
+
+**Architecture:** Validation quality currently depends on which door the user came through. `auto3d run -c` is well validated by `CLIConfig`'s Pydantic `Field` bounds; the Python API and the legacy YAML path — what scientific users script against — enforce almost nothing. This phase pushes one set of bounds into every path, extracts the element/charge guard so the auxiliary entry points can use it, and removes the options that are accepted and silently ignored.
+
+**Tech Stack:** Python 3.11+, Pydantic v2, Typer/Rich CLI, RDKit, pytest.
+
+**Source spec:** `docs/superpowers/specs/2026-07-30-audit-remediation-design.md` §8.
+**Verified facts:** `.superpowers/notes/phase5-verified-facts.md` — **read it before Task 1.** Three of the spec's claims are wrong and are corrected there.
+
+---
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+**Authorship (repository owner's global rules, mechanically enforced):**
+- Commits authored solely by Olexandr Isayev. No `Co-Authored-By`, no `Signed-off-by`, no generated-by footers.
+- No commit message, branch name, PR title or body may mention AI assistance, Claude, Copilot, or any AI tool.
+- Never modify `user.name`, `user.email`, or `commit.gpgsign`.
+
+**Development box limits — hard:**
+- ~2 GB RAM; 8 CUDA devices in active use by other work.
+- **Never run `pytest -m slow`.** **Never load a neural network potential.** Never trigger a model download.
+- Only test command: `pytest tests/ -q -rxX -m "not slow" -p no:randomly`. Use `-p no:randomly`: under default randomized ordering the count varies by a few tests because of a pre-existing multiprocessing-start-method sensitivity in `test_parallel_embed.py` / `test_mp_start_method.py`, unrelated to this work.
+- Registry name and path lookups are pure offline dict reads and are safe.
+
+**Git discipline:**
+- One new commit per task. **Never `git commit --amend`.**
+- **Never `git checkout`, `git worktree`, `git restore` or `git stash`** — an agent destroyed uncommitted work that way. Apply and revert verification mutations with Edit in both directions.
+- `git add` only the files a task names. Never `git add -A`.
+- Verify each message with `git log -1 --format=%B | cat -A`.
+
+**Release vehicle:** 4.0.0. Breaking changes approved. This phase's planned breaks: **B9** (`Auto3DOptions` enforces `CLIConfig`'s bounds), **B10** (`k` and `window` together raise), **B11** (`smiles2mols` raises on options it cannot honor).
+
+**Tripwire discipline.** Eight markers are owned here, **all fast-tier — every one must actually be run.**
+
+| Finding | Node ID (`tests/test_config_parity.py`) | Task |
+|---|---|---|
+| C10 | `TestAuto3DOptionsBounds::test_negative_threshold_is_rejected` | 1 |
+| M27 | `TestAuto3DOptionsBounds::test_zero_max_confs_is_rejected` | 1 |
+| C10 | `TestAuto3DOptionsBounds::test_zero_convergence_threshold_is_rejected` | 1 |
+| M28 | `TestMutuallyExclusiveSelectors::test_k_and_window_together_raise` | 2 |
+| C11 | `TestAuxiliaryEntryPointGuards::test_calc_spe_rejects_charged_input_for_ani` | 3 |
+| M15 | `TestSmiles2MolsHonesty::test_unsupported_option_raises` | 4 |
+| M15 | `TestSmiles2MolsHonesty::test_caller_config_is_not_mutated` | 4 |
+| M17 | `TestDuplicateInchikeyInputs::test_duplicate_smiles_both_survive` | 5 |
+
+- The owning task deletes its marker in the same commit; `strict=True` makes a passing xfail a hard failure.
+- The two remaining markers after this phase are C14 ×2 in `tests/test_durability.py`, owned by Phase 6.
+- Repository-wide inventory must go **10 → 2**.
+
+**Style:** American spelling. Type hints on new functions. `ruff check src/ tests/` clean before every commit. Match surrounding comment density.
+
+**Report wall time with every test run.** A task in Phase 4 quadrupled the suite runtime without noticing.
+
+---
+
+### Task 1: C10 and M27 — one set of bounds, on every path
+
+`Auto3DOptions.__post_init__` (`config.py:143-153`) only lowercases three engine strings and rejects strictly-negative `k`/`window`. Verified live: `Auto3DOptions(path="x.smi", k=1, threshold=-1)` and `convergence_threshold=0` are both accepted. `threshold=-1` sets `pruneRmsThresh=-1` and makes `rmsd < -1` never true, **silently disabling duplicate-conformer removal while presenting the output as deduplicated**. `convergence_threshold=0` makes `fmax > opttol` permanently true, burning all 2000 steps. And `max_confs` has no lower bound in **any** of the three paths, so `max_confs=0` reaches `EmbedMultipleConfs(numConfs=0)` and every molecule yields nothing.
+
+The legacy YAML path (`auto3Dcli.py:82-119`) calls `Auto3DOptions(**parameters)` directly at `:118` and never constructs a `CLIConfig`, so it skips every `Field` bound, the engine registry check, and the `Literal` validation.
+
+**Files:**
+- Modify: `src/Auto3D/config.py`
+- Modify: `src/Auto3D/cli/config_schema.py` (add the missing `max_confs` bound)
+- Modify: `src/Auto3D/auto3Dcli.py`
+- Modify: `tests/test_config_parity.py` (delete three decorators)
+
+**Interfaces:**
+- Produces: `Auto3DOptions.__post_init__` raising `ConfigurationError` for out-of-range values. Later tasks rely on this being the single place bounds live.
+
+- [ ] **Step 1: Delete the three decorators and run them**
+
+In `tests/test_config_parity.py`, delete only the decorators on `test_negative_threshold_is_rejected`, `test_zero_max_confs_is_rejected` and `test_zero_convergence_threshold_is_rejected`. Then:
+
+```bash
+pytest tests/test_config_parity.py -q -rxX -m "not slow" -p no:randomly
+```
+
+**These are fast-tier — run them and record the failures.** Read each test first: they define which exception type is expected. Satisfy the tests as written; if one demands something you believe is wrong, report it rather than editing it.
+
+- [ ] **Step 2: Give `Auto3DOptions` the bounds `CLIConfig` already has**
+
+Read `CLIConfig`'s field list (`config_schema.py:29-71`) and mirror **every** numeric bound into `__post_init__`. The measured set: `k` ≥ 1, `window` > 0, `mpi_np` ≥ 1, `opt_steps` ≥ 1, `convergence_threshold` > 0, `patience` ≥ 1, `threshold` > 0, `batchsize_atoms` ≥ 1, `memory` ≥ 1, `capacity` ≥ 1, and `max_confs` ≥ 1 — which `CLIConfig` is **also** missing (`config_schema.py:52` is a plain `int | None`), so add it in both places.
+
+Raise `ConfigurationError`, not `ValueError`, so the CLI's differentiated exit-code table applies. Name the field and the received value in every message.
+
+Write the bounds **once** if you can find a clean way to share them between the dataclass and the Pydantic model, rather than as two hand-maintained lists — the spec's concern is exactly that these drift. If sharing proves invasive, keep them separate but add a test asserting the two sets agree field-by-field, so drift fails the suite rather than shipping.
+
+- [ ] **Step 3: Route legacy YAML through `CLIConfig`**
+
+In `auto3Dcli.py`'s `_run_legacy_yaml`, replace the direct `Auto3DOptions(**parameters)` with a `CLIConfig` construction followed by `.to_auto3d_options()`. That single change inherits `extra="forbid"`, the engine registry check, `parse_gpu_idx`, the `Literal` validation and every `Field` bound.
+
+Be careful: the legacy path converts `"None"` strings to `None` before constructing. Confirm that conversion still happens before `CLIConfig` sees the values, and that a YAML key `CLIConfig` does not know now produces a clear error rather than a Pydantic traceback — `extra="forbid"` is a behavior change for anyone with a stray key in their `parameters.yaml`, and it belongs in the docs.
+
+- [ ] **Step 4: Run, verify parity, commit**
+
+```bash
+pytest tests/test_config_parity.py -q -rxX -m "not slow" -p no:randomly
+pytest tests/ -q -rxX -m "not slow" -p no:randomly
+ruff check src/ tests/
+```
+
+Add a test asserting the phase's exit criterion directly: the same `parameters.yaml` produces identical validation results through `auto3d run -c`, the legacy `auto3d parameters.yaml` path, and `Auto3DOptions(**yaml)` — and that `threshold=-1` is rejected by all three.
+
+Watch for existing tests that construct an out-of-range `Auto3DOptions` deliberately. Any that do encoded the permissive behavior; update them and say so.
+
+```bash
+git add src/Auto3D/config.py src/Auto3D/cli/config_schema.py src/Auto3D/auto3Dcli.py tests/test_config_parity.py
+git commit -m "fix!: enforce configuration bounds on every entry point
+
+Auto3DOptions validated only k and window, and only rejected strictly-negative
+values, so threshold=-1 was accepted end to end -- setting pruneRmsThresh=-1
+and making rmsd < -1 never true, which silently disabled duplicate-conformer
+removal while presenting the output as deduplicated. convergence_threshold=0
+made fmax > opttol permanently true and burned every optimization step.
+max_confs had no lower bound in any path, so max_confs=0 reached
+EmbedMultipleConfs(numConfs=0) and every molecule produced nothing.
+
+The legacy YAML entry point constructed Auto3DOptions directly, skipping every
+Field bound, the engine registry check and the Literal validation; it now goes
+through CLIConfig like auto3d run -c."
+```
+
+---
+
+### Task 2: M28 — `k` and `window` are mutually exclusive, and a shipped preset proves it
+
+`ConformerRanker.run` (`ranking.py:196-198`) tests `if self.k:` before `elif self.window:`, so whenever both are set the window is silently ignored. The shipped `thorough` preset (`cli/commands/config.py:52-56`) sets **both** `k=10` and `window=5.0` — so a preset Auto3D ships has an inert setting, and any user who trusted it got top-10 selection rather than a 5 kcal/mol window.
+
+**Files:**
+- Modify: `src/Auto3D/config.py` (or wherever Task 1 put the validation)
+- Modify: `src/Auto3D/cli/commands/config.py` (the preset)
+- Modify: `tests/test_config_parity.py` (delete the M28 decorator)
+
+- [ ] **Step 1: Delete the decorator and run it.** Fast-tier — record the failure.
+
+- [ ] **Step 2: Raise when both are set.** Match `select_tautomers`, which the spec says already does this — read it and follow its exception type and message shape rather than inventing a new one. Put the check where Task 1 put the other bounds, so every entry point inherits it.
+
+- [ ] **Step 3: Fix the preset.** Decide whether `thorough` should mean top-k or a window, and say why in your report. It has shipped as top-10 (because `k` won), so **choosing `window` silently changes what existing users get** — if you pick `window`, that belongs in the docs as a behavior change.
+
+- [ ] **Step 4: Add a test that every shipped preset is self-consistent** — no preset may set both. This is the guard that would have caught the original defect, and presets are exactly the kind of data nobody re-reads.
+
+- [ ] **Step 5: Run, lint, commit.**
+
+```
+fix!: reject k and window together
+
+ConformerRanker tested k before window, so setting both silently ignored the
+window. The shipped `thorough` preset set both, making its window: 5.0 inert --
+users who selected it got top-10 selection instead. Both are now rejected
+together, and every shipped preset is checked for the same mistake.
+```
+
+---
+
+### Task 3: C11 — extract the element/charge guard so the auxiliary entry points can use it
+
+**The spec is wrong about this one.** It says to "call the existing element/charge guard" from `calc_spe`, `opt_geometry` and `calc_thermo`. **No such function exists.** The check — `ANI_elements = {1,6,7,8,9,16,17}` plus `GetFormalCharge` — is inlined inside `check_smi_format` (`utils/validation.py:159,208-210`) and `check_sdf_format` (`:236,250-252`), both reachable only through `check_input` (`:36,112-120`). Its only callers are `auto3D.py:139` (`smiles2mols`) and `workflow.py:203` (`main()`).
+
+So a carboxylate handed to ANI2x through `calc_spe` is evaluated as the neutral species: tens of kcal/mol wrong, with wrong forces, so the "optimized" geometry is wrong too.
+
+**Files:**
+- Modify: `src/Auto3D/utils/validation.py` (extract the guard)
+- Modify: `src/Auto3D/SPE.py`, `src/Auto3D/ASE/geometry.py`, `src/Auto3D/ASE/thermo.py`
+- Modify: `tests/test_config_parity.py` (delete the C11 decorator)
+
+- [ ] **Step 1: Delete the decorator and run it.** Fast-tier. **Read the test first** — it stubs the model machinery (`get_device`/`create_model`/`EnForce_ANI`/`pad_from_mols`) so `calc_spe` itself runs for real without loading a potential, the same technique `test_isomer_engine_hardening.py` and `test_durability.py` use. Your fix must sit early enough in `calc_spe` to be reached with those stubs in place.
+
+- [ ] **Step 2: Extract the guard into a callable function.** It should take a molecule or a list of molecules and the engine name, and raise when the engine cannot represent the input. Have `check_smi_format` and `check_sdf_format` call it, so there is one implementation rather than two inlined copies that can drift — they currently duplicate the element set.
+
+- [ ] **Step 3: Call it from the three API functions.** These accept SDF paths, not SMILES, so check what each actually receives before wiring.
+
+- [ ] **Step 4: Move the engine-name guard in too.** Phase 4 left `resolve_engine_name` at three CLI call sites (`cli/commands/properties.py:59,80,101`) rather than inside these functions, because `test_durability.py`'s C14 tripwire calls `opt_geometry` with a deliberately invalid model name. **Now that you are adding validation inside these functions anyway, move the engine guard in as well** and update C14's test to pass a valid name — its point is durability of the input file, not the model name. If that turns out to break C14's premise, stop and report; do not weaken the tripwire.
+
+- [ ] **Step 5: Run, lint, commit.**
+
+```
+fix!: guard the auxiliary entry points against unsupported input
+
+check_input's element and charge validation ran only in main() and
+smiles2mols, and existed only as two inlined copies inside check_smi_format
+and check_sdf_format. A carboxylate handed to ANI2x through calc_spe was
+evaluated as the neutral species -- tens of kcal/mol wrong, with wrong forces,
+so the optimized geometry was wrong too.
+
+The guard is now one function, called by both format checkers and by calc_spe,
+opt_geometry and calc_thermo. The engine-name check moves in alongside it.
+```
+
+---
+
+### Task 4: M15 and M16 — say what you do not do, and stop mutating the caller
+
+In `smiles2mols` (`auto3D.py:102-196`): `enumerate_tautomer` is never read, `isomer_engine` is ignored (`IsomerEngineFactory.create(engine_type="rdkit", ...)` is hardcoded at `:151`), and `mode_oe` is never passed. It calls `check_input` (`:139`) but **not** `check_valid_configuration`, so an out-of-range `gpu_idx` fails opaquely. And it mutates the caller's object at `:130` (`args['path'] = path0`) and `:138` (`args.input_format = 'smi'`), leaving `path` pointing into a deleted temporary directory.
+
+Separately (M16), `WorkflowOrchestrator`'s comment at `workflow.py:329-331` says the caller's shared config is never mutated. That is true of `_run_pipeline`'s local `replace()` at `:332`, but `_validate_input` mutates `self.config` at `:169` and `:180` — so the comment reads as a broader guarantee than it makes.
+
+**Files:**
+- Modify: `src/Auto3D/auto3D.py`
+- Modify: `src/Auto3D/workflow.py`
+- Modify: `tests/test_config_parity.py` (delete two M15 decorators)
+
+- [ ] **Step 1: Delete both decorators and run them.** Fast-tier. Both stub the pipeline stages, so they are hermetic — read `_stub_pipeline` before changing anything.
+
+- [ ] **Step 2: Raise on options that cannot be honored** (B11). Name the specific option in the message and say what to use instead — `main()` for tautomer enumeration or a non-RDKit isomer engine. Raising `NotImplementedError` or an `Auto3DError` both satisfy the test; pick one and justify it.
+
+- [ ] **Step 3: Stop mutating the caller.** Take a copy at the top. Then call `check_valid_configuration` so `gpu_idx` and the rest are validated the way `main()` validates them.
+
+- [ ] **Step 4: Fix `WorkflowOrchestrator` (M16).** Either apply `replace()` once at the top of `run()` so the claim becomes true, or narrow the comment to what it actually guarantees. **Prefer making the claim true** — a second `main(args)` in one process currently reuses the first run's `job_name`, which is a real defect, not just a documentation one. Add a test for the two-runs-in-one-process case.
+
+- [ ] **Step 5: Run, lint, commit.**
+
+```
+fix!: smiles2mols raises on options it cannot honor
+
+enumerate_tautomer, isomer_engine and mode_oe were accepted and ignored -- the
+function has no tautomer step and hardcodes the RDKit engine. It also skipped
+check_valid_configuration, so an out-of-range gpu_idx failed opaquely, and it
+mutated the caller's config, leaving path pointing into a deleted temporary
+directory.
+
+WorkflowOrchestrator now copies the caller's config once at the top of run(),
+making the invariant its comment already claimed true: a second main(args) in
+one process no longer reuses the first run's job_name.
+```
+
+---
+
+### Task 5: M17 — a disambiguated InChIKey must not be re-merged
+
+`smiles2smi` (`utils/file_ops.py:119`) disambiguates a duplicate InChIKey as `f"{inchikey}_{count}"` — `KEY_2` — **specifically so the second input is not dropped**. Then `ConformerRanker.run` (`ranking.py:188`) groups on `_Name.split("_")[0]`, mapping `KEY_2` straight back to `KEY`. With `k=1` the second molecule silently vanishes.
+
+**Files:**
+- Modify: `src/Auto3D/ranking.py`
+- Modify: `tests/test_config_parity.py` (delete the M17 decorator)
+
+- [ ] **Step 1: Delete the decorator and run it.** Fast-tier.
+
+- [ ] **Step 2: Group on the full assigned ID.** This is delicate: `split("_")[0]` is load-bearing elsewhere. Conformer names are `<species>_<isomer>_<conformer>` on both input paths after Phase 2, and the final write sets `_Name` to `t.split("_")[0]`. Work out what the group key must be so that conformers of one species still group together **and** `KEY_2` stays distinct from `KEY`, and say in your report how you verified both properties. Phase 2's `tests/test_sdf_isomer_enumeration.py` pins the naming; run it.
+
+- [ ] **Step 3: Run the ranking and pipeline tests specifically**, then the full suite. A regression here silently changes which conformers are emitted, so name in your report which existing tests cover grouping and confirm they still pass for the right reason.
+
+- [ ] **Step 4: Lint, commit.**
+
+```
+fix: keep a disambiguated InChIKey distinct through ranking
+
+smiles2smi renames a duplicate InChIKey to KEY_2 so the second input is not
+dropped, but ranking grouped on the text before the first underscore and
+mapped it straight back to KEY. With k=1 the second molecule vanished.
+```
+
+---
+
+### Task 6: M26 and M29 — typed exceptions that carry what the hints need
+
+`DependencyError` (`exceptions.py:102-108`) defines no `dependency_name`, and none of its four raise sites (`utils/validation.py:72,82,90`, `cli/commands/properties.py:104`) sets one. `cli/errors.py:62` reads `getattr(error, "dependency_name", "unknown")` into a hints map keyed on `openeye`/`torchani`/`ase` — so **every user sees "Install the missing dependency: unknown"** and the map is dead.
+
+Four exception classes have **zero raise sites**: `ModelNotFoundError` (`:41`), `ConvergenceError` (`:72`), `IsomerEnumerationError` (`:81`), `TautomerEnumerationError` (`:89`). There are 29 bare `ValueError`/`RuntimeError` raises in `src/` for domain errors, so the differentiated exit-code table is largely unreachable.
+
+**Files:**
+- Modify: `src/Auto3D/exceptions.py`, `src/Auto3D/utils/validation.py`, `src/Auto3D/cli/commands/properties.py`
+- Modify: the modules holding the domain raises you convert
+
+- [ ] **Step 1: Give `DependencyError` its `dependency_name`** and set it at all four raise sites. Add a test that each produces the hint the map intends — the defect is that the hint was unreachable, so a test asserting the exception type alone would not catch a regression.
+
+- [ ] **Step 2: Use or delete the four dead classes.** For each, either convert the matching bare raises or delete the class. **Deleting is a legitimate outcome** — an exception class nobody raises is the same dead-code shape as C9 and C7. Decide per class and justify each in your report.
+
+- [ ] **Step 3: Convert the domain raises you can do safely.** Do not attempt all 29 — prioritize those on user-facing paths where the exit code matters, and list in your report which you converted and which you left with the reason. A half-converted hierarchy that is honest beats a fully-converted one that mislabels a programming error as a domain error.
+
+- [ ] **Step 4: Fix the `.smi`/`.sdf` asymmetry** the spec names: the same empty-ID defect raises `InputValidationError` in one path and a bare `ValueError` in the other. Verify it still exists before fixing it.
+
+- [ ] **Step 5: Run, lint, commit.**
+
+---
+
+### Task 7: M23 and M25 — one GPU policy, and a validator that agrees with the runner
+
+**M23:** `check_valid_configuration` runs first (`workflow.py:186-201`) and raises `ConfigurationError` at `validation.py:314-315` when GPU is requested without CUDA, so `check_input`'s `GPUError` (`validation.py:66-68`) is unreachable from `main()` — though it **is** reachable through `smiles2mols`, which never calls `check_valid_configuration`. Meanwhile `auto3d energy` on a CPU-only box silently falls back to CPU through `get_device` (`model_factory.py:179-193`): no error, no warning. Three entry points, three behaviors.
+
+**M25:** `validate_smiles_file` (`cli/commands/validate.py:26-56`) does not require an ID column (`:42`), but `encode_ids`/`iter_smi_records` require ≥2 tokens and raise `InputValidationError` (`file_ops.py:64-69`). So a SMILES-only file **passes `auto3d validate` and then fails the run**, whose hint tells the user to run the validator that just approved it. They also disagree on comments: `validate` skips `#` lines (`:37`); `iter_smi_records` has no comment handling at all.
+
+**Files:**
+- Modify: `src/Auto3D/utils/validation.py`, `src/Auto3D/cli/commands/validate.py`, `src/Auto3D/utils/file_ops.py`, and the auxiliary command modules
+
+- [ ] **Step 1: Pick one GPU policy and apply it everywhere.** Fatal, or fallback-with-warning. Say which you chose and why. The criterion is that a user gets the same answer regardless of entry point — and that whichever you choose, a CPU-only box gets a message naming `--no-gpu` rather than an unrelated hint.
+
+- [ ] **Step 2: Make `auto3d validate` agree with the runner.** The validator must reject exactly what the runner rejects. Decide the comment-line question deliberately: either both skip `#` lines or neither does. A validator that is more permissive than the runner is worse than no validator, because its approval is what the user acts on.
+
+- [ ] **Step 3: Add a parity test** — a file that passes `auto3d validate` must not fail `encode_ids`, and vice versa. Cover the ID-less line and the comment line specifically.
+
+- [ ] **Step 4: Run, lint, commit.**
+
+---
+
+### Task 8: Release documentation
+
+**Files:** `CHANGELOG.md`, `docs/source/migration-4.0.rst`
+
+- [ ] **Read the commits first** (`git log -p` over this phase) and describe what landed. Four earlier phases each diverged from their plans during review; expect the same.
+
+- [ ] **Lead Breaking Changes** with the three planned breaks — B9 (bounds enforced everywhere, so a config that used to be accepted now raises), B10 (`k` and `window` together raise), B11 (`smiles2mols` raises on options it cannot honor) — plus `extra="forbid"` now reaching the legacy YAML path, which will reject a stray key that used to be ignored.
+
+- [ ] **Say plainly that `threshold=-1` silently disabled duplicate removal in 3.x**, and that `convergence_threshold=0` burned every step. Users need to know their old results may not be what they thought.
+
+- [ ] **If Task 2 changed what the `thorough` preset means**, that is a behavior change for anyone who selected it — document it.
+
+- [ ] Verify the docs build with `python -c "import docutils.core, pathlib; docutils.core.publish_doctree(pathlib.Path('docs/source/migration-4.0.rst').read_text())"`. A full Sphinx build may fail on a pre-existing missing `nbsphinx`; not yours to fix.
+
+---
+
+## Phase exit criteria
+
+1. `pytest tests/ -q -rxX -m "not slow" -p no:randomly` — all pass, **0 xpassed**, 0 failed.
+2. `grep -rn 'reason="[CM][0-9]' tests/ | wc -l` returns **2** (C14 ×2, Phase 6's).
+3. `grep -rn 'C10:\|C11:\|M15:\|M17:\|M27:\|M28:' tests/` returns no `reason=` tags.
+4. `ruff check src/ tests/` clean.
+5. The same `parameters.yaml` produces identical validation results through `auto3d run -c`, `auto3d parameters.yaml`, and `Auto3DOptions(**yaml)`; `threshold=-1` is rejected by all three.
+6. `grep -rn 'dependency_name' src/Auto3D/exceptions.py` shows the attribute defined.
+
+## Known limits of local verification
+
+- Every tripwire in this phase is fast-tier and must be run; there is no "first executes in CI" excuse here.
+- The GPU policy cannot be exercised on a CPU-only box from this machine, which has 8 CUDA devices — simulate the no-CUDA case rather than assuming.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "rdkit>=2022.9.5",
     "torch>=2.8",
     "aimnet>=0.2",
+    "requests>=2.32.3",
     "typer>=0.12.0",
     "rich>=13.0.0",
     "pydantic>=2.0",

--- a/src/Auto3D/ASE/geometry.py
+++ b/src/Auto3D/ASE/geometry.py
@@ -16,8 +16,10 @@ from Auto3D.constants import (
     DEFAULT_OPT_STEPS,
 )
 from Auto3D.model_factory import get_device
+from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
+from Auto3D.utils.validation import check_engine_supports_molecules
 
 __all__ = ["opt_geometry"]
 
@@ -72,6 +74,12 @@ def opt_geometry(
         ...     batchsize_atoms=2048,
         ... )
     """
+    # Fail fast on an unrecognized engine name -- the same guard the CLI's
+    # `optimize` command already runs before calling this function
+    # (cli/commands/properties.py), now also enforced for direct Python-API
+    # callers. Pure offline registry lookup: no network, no model load.
+    resolve_engine_name(model_name)
+
     ev2hatree = 1 / hartree2ev
     # Apply the shared torch configuration so allow_tf32 is honored here too
     # (this path previously ignored it).
@@ -92,6 +100,13 @@ def opt_geometry(
         outpath = os.path.join(dir, basename)
 
     device = get_device(gpu_idx, use_gpu=use_gpu)
+
+    # ANI2x/ANI2xt can only represent uncharged, in-set molecules (C11): a
+    # charged or out-of-set species handed to either would otherwise be
+    # silently optimized as a different, neutral species -- wrong energy,
+    # wrong forces, wrong geometry.
+    input_mols = [mol for mol in Chem.SDMolSupplier(path, removeHs=False) if mol is not None]
+    check_engine_supports_molecules(input_mols, model_name)
 
     opt_config = OptimizationConfig(
         opt_steps=opt_steps,

--- a/src/Auto3D/ASE/geometry.py
+++ b/src/Auto3D/ASE/geometry.py
@@ -19,7 +19,7 @@ from Auto3D.model_factory import get_device
 from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
-from Auto3D.utils.validation import check_engine_supports_molecules
+from Auto3D.utils.validation import check_engine_supports_molecules, check_gpu_requested
 
 __all__ = ["opt_geometry"]
 
@@ -79,6 +79,16 @@ def opt_geometry(
     # (cli/commands/properties.py), now also enforced for direct Python-API
     # callers. Pure offline registry lookup: no network, no model load.
     resolve_engine_name(model_name)
+
+    # opt_geometry never goes through check_input/check_valid_configuration,
+    # so without this it would reach model_factory.get_device below and
+    # silently fall back to CPU instead of failing the same way `auto3d
+    # optimize` already does at its CLI wrapper (cli/commands/properties.py)
+    # -- and the same way `auto3d run`/smiles2mols do via check_input /
+    # check_valid_configuration. check_gpu_requested is the single source of
+    # truth for this policy; called here, before get_device/optimizing below,
+    # so no compute (and no model construction) happens first.
+    check_gpu_requested(use_gpu)
 
     ev2hatree = 1 / hartree2ev
     # Apply the shared torch configuration so allow_tf32 is honored here too

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -949,20 +949,25 @@ def calc_thermo(path: str, model_name: str, mol_info_func=None,
     else:
         outpath = path_obj.parent / f"{path_obj.stem}_{model_name}_G.sdf"
 
-    device = get_device(gpu_idx, use_gpu=use_gpu)
-
-    hessian_model = _load_hessian_model(model_name, device)
-    model, calculator = model_name2model_calculator(model_name, device)
-
     mols = list(Chem.SDMolSupplier(path, removeHs=False))
 
     # ANI2x/ANI2xt can only represent uncharged, in-set molecules (C11): a
     # charged or out-of-set species handed to either would otherwise be
     # silently relaxed and differentiated as a different, neutral species --
-    # wrong energy, wrong Hessian, wrong thermochemistry.
+    # wrong energy, wrong Hessian, wrong thermochemistry. Parsing `mols`
+    # needs only `path`, not a device or model, so it -- and this guard,
+    # which needs only `mols`/`model_name` -- both happen before
+    # get_device/_load_hessian_model/model_name2model_calculator below,
+    # matching check_gpu_requested's already-first placement: every guard
+    # that can fail fast, does, before any device/model construction.
     check_engine_supports_molecules(
         [mol for mol in mols if mol is not None], model_name
     )
+
+    device = get_device(gpu_idx, use_gpu=use_gpu)
+
+    hessian_model = _load_hessian_model(model_name, device)
+    model, calculator = model_name2model_calculator(model_name, device)
 
     for mol in tqdm(list(iter_thermo_records(mols))):
         # Routed through mol2atoms (rather than a bare Atoms(species, coord))

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -36,7 +36,7 @@ from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
 from Auto3D.utils.logging_config import get_logger
-from Auto3D.utils.validation import check_engine_supports_molecules
+from Auto3D.utils.validation import check_engine_supports_molecules, check_gpu_requested
 
 __all__ = ["calc_thermo"]
 
@@ -911,6 +911,17 @@ def calc_thermo(path: str, model_name: str, mol_info_func=None,
     # (cli/commands/properties.py), now also enforced for direct Python-API
     # callers. Pure offline registry lookup: no network, no model load.
     resolve_engine_name(model_name)
+
+    # calc_thermo never goes through check_input/check_valid_configuration, so
+    # without this it would reach model_factory.get_device below and silently
+    # fall back to CPU instead of failing the same way `auto3d thermo`
+    # already does at its CLI wrapper (cli/commands/properties.py) -- and the
+    # same way `auto3d run`/smiles2mols do via check_input /
+    # check_valid_configuration. check_gpu_requested is the single source of
+    # truth for this policy; called here, before get_device/_load_hessian_model/
+    # model_name2model_calculator below, so no compute (and no model
+    # construction) happens first.
+    check_gpu_requested(use_gpu)
 
     # Surface the symmetry-number caveat once per run (not per molecule) so it is
     # visible without spamming the log.

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -32,9 +32,11 @@ from Auto3D.constants import (
     LINEARITY_MOMENT_RATIO,
 )
 from Auto3D.model_factory import create_model, get_device
+from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
 from Auto3D.utils.logging_config import get_logger
+from Auto3D.utils.validation import check_engine_supports_molecules
 
 __all__ = ["calc_thermo"]
 
@@ -904,6 +906,12 @@ def calc_thermo(path: str, model_name: str, mol_info_func=None,
         molecules (e.g. benzene, sigma=12) the default over-counts rotational
         entropy by up to a few kcal/mol in T*S, so set that property when known.
     """
+    # Fail fast on an unrecognized engine name -- the same guard the CLI's
+    # `thermo` command already runs before calling this function
+    # (cli/commands/properties.py), now also enforced for direct Python-API
+    # callers. Pure offline registry lookup: no network, no model load.
+    resolve_engine_name(model_name)
+
     # Surface the symmetry-number caveat once per run (not per molecule) so it is
     # visible without spamming the log.
     logger.info(
@@ -936,6 +944,15 @@ def calc_thermo(path: str, model_name: str, mol_info_func=None,
     model, calculator = model_name2model_calculator(model_name, device)
 
     mols = list(Chem.SDMolSupplier(path, removeHs=False))
+
+    # ANI2x/ANI2xt can only represent uncharged, in-set molecules (C11): a
+    # charged or out-of-set species handed to either would otherwise be
+    # silently relaxed and differentiated as a different, neutral species --
+    # wrong energy, wrong Hessian, wrong thermochemistry.
+    check_engine_supports_molecules(
+        [mol for mol in mols if mol is not None], model_name
+    )
+
     for mol in tqdm(list(iter_thermo_records(mols))):
         # Routed through mol2atoms (rather than a bare Atoms(species, coord))
         # so isotope masses are applied consistently with vib_hessian's Atoms

--- a/src/Auto3D/SPE.py
+++ b/src/Auto3D/SPE.py
@@ -9,9 +9,11 @@ from rdkit import Chem
 from Auto3D.batch_opt.batchopt import EnForce_ANI
 from Auto3D.batch_opt.padding import pad_from_mols
 from Auto3D.model_factory import create_model, get_device
+from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
 from Auto3D.utils.logging_config import get_logger
+from Auto3D.utils.validation import check_engine_supports_molecules
 
 logger = get_logger(__name__)
 
@@ -42,6 +44,12 @@ def calc_spe(
     Returns:
         Path to output SDF file with energies.
     """
+    # Fail fast on an unrecognized engine name -- the same guard the CLI's
+    # `energy` command already runs before calling this function
+    # (cli/commands/properties.py), now also enforced for direct Python-API
+    # callers. Pure offline registry lookup: no network, no model load.
+    resolve_engine_name(model_name)
+
     # Apply the shared torch configuration so allow_tf32 is honored here too
     # (this path previously ignored it).
     configure_torch(TorchConfig(allow_tf32=allow_tf32))
@@ -91,6 +99,12 @@ def calc_spe(
         with Chem.SDWriter(str(outpath)):
             pass
         return str(outpath)
+
+    # ANI2x/ANI2xt can only represent uncharged, in-set molecules (C11): a
+    # charged or out-of-set species handed to either would otherwise be
+    # silently evaluated as a different, neutral species by the forward pass
+    # below -- tens of kcal/mol wrong, with wrong forces.
+    check_engine_supports_molecules(mols, model_name)
 
     # Use new vectorized padding that returns tensors directly. calc_spe only
     # needs energies (not forces), so the atom mask pad_from_mols also returns

--- a/src/Auto3D/SPE.py
+++ b/src/Auto3D/SPE.py
@@ -76,18 +76,14 @@ def calc_spe(
             basename = f"{stem}_{model_name}_E.sdf"
         outpath = dir_path / basename
 
-    # Use get_device from model_factory (honors use_gpu)
-    device = get_device(gpu_idx, use_gpu=use_gpu)
-
-    # Use ModelFactory to create model adapter
-    model_adapter = create_model(model_name, device)
-
-    # Create EnForce_ANI wrapper for batched forward support (new API without name)
-    model = EnForce_ANI(model_adapter)
-
     # Filter once up front: drop None records (unparseable) and conformerless
     # molecules so pad_from_mols never dereferences a bad record, and so the
-    # writer loop below stays index-aligned with the energies tensor.
+    # writer loop below stays index-aligned with the energies tensor. Parsing
+    # `mols` needs only `path`, not a device or model, so it -- and the C11
+    # guard right below, which needs only `mols`/`model_name` -- both happen
+    # before get_device/create_model, matching check_gpu_requested's
+    # already-first placement: every guard that can fail fast, does, before
+    # any device/model construction.
     mols = []
     for i, mol in enumerate(Chem.SDMolSupplier(path, removeHs=False)):
         if mol is None:
@@ -113,8 +109,19 @@ def calc_spe(
     # ANI2x/ANI2xt can only represent uncharged, in-set molecules (C11): a
     # charged or out-of-set species handed to either would otherwise be
     # silently evaluated as a different, neutral species by the forward pass
-    # below -- tens of kcal/mol wrong, with wrong forces.
+    # below -- tens of kcal/mol wrong, with wrong forces. Checked before
+    # get_device/create_model (below) so a bad molecule fails fast, without
+    # constructing a (possibly GPU-resident) model first.
     check_engine_supports_molecules(mols, model_name)
+
+    # Use get_device from model_factory (honors use_gpu)
+    device = get_device(gpu_idx, use_gpu=use_gpu)
+
+    # Use ModelFactory to create model adapter
+    model_adapter = create_model(model_name, device)
+
+    # Create EnForce_ANI wrapper for batched forward support (new API without name)
+    model = EnForce_ANI(model_adapter)
 
     # Use new vectorized padding that returns tensors directly. calc_spe only
     # needs energies (not forces), so the atom mask pad_from_mols also returns

--- a/src/Auto3D/SPE.py
+++ b/src/Auto3D/SPE.py
@@ -13,7 +13,7 @@ from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.torch_config import TorchConfig, configure_torch
 from Auto3D.utils import hartree2ev
 from Auto3D.utils.logging_config import get_logger
-from Auto3D.utils.validation import check_engine_supports_molecules
+from Auto3D.utils.validation import check_engine_supports_molecules, check_gpu_requested
 
 logger = get_logger(__name__)
 
@@ -49,6 +49,16 @@ def calc_spe(
     # (cli/commands/properties.py), now also enforced for direct Python-API
     # callers. Pure offline registry lookup: no network, no model load.
     resolve_engine_name(model_name)
+
+    # calc_spe never goes through check_input/check_valid_configuration, so
+    # without this it would reach model_factory.get_device below and silently
+    # fall back to CPU instead of failing the same way `auto3d energy`
+    # already does at its CLI wrapper (cli/commands/properties.py) -- and the
+    # same way `auto3d run`/smiles2mols do via check_input /
+    # check_valid_configuration. check_gpu_requested is the single source of
+    # truth for this policy; called here, before get_device/create_model
+    # below, so no compute (and no model construction) happens first.
+    check_gpu_requested(use_gpu)
 
     # Apply the shared torch configuration so allow_tf32 is honored here too
     # (this path previously ignored it).

--- a/src/Auto3D/auto3D.py
+++ b/src/Auto3D/auto3D.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import multiprocessing as mp
 import tempfile
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -25,6 +26,7 @@ from Auto3D.models.preflight import preflight_model
 from Auto3D.ranking import ranking
 from Auto3D.utils import (
     check_input,
+    check_valid_configuration,
     create_chunk_meta_names,
     reorder_sdf,
 )
@@ -113,12 +115,41 @@ def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
         List of RDKit Mol objects representing low-energy conformers.
 
     Raises:
-        ConfigurationError: If neither k nor window is specified, or the
-            optimizing engine name is not recognized.
+        ConfigurationError: If neither k nor window is specified, the
+            optimizing engine name is not recognized, the configuration is
+            otherwise invalid (e.g. an out-of-range ``gpu_idx``), or an
+            option this function cannot honor is requested --
+            ``enumerate_tautomer=True`` (no tautomer-enumeration step) or a
+            non-``'rdkit'`` ``isomer_engine`` (the RDKit engine is
+            hardcoded, so ``mode_oe`` has no effect either). Use ``main()``
+            for either of those.
         ModelLoadError: If the optimizing model could not be obtained or
             loaded.
         DependencyError: If a required optional dependency is missing.
     """
+    # Copy the caller's config up front: smiles2mols must not mutate the
+    # object it was given (M15). Every assignment below (path, input_format)
+    # lands on this private copy; `args` no longer refers to the caller's
+    # object for the rest of this function.
+    args = replace(args)
+
+    # smiles2mols has no tautomer-enumeration step and hardcodes the RDKit
+    # isomer engine below (mode_oe only ever affects the omega engine, so it
+    # has no effect here regardless) -- silently ignoring these three options
+    # was M15. Raise instead of letting the caller believe they took effect.
+    if args.enumerate_tautomer:
+        raise ConfigurationError(
+            "smiles2mols does not support enumerate_tautomer=True: it has no "
+            "tautomer-enumeration step. Use main() for tautomer enumeration."
+        )
+    if args.isomer_engine.lower() != "rdkit":
+        raise ConfigurationError(
+            f"smiles2mols only supports isomer_engine='rdkit', got "
+            f"{args.isomer_engine!r}. The RDKit engine is hardcoded here "
+            "(mode_oe has no effect either way). Use main() for a "
+            "non-RDKit isomer engine."
+        )
+
     # Configure PyTorch settings (TF32, cuDNN benchmark)
     from Auto3D.torch_config import TorchConfig, configure_torch
     torch_config = TorchConfig(allow_tf32=args.allow_tf32)
@@ -127,7 +158,7 @@ def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
     with tempfile.TemporaryDirectory() as tmpdirname:
         path0 = str(Path(tmpdirname) / "smiles.smi")
         smiles2smi(smiles, path0)  # save all SMILES into a smi file
-        args['path'] = path0
+        args.path = path0
         k = args.k
         window = args.window
         if (not k) and (not window):
@@ -136,6 +167,28 @@ def smiles2mols(smiles: list[str], args: Auto3DOptions) -> list[Chem.Mol]:
                 "Usually, setting '--k=1' satisfies most needs."
             )
         args.input_format = 'smi'
+
+        # Fail fast on an invalid configuration (notably an out-of-range
+        # gpu_idx) the same way main() does via WorkflowOrchestrator --
+        # check_input alone does not catch this, so it used to only surface
+        # opaquely deep inside optimization.
+        config_errors = check_valid_configuration(
+            path=args.path,
+            k=args.k,
+            window=args.window,
+            use_gpu=args.use_gpu,
+            gpu_idx=args.gpu_idx,
+            optimizing_engine=args.optimizing_engine,
+            isomer_engine=args.isomer_engine,
+            opt_steps=args.opt_steps,
+            enumerate_tautomer=args.enumerate_tautomer,
+            tauto_engine=args.tauto_engine,
+        )
+        if config_errors:
+            raise ConfigurationError(
+                "Invalid configuration:\n  - " + "\n  - ".join(config_errors)
+            )
+
         check_input(args)
 
         # Resolve the engine name and verify the model is obtainable HERE

--- a/src/Auto3D/auto3Dcli.py
+++ b/src/Auto3D/auto3Dcli.py
@@ -84,7 +84,7 @@ def _run_legacy_yaml(yaml_path: str) -> None:
         import yaml
 
         from Auto3D.auto3D import main
-        from Auto3D.cli.config_schema import CLIConfig
+        from Auto3D.cli.config_schema import build_cli_config
         from Auto3D.exceptions import InputValidationError
         from Auto3D.utils.logging_config import configure_logging
 
@@ -120,10 +120,12 @@ def _run_legacy_yaml(yaml_path: str) -> None:
         # check_field_bounds/FIELD_BOUNDS), the engine registry check,
         # parse_gpu_idx, and Literal validation on tauto_engine/isomer_engine.
         # It also means extra="forbid": a YAML key CLIConfig doesn't
-        # recognize now raises a pydantic ValidationError (caught below by
-        # the blanket `except Exception`) instead of silently passing
-        # through to Auto3DOptions as it used to.
-        config = CLIConfig(**parameters)
+        # recognize now raises -- via build_cli_config, which translates
+        # pydantic's ValidationError into Auto3D's own ConfigurationError, so
+        # the blanket `except Exception` below shows exit code 2 with a hint
+        # instead of the generic "Unexpected Error" panel at exit 1 -- instead
+        # of silently passing through to Auto3DOptions as it used to.
+        config = build_cli_config(**parameters)
         options = config.to_auto3d_options()
         result = main(options)
         console.print(f"\n[green]✓[/green] Output: [cyan]{result}[/cyan]")

--- a/src/Auto3D/auto3Dcli.py
+++ b/src/Auto3D/auto3Dcli.py
@@ -84,7 +84,7 @@ def _run_legacy_yaml(yaml_path: str) -> None:
         import yaml
 
         from Auto3D.auto3D import main
-        from Auto3D.config import Auto3DOptions
+        from Auto3D.cli.config_schema import CLIConfig
         from Auto3D.exceptions import InputValidationError
         from Auto3D.utils.logging_config import configure_logging
 
@@ -115,7 +115,16 @@ def _run_legacy_yaml(yaml_path: str) -> None:
         )
         console.print()
 
-        options = Auto3DOptions(**parameters)
+        # CLIConfig gives this legacy path the same validation as `auto3d run
+        # -c`: every Field bound (shared with Auto3DOptions via
+        # check_field_bounds/FIELD_BOUNDS), the engine registry check,
+        # parse_gpu_idx, and Literal validation on tauto_engine/isomer_engine.
+        # It also means extra="forbid": a YAML key CLIConfig doesn't
+        # recognize now raises a pydantic ValidationError (caught below by
+        # the blanket `except Exception`) instead of silently passing
+        # through to Auto3DOptions as it used to.
+        config = CLIConfig(**parameters)
+        options = config.to_auto3d_options()
         result = main(options)
         console.print(f"\n[green]✓[/green] Output: [cyan]{result}[/cyan]")
     except Exception as e:  # noqa: BLE001 - present every failure as a clean panel

--- a/src/Auto3D/cli/commands/config.py
+++ b/src/Auto3D/cli/commands/config.py
@@ -50,8 +50,14 @@ PRESETS: dict[str, dict[str, Any]] = {
         "opt_steps": 2000,
     },
     "thorough": {
+        # k=10 only -- NOT also window=5.0 (M28). Both were set here before;
+        # ConformerRanker.run tested k before window, so k always won and
+        # window was silently inert -- and is now rejected outright by
+        # Auto3DOptions/CLIConfig if both are set. Kept k rather than
+        # switching to window because that is the value every user of this
+        # preset has actually been getting since it shipped; picking window
+        # instead would be a silent behavior change dressed up as a bug fix.
         "k": 10,
-        "window": 5.0,
         "opt_steps": 5000,
     },
 }

--- a/src/Auto3D/cli/commands/models.py
+++ b/src/Auto3D/cli/commands/models.py
@@ -230,7 +230,13 @@ def execute_models_test(
         from Auto3D.batch_opt.species import to_model_species
         from Auto3D.exceptions import NumericalError
         from Auto3D.model_factory import create_model, get_device
+        from Auto3D.utils.validation import check_gpu_requested
 
+        # `energy`/`optimize`/`thermo` (cli/commands/properties.py) already call
+        # this before doing any work; `models test` reached
+        # model_factory.get_device directly and silently fell back to CPU on a
+        # CPU-only box instead of failing the same way -- the last M23 gap.
+        check_gpu_requested(gpu)
         device = get_device(gpu_idx, use_gpu=gpu)
         with console.status(f"[bold]Loading {engine} on {device}..."):
             t0 = time.time()

--- a/src/Auto3D/cli/commands/properties.py
+++ b/src/Auto3D/cli/commands/properties.py
@@ -19,6 +19,7 @@ from Auto3D.cli.console import console, print_success
 from Auto3D.cli.errors import handle_error
 from Auto3D.exceptions import ConfigurationError, DependencyError
 from Auto3D.models.preflight import resolve_engine_name
+from Auto3D.utils.validation import check_gpu_requested
 
 # Engine names offered for shell completion. Free-form registry names and custom
 # model paths are also accepted -- each command below validates them with
@@ -56,6 +57,11 @@ def execute_energy(
         # model construction (C11-shaped gap: a guard present in `main()` via
         # WorkflowOrchestrator._validate_input, absent here).
         resolve_engine_name(engine)
+        # calc_spe never goes through check_input/check_valid_configuration,
+        # so without this it would silently fall back to CPU through
+        # model_factory.get_device instead of failing the same way `auto3d
+        # run`/smiles2mols do (M23).
+        check_gpu_requested(gpu)
         from Auto3D.SPE import calc_spe
         out = calc_spe(
             str(input_file), engine, gpu_idx=gpu_idx, use_gpu=gpu,
@@ -76,6 +82,7 @@ def execute_optimize(
     try:
         # Validate before doing any work -- see execute_energy's comment.
         resolve_engine_name(engine)
+        check_gpu_requested(gpu)
         from Auto3D.ASE.geometry import opt_geometry
         out = opt_geometry(
             str(input_file), engine, gpu_idx=gpu_idx, opt_tol=opt_tol,
@@ -98,6 +105,7 @@ def execute_thermo(
     try:
         # Validate before doing any work -- see execute_energy's comment.
         resolve_engine_name(engine)
+        check_gpu_requested(gpu)
         try:
             from Auto3D.ASE.thermo import calc_thermo
         except ImportError as e:

--- a/src/Auto3D/cli/commands/properties.py
+++ b/src/Auto3D/cli/commands/properties.py
@@ -144,10 +144,10 @@ def execute_tautomers(
         if tauto_k is None and tauto_window is None:
             tauto_k = 1  # sensible default: keep the single most stable tautomer
 
-        from Auto3D.cli.config_schema import CLIConfig
+        from Auto3D.cli.config_schema import build_cli_config
         from Auto3D.tautomer import get_stable_tautomers
 
-        cfg = CLIConfig(
+        cfg = build_cli_config(
             path=input_file, k=1, optimizing_engine=engine, use_gpu=gpu,
             gpu_idx=gpu_idx if gpu_idx is not None else 0,
             enumerate_tautomer=True,

--- a/src/Auto3D/cli/commands/properties.py
+++ b/src/Auto3D/cli/commands/properties.py
@@ -103,6 +103,7 @@ def execute_thermo(
         except ImportError as e:
             raise DependencyError(
                 "Thermochemistry requires ASE, which is not installed.",
+                dependency_name="ase",
             ) from e
 
         # Scalar --temperature -> the per-mol (id, T) callback calc_thermo expects.

--- a/src/Auto3D/cli/commands/run.py
+++ b/src/Auto3D/cli/commands/run.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-from Auto3D.cli.config_schema import CLIConfig, load_yaml_config, merge_configs
+from Auto3D.cli.config_schema import build_cli_config, load_yaml_config, merge_configs
 from Auto3D.cli.console import console, print_banner, print_warning
 from Auto3D.cli.errors import handle_error
 from Auto3D.cli.results import (
@@ -90,10 +90,10 @@ def execute_run(
         # Build configuration
         if config_file:
             config = load_yaml_config(config_file)
-            config = CLIConfig(path=input_file, **config.model_dump(exclude={"path"}))
+            config = build_cli_config(path=input_file, **config.model_dump(exclude={"path"}))
         else:
             # Pydantic provides defaults for all fields except path
-            config = CLIConfig(path=input_file)  # type: ignore[call-arg]
+            config = build_cli_config(path=input_file)  # type: ignore[call-arg]
 
         # Apply CLI overrides
         overrides = {

--- a/src/Auto3D/cli/commands/validate.py
+++ b/src/Auto3D/cli/commands/validate.py
@@ -24,7 +24,14 @@ class ValidationResult:
 
 
 def validate_smiles_file(file_path: Path) -> ValidationResult:
-    """Validate a SMILES file."""
+    """Validate a SMILES file.
+
+    Must reject exactly what the runner (encode_ids/iter_smi_records,
+    file_ops.py) rejects, or a passing `auto3d validate` is not trustworthy
+    (M25): a line needs both a SMILES and an ID (whitespace-separated), and
+    '#'-prefixed lines are treated as comments -- both checks mirrored from
+    file_ops.iter_smi_records so the two never drift apart again.
+    """
     from rdkit import Chem
 
     errors: list[tuple[int, str, str]] = []
@@ -39,7 +46,12 @@ def validate_smiles_file(file_path: Path) -> ValidationResult:
 
             total_count += 1
             parts = line.split()
-            smiles = parts[0] if parts else ""
+            if len(parts) < 2:
+                errors.append(
+                    (i, line[:50], "Missing molecule ID (expected 'SMILES ID')")
+                )
+                continue
+            smiles = parts[0]
 
             mol = Chem.MolFromSmiles(smiles)
             if mol is None:

--- a/src/Auto3D/cli/config_schema.py
+++ b/src/Auto3D/cli/config_schema.py
@@ -124,6 +124,16 @@ class CLIConfig(BaseModel):
         """Convert to Auto3DOptions for core workflow."""
         # Map built-in engine names back to the canonical form expected by
         # Auto3DOptions; registry names and custom paths pass through verbatim.
+        #
+        # This table is live, not dead: `_validate_engine` (above) now accepts
+        # any case of these three names -- `resolve_engine_name` case-folds
+        # them -- but it validates and returns `v` unchanged, so
+        # `self.optimizing_engine` still carries whatever case the caller
+        # typed (e.g. "ani2x"). This map is what normalizes that back to the
+        # exact mixed-case spelling (`ANI2x`/`ANI2xt`) that `MODEL_ANI2X`/
+        # `MODEL_ANI2XT` and their downstream exact-match comparisons expect.
+        # Registry names/aliases are deliberately left out of this map and
+        # pass through as typed -- see test_config_accepts_registry_and_path_engines.
         engine_map = {"ANI2X": "ANI2x", "ANI2XT": "ANI2xt", "AIMNET": "AIMNET"}
         engine = engine_map.get(self.optimizing_engine.upper(), self.optimizing_engine)
 

--- a/src/Auto3D/cli/config_schema.py
+++ b/src/Auto3D/cli/config_schema.py
@@ -13,7 +13,7 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
-from Auto3D.config import Auto3DOptions, check_field_bounds
+from Auto3D.config import SELECTOR_FIELDS, Auto3DOptions, check_field_bounds
 from Auto3D.constants import (
     DEFAULT_BATCHSIZE_ATOMS,
     DEFAULT_CAPACITY,
@@ -186,6 +186,31 @@ class CLIConfig(BaseModel):
         )
 
 
+def build_cli_config(**kwargs: Any) -> CLIConfig:
+    """Construct a ``CLIConfig``, translating a pydantic ``ValidationError``
+    into Auto3D's own ``ConfigurationError``.
+
+    This is the one construction path every site that builds a ``CLIConfig``
+    from external data (a YAML file, merged CLI overrides, a bare CLI
+    invocation) should call instead of ``CLIConfig(...)`` directly. Before
+    this helper existed, that translation lived only inside `merge_configs`
+    -- so a bad value reaching CLIConfig through `load_yaml_config` (a
+    config-file value, never merged with any CLI override) raised a raw
+    pydantic `ValidationError` that `cli/commands/run.py`'s `except
+    Auto3DError` clause does not catch. It fell through to the generic
+    "Unexpected Error" panel at exit code 1 instead of the ConfigurationError
+    panel (exit 2, "run auto3d config init" hint) every other invalid-
+    configuration path produces -- e.g. `auto3d run in.smi -c cfg.yaml` with
+    `cfg.yaml` setting `k: 0`. Concentrating the translation here, rather than
+    duplicating the try/except at each construction site, is what keeps every
+    site in sync with no second edit.
+    """
+    try:
+        return CLIConfig(**kwargs)
+    except ValidationError as exc:
+        raise ConfigurationError(str(exc)) from exc
+
+
 def load_yaml_config(yaml_path: Path) -> CLIConfig:
     """Load and validate configuration from YAML file."""
     with open(yaml_path) as f:
@@ -196,48 +221,42 @@ def load_yaml_config(yaml_path: Path) -> CLIConfig:
         if val == "None":
             data[key] = None
 
-    return CLIConfig(**data)
+    return build_cli_config(**data)
 
 
 def merge_configs(base: CLIConfig, overrides: dict[str, Any]) -> CLIConfig:
     """Merge CLI overrides into base configuration.
 
     An override replaces the base's value for that field -- it does not
-    accumulate alongside it. This matters most for `k`/`window`: they are
-    mutually-exclusive conformer-selection strategies
-    (`Auto3D.config._check_selectors_mutually_exclusive`), so an explicit
-    `--k`/`--window` on the CLI is the user choosing *which* strategy to use,
-    substituting for whatever the config file set -- not requesting both at
-    once. Before this fix, `auto3d run in.smi -c cfg.yaml --k 1` with
-    `cfg.yaml`'s `window: 5.0` left both `k=1` (the override) and `window=5.0`
-    (the file's, still sitting in `base_dict`) in the merged result, which
-    the mutual-exclusion guard then rejected -- even though substituting one
-    selector for the other is exactly what a CLI override is for. When the
-    CLI explicitly sets one selector and leaves the other alone, the file's
-    other selector is cleared here so only the explicit one survives; if the
-    CLI explicitly sets *both* (a genuine conflict, not a merge artifact),
-    neither is cleared and the mutual-exclusion guard below still fires.
+    accumulate alongside it. This matters most for the mutually-exclusive
+    conformer-selection strategies in `Auto3D.config.SELECTOR_FIELDS` (`k`/
+    `window`; see `Auto3D.config._check_selectors_mutually_exclusive`): an
+    explicit `--k`/`--window` on the CLI is the user choosing *which*
+    strategy to use, substituting for whatever the config file set -- not
+    requesting both at once. Before this fix, `auto3d run in.smi -c cfg.yaml
+    --k 1` with `cfg.yaml`'s `window: 5.0` left both `k=1` (the override) and
+    `window=5.0` (the file's, still sitting in `base_dict`) in the merged
+    result, which the mutual-exclusion guard then rejected -- even though
+    substituting one selector for the other is exactly what a CLI override is
+    for. When the CLI explicitly sets one selector and leaves the rest alone,
+    every other selector is cleared here so only the explicit one survives;
+    if the CLI explicitly sets more than one selector at once (a genuine
+    conflict, not a merge artifact), none are cleared and the mutual-exclusion
+    guard below still fires. Iterating `SELECTOR_FIELDS` -- rather than
+    hardcoding `k`/`window` a second time here -- means a third selector added
+    to that one tuple picks up this substitution behavior automatically.
     """
     base_dict = base.model_dump()
 
-    if overrides.get("k") is not None and overrides.get("window") is None:
-        base_dict["window"] = None
-    elif overrides.get("window") is not None and overrides.get("k") is None:
-        base_dict["k"] = None
+    explicit = [f for f in SELECTOR_FIELDS if overrides.get(f) is not None]
+    if len(explicit) == 1:
+        for f in SELECTOR_FIELDS:
+            if f != explicit[0]:
+                base_dict[f] = None
 
     # Only apply non-None overrides
     for key, value in overrides.items():
         if value is not None:
             base_dict[key] = value
 
-    try:
-        return CLIConfig(**base_dict)
-    except ValidationError as exc:
-        # execute_run (cli/commands/run.py) only special-cases Auto3DError;
-        # an untranslated pydantic ValidationError here fell through to the
-        # generic "Unexpected Error" panel at exit code 1 instead of the
-        # ConfigurationError panel (exit 2, "run auto3d config init" hint)
-        # every other invalid-configuration path in this phase produces --
-        # e.g. an explicit `--k`/`--window` conflict, or an override that
-        # violates a FIELD_BOUNDS bound.
-        raise ConfigurationError(str(exc)) from exc
+    return build_cli_config(**base_dict)

--- a/src/Auto3D/cli/config_schema.py
+++ b/src/Auto3D/cli/config_schema.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
-from Auto3D.config import Auto3DOptions
+from Auto3D.config import Auto3DOptions, check_field_bounds
 from Auto3D.constants import (
     DEFAULT_BATCHSIZE_ATOMS,
     DEFAULT_CAPACITY,
@@ -34,8 +34,8 @@ class CLIConfig(BaseModel):
     """Path to input .smi or .sdf file."""
 
     # Output control
-    k: int | None = Field(None, ge=1, description="Top-k conformers per molecule")
-    window: float | None = Field(None, gt=0, description="Energy window in kcal/mol")
+    k: int | None = Field(None, description="Top-k conformers per molecule")
+    window: float | None = Field(None, description="Energy window in kcal/mol")
 
     # Engine settings
     optimizing_engine: str = "AIMNET"
@@ -50,18 +50,18 @@ class CLIConfig(BaseModel):
     isomer_engine: Literal["rdkit", "omega"] = "rdkit"
     mode_oe: str = "classic"
     max_confs: int | None = None
-    mpi_np: int = Field(4, ge=1)
+    mpi_np: int = 4
 
     # Optimization settings
-    opt_steps: int = Field(DEFAULT_OPT_STEPS, ge=1)
-    convergence_threshold: float = Field(DEFAULT_CONVERGENCE_THRESHOLD, gt=0)
-    patience: int = Field(DEFAULT_PATIENCE, ge=1)
-    threshold: float = Field(DEFAULT_RMSD_THRESHOLD, gt=0)
-    batchsize_atoms: int = Field(DEFAULT_BATCHSIZE_ATOMS, ge=1)
+    opt_steps: int = DEFAULT_OPT_STEPS
+    convergence_threshold: float = DEFAULT_CONVERGENCE_THRESHOLD
+    patience: int = DEFAULT_PATIENCE
+    threshold: float = DEFAULT_RMSD_THRESHOLD
+    batchsize_atoms: int = DEFAULT_BATCHSIZE_ATOMS
 
     # Resource settings
-    memory: int | None = Field(None, ge=1)
-    capacity: int = Field(DEFAULT_CAPACITY, ge=1)
+    memory: int | None = None
+    capacity: int = DEFAULT_CAPACITY
     allow_tf32: bool = False
 
     # Output settings
@@ -107,6 +107,18 @@ class CLIConfig(BaseModel):
     def normalize_lowercase(cls, v: str) -> str:
         """Normalize to lowercase."""
         return v.lower() if isinstance(v, str) else v
+
+    @model_validator(mode="after")
+    def _check_bounds(self) -> CLIConfig:
+        """Enforce Auto3D.config.FIELD_BOUNDS -- the same table Auto3DOptions
+        uses -- instead of a second, hand-maintained set of Field(ge=/gt=)
+        constraints that could silently drift from it.
+        """
+        try:
+            check_field_bounds(self.__dict__)
+        except ConfigurationError as exc:
+            raise ValueError(str(exc)) from exc
+        return self
 
     def to_auto3d_options(self) -> Auto3DOptions:
         """Convert to Auto3DOptions for core workflow."""

--- a/src/Auto3D/cli/config_schema.py
+++ b/src/Auto3D/cli/config_schema.py
@@ -13,7 +13,12 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
-from Auto3D.config import SELECTOR_FIELDS, Auto3DOptions, check_field_bounds
+from Auto3D.config import (
+    SELECTOR_FIELDS,
+    SENTINEL_FIELDS,
+    Auto3DOptions,
+    check_field_bounds,
+)
 from Auto3D.constants import (
     DEFAULT_BATCHSIZE_ATOMS,
     DEFAULT_CAPACITY,
@@ -70,7 +75,14 @@ class CLIConfig(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    @field_validator("k", "window", "memory", "max_confs", mode="before")
+    # The field list is `Auto3D.config.SENTINEL_FIELDS` itself, not a second
+    # hand-maintained copy of the same four names: a fifth sentinel field
+    # added to that constant would otherwise keep `check_field_bounds`'s
+    # None/False skip but miss this False->None interception, silently
+    # reopening the exact entry-point divergence this phase closed (accepted
+    # by Auto3DOptions, rejected by CLIConfig). `sorted` only pins a
+    # deterministic argument order -- SENTINEL_FIELDS is a frozenset.
+    @field_validator(*sorted(SENTINEL_FIELDS), mode="before")
     @classmethod
     def _false_means_unset(cls, v: Any) -> Any:
         """Map the legacy ``False`` "not specified" sentinel to ``None``.
@@ -187,8 +199,8 @@ class CLIConfig(BaseModel):
 
 
 def build_cli_config(**kwargs: Any) -> CLIConfig:
-    """Construct a ``CLIConfig``, translating a pydantic ``ValidationError``
-    into Auto3D's own ``ConfigurationError``.
+    """Construct a ``CLIConfig``, translating any construction failure into
+    Auto3D's own ``ConfigurationError``.
 
     This is the one construction path every site that builds a ``CLIConfig``
     from external data (a YAML file, merged CLI overrides, a bare CLI
@@ -204,11 +216,31 @@ def build_cli_config(**kwargs: Any) -> CLIConfig:
     `cfg.yaml` setting `k: 0`. Concentrating the translation here, rather than
     duplicating the try/except at each construction site, is what keeps every
     site in sync with no second edit.
+
+    ``ValidationError`` is not the only way ``CLIConfig(...)`` can fail.
+    Pydantic converts a ``ValueError``/``AssertionError`` raised inside a
+    validator into a field-named ``ValidationError``, but it re-raises any
+    other exception unchanged -- and ``parse_gpu_idx`` above calls ``int(x)``,
+    which raises ``TypeError`` on a value that is neither a string, a number,
+    nor a list (``auto3d run in.smi -c cfg.yaml`` with ``gpu_idx: {a: 1}``).
+    Translating only ``ValidationError`` let that ``TypeError`` escape to
+    ``cli/commands/run.py``'s ``except Exception`` clause, producing the
+    generic "Unexpected Error" panel at exit code 1 -- precisely the outcome
+    this helper exists to eliminate, and for the same class of input (a bad
+    value in a config file) it already handles correctly everywhere else. A
+    malformed configuration value is a configuration error whichever layer
+    notices it, so it exits 2 with the "run auto3d config init" hint like
+    every other one.
     """
     try:
         return CLIConfig(**kwargs)
     except ValidationError as exc:
         raise ConfigurationError(str(exc)) from exc
+    except (TypeError, ValueError) as exc:
+        # Raised out of a field validator's own coercion (see above) rather
+        # than by pydantic, so it carries no field name -- say which layer
+        # rejected it instead of surfacing a bare "int() argument must be...".
+        raise ConfigurationError(f"Invalid configuration value: {exc}") from exc
 
 
 def load_yaml_config(yaml_path: Path) -> CLIConfig:
@@ -230,7 +262,7 @@ def merge_configs(base: CLIConfig, overrides: dict[str, Any]) -> CLIConfig:
     An override replaces the base's value for that field -- it does not
     accumulate alongside it. This matters most for the mutually-exclusive
     conformer-selection strategies in `Auto3D.config.SELECTOR_FIELDS` (`k`/
-    `window`; see `Auto3D.config._check_selectors_mutually_exclusive`): an
+    `window`; see `Auto3D.config.check_selectors_mutually_exclusive`): an
     explicit `--k`/`--window` on the CLI is the user choosing *which*
     strategy to use, substituting for whatever the config file set -- not
     requesting both at once. Before this fix, `auto3d run in.smi -c cfg.yaml

--- a/src/Auto3D/cli/config_schema.py
+++ b/src/Auto3D/cli/config_schema.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from Auto3D.config import Auto3DOptions, check_field_bounds
 from Auto3D.constants import (
@@ -69,6 +69,27 @@ class CLIConfig(BaseModel):
     job_name: str = ""
 
     model_config = {"extra": "forbid"}
+
+    @field_validator("k", "window", "memory", "max_confs", mode="before")
+    @classmethod
+    def _false_means_unset(cls, v: Any) -> Any:
+        """Map the legacy ``False`` "not specified" sentinel to ``None``.
+
+        Pydantic coerces ``bool`` to ``int``/``float`` (``bool`` is an
+        ``int`` subclass) as part of its own type validation, which runs
+        *before* the ``mode="after"`` model validator below
+        (``_check_bounds``) ever sees the value. So by the time
+        ``check_field_bounds``'s ``value is False`` skip runs, ``False`` has
+        already become ``0``/``0.0`` and fails the ``k``/``memory``/
+        ``max_confs`` >=1 or ``window`` >0 bound -- even though
+        ``Auto3DOptions`` (which has no such coercion step) accepts the same
+        input. This ``mode="before"`` validator runs first and intercepts
+        ``False`` ahead of that coercion, so both classes agree that
+        ``k=False``/``window=False``/``memory=False``/``max_confs=False``
+        mean "not specified", exactly like the shipped
+        ``docs/legacy-v2/parameters.yaml`` example (``window: False``).
+        """
+        return None if v is False else v
 
     @field_validator("gpu_idx", mode="before")
     @classmethod
@@ -179,12 +200,44 @@ def load_yaml_config(yaml_path: Path) -> CLIConfig:
 
 
 def merge_configs(base: CLIConfig, overrides: dict[str, Any]) -> CLIConfig:
-    """Merge CLI overrides into base configuration."""
+    """Merge CLI overrides into base configuration.
+
+    An override replaces the base's value for that field -- it does not
+    accumulate alongside it. This matters most for `k`/`window`: they are
+    mutually-exclusive conformer-selection strategies
+    (`Auto3D.config._check_selectors_mutually_exclusive`), so an explicit
+    `--k`/`--window` on the CLI is the user choosing *which* strategy to use,
+    substituting for whatever the config file set -- not requesting both at
+    once. Before this fix, `auto3d run in.smi -c cfg.yaml --k 1` with
+    `cfg.yaml`'s `window: 5.0` left both `k=1` (the override) and `window=5.0`
+    (the file's, still sitting in `base_dict`) in the merged result, which
+    the mutual-exclusion guard then rejected -- even though substituting one
+    selector for the other is exactly what a CLI override is for. When the
+    CLI explicitly sets one selector and leaves the other alone, the file's
+    other selector is cleared here so only the explicit one survives; if the
+    CLI explicitly sets *both* (a genuine conflict, not a merge artifact),
+    neither is cleared and the mutual-exclusion guard below still fires.
+    """
     base_dict = base.model_dump()
+
+    if overrides.get("k") is not None and overrides.get("window") is None:
+        base_dict["window"] = None
+    elif overrides.get("window") is not None and overrides.get("k") is None:
+        base_dict["k"] = None
 
     # Only apply non-None overrides
     for key, value in overrides.items():
         if value is not None:
             base_dict[key] = value
 
-    return CLIConfig(**base_dict)
+    try:
+        return CLIConfig(**base_dict)
+    except ValidationError as exc:
+        # execute_run (cli/commands/run.py) only special-cases Auto3DError;
+        # an untranslated pydantic ValidationError here fell through to the
+        # generic "Unexpected Error" panel at exit code 1 instead of the
+        # ConfigurationError panel (exit 2, "run auto3d config init" hint)
+        # every other invalid-configuration path in this phase produces --
+        # e.g. an explicit `--k`/`--window` conflict, or an override that
+        # violates a FIELD_BOUNDS bound.
+        raise ConfigurationError(str(exc)) from exc

--- a/src/Auto3D/cli/errors.py
+++ b/src/Auto3D/cli/errors.py
@@ -14,7 +14,6 @@ from Auto3D.exceptions import (
     GPUError,
     InputValidationError,
     ModelError,
-    ModelNotFoundError,
 )
 
 # Differentiated exit codes for scripting/CI. 1 = generic; the rest let callers
@@ -25,7 +24,7 @@ EXIT_CODES: dict[type, int] = {
     InputValidationError: 2,
     DependencyError: 3,
     GPUError: 4,
-    ModelError: 5,  # includes ModelNotFoundError / ModelLoadError / NumericalError
+    ModelError: 5,  # includes ModelLoadError / NumericalError
 }
 
 
@@ -51,9 +50,6 @@ def get_error_hint(error: Auto3DError) -> str | None:
 
     if isinstance(error, InputValidationError):
         return "Run 'auto3d validate <file>' to check your input file"
-
-    if isinstance(error, ModelNotFoundError):
-        return "Available engines: AIMNET, ANI2x, ANI2xt\nRun 'auto3d models list' for details"
 
     if isinstance(error, GPUError):
         return "Try --no-gpu to run on CPU, or check CUDA installation"

--- a/src/Auto3D/cli/results.py
+++ b/src/Auto3D/cli/results.py
@@ -105,27 +105,6 @@ def print_failures(failures: list[FailedMolecule], verbose: bool = False) -> Non
         console.print("[dim]Run with -v to see details[/dim]")
 
 
-def count_input_molecules(input_path: str) -> int:
-    """Best-effort count of input molecules in a .smi or .sdf file.
-
-    Used to derive the failure count (inputs that produced no conformer) for the
-    results summary. Returns 0 for unrecognized extensions so the caller can fall
-    back gracefully.
-    """
-    from pathlib import Path
-
-    ext = Path(input_path).suffix.lower()
-    if ext == ".smi":
-        from Auto3D.utils.file_ops import iter_smi_records
-
-        return sum(1 for _ in iter_smi_records(input_path, on_malformed="skip"))
-    if ext == ".sdf":
-        from Auto3D.utils.file_ops import count_sdf
-
-        return count_sdf(input_path)
-    return 0
-
-
 def count_from_output(output_path: str) -> tuple[int, int]:
     """Return (unique_molecule_count, conformer_count) from an output SDF.
 

--- a/src/Auto3D/config.py
+++ b/src/Auto3D/config.py
@@ -74,7 +74,21 @@ def check_field_bounds(values: dict) -> None:
         if value is None or value is False:
             continue
         cmp, symbol = _BOUND_OPS[kind]
-        if not cmp(value, limit):
+        try:
+            in_bounds = cmp(value, limit)
+        except TypeError as exc:
+            # A non-numeric value (e.g. threshold="0.3", a str) makes the
+            # comparison itself raise -- a bare TypeError here is exactly
+            # the kind of untyped raise this phase is closing everywhere
+            # else (see the mutual-exclusion and range checks below/above),
+            # so it must be a ConfigurationError too, not a fall-through
+            # exception the CLI's `handle_error` treats as an "Unexpected
+            # Error" (exit code 1, no hint) instead of a configuration
+            # problem (exit code 2, "run auto3d config init").
+            raise ConfigurationError(
+                f"{name} must be a number, got {value!r}"
+            ) from exc
+        if not in_bounds:
             raise ConfigurationError(
                 f"{name} must be {symbol} {limit}, got {value!r}"
             )

--- a/src/Auto3D/config.py
+++ b/src/Auto3D/config.py
@@ -78,6 +78,46 @@ def check_field_bounds(values: dict) -> None:
             raise ConfigurationError(
                 f"{name} must be {symbol} {limit}, got {value!r}"
             )
+    _check_selectors_mutually_exclusive(values)
+
+
+def _check_selectors_mutually_exclusive(values: dict) -> None:
+    """Reject ``k`` and ``window`` when both are specified (M28).
+
+    They are alternative conformer-selection strategies -- top-k vs. an
+    energy window -- and ``ConformerRanker.run`` (ranking.py) only consults
+    one of them, so specifying both means one is silently inert. This is
+    what the shipped ``thorough`` preset (cli/commands/config.py) did before
+    this fix: ``k=10`` and ``window=5.0`` together, with ``k`` always
+    winning.
+
+    Called from inside ``check_field_bounds`` (rather than as a second call
+    each caller must remember to make) so both ``Auto3DOptions.__post_init__``
+    and ``CLIConfig``'s model validator inherit it automatically -- neither
+    needed a code change to pick this up.
+
+    ``select_tautomers`` (Auto3D/tautomer.py) already rejects the equivalent
+    combination for tautomer selection, but with a bare ``ValueError`` (one
+    of the un-typed raises M29 tracks) -- not an ``Auto3DError`` subclass.
+    This raises ``ConfigurationError`` instead, matching this module's own
+    convention (every other bound above does the same) and its docstring's
+    "incompatible parameter combinations" case, so it can be caught the same
+    way as any other configuration-shape violation. The message deliberately
+    echoes select_tautomers's wording ("Only k OR window needs to be
+    specified") rather than inventing new phrasing.
+
+    ``None``/``False`` mean "not specified", the same convention used above:
+    by the time this runs, an out-of-range k/window (e.g. ``k=0``) has
+    already raised in the loop above, so a value reaching here is either
+    unset or a valid, deliberately-specified one.
+    """
+    k = values.get("k")
+    window = values.get("window")
+    if k and window:
+        raise ConfigurationError(
+            "Only one of k or window may be specified, got "
+            f"k={k!r} and window={window!r}"
+        )
 
 
 def optimizer_worker_indices(

--- a/src/Auto3D/config.py
+++ b/src/Auto3D/config.py
@@ -69,7 +69,7 @@ FIELD_BOUNDS: dict[str, tuple[str, float]] = {
 SENTINEL_FIELDS: frozenset[str] = frozenset({"k", "window", "memory", "max_confs"})
 
 # Mutually-exclusive conformer-selection strategies (see
-# _check_selectors_mutually_exclusive below). Exposed as a shared tuple --
+# check_selectors_mutually_exclusive below). Exposed as a shared tuple --
 # rather than left implicit in that function's body -- so other call sites
 # that need to know which fields are alternative selectors, not just whether
 # a given combination is invalid, use the same list instead of hardcoding
@@ -132,10 +132,10 @@ def check_field_bounds(values: dict) -> None:
             raise ConfigurationError(
                 f"{name} must be {symbol} {limit}, got {value!r}"
             )
-    _check_selectors_mutually_exclusive(values)
+    check_selectors_mutually_exclusive(values)
 
 
-def _check_selectors_mutually_exclusive(values: dict) -> None:
+def check_selectors_mutually_exclusive(values: dict) -> None:
     """Reject more than one of ``SELECTOR_FIELDS`` (currently ``k``/
     ``window``) being specified at once (M28).
 

--- a/src/Auto3D/config.py
+++ b/src/Auto3D/config.py
@@ -45,6 +45,44 @@ FIELD_BOUNDS: dict[str, tuple[str, float]] = {
     "max_confs": ("ge", 1),
 }
 
+# The subset of FIELD_BOUNDS where None/False mean "not specified" (dynamic/
+# default behavior) rather than an actual value to bounds-check -- k/window
+# are alternative selection strategies that default to "unset", memory/
+# max_confs both have a documented "None means auto-detect/dynamic" meaning
+# (see their Auto3DOptions docstrings and CLIConfig's ``int | None`` typing).
+#
+# The other seven FIELD_BOUNDS entries (mpi_np, opt_steps,
+# convergence_threshold, patience, threshold, batchsize_atoms, capacity) have
+# no such "unset" meaning -- they always have a concrete default already, so
+# there is nothing for None/False to opt out of -- and CLIConfig types them as
+# plain `int`/`float` (not `| None`), so pydantic already rejects None there on
+# construction. Before this constant existed, the loop below skipped None/
+# False for *all eleven* fields, so passing e.g. ``threshold=None`` straight to
+# Auto3DOptions (a dataclass with no type-coercion step) was silently accepted
+# while ``CLIConfig(threshold=None)`` rejected it -- the same
+# entry-point-dependent divergence this phase closed for k/window/memory/
+# max_confs, just left open for the other seven. Scoping the skip to exactly
+# this set, rather than every key in FIELD_BOUNDS, is what closes it: an
+# explicit None/False on any of the seven now falls through to the same
+# comparison (and the same ConfigurationError) on both entry points instead of
+# being silently waved through on the Auto3DOptions side only.
+SENTINEL_FIELDS: frozenset[str] = frozenset({"k", "window", "memory", "max_confs"})
+
+# Mutually-exclusive conformer-selection strategies (see
+# _check_selectors_mutually_exclusive below). Exposed as a shared tuple --
+# rather than left implicit in that function's body -- so other call sites
+# that need to know which fields are alternative selectors, not just whether
+# a given combination is invalid, use the same list instead of hardcoding
+# "k"/"window" a second time. cli/config_schema.py's merge_configs is exactly
+# such a site: an explicit CLI override of one selector must clear every
+# *other* selector from the base config (so an override substitutes for the
+# file's selector instead of accumulating alongside it), which requires
+# knowing the full set of selector field names, not just how to reject an
+# invalid combination of them. Adding a third selector needs only one edit,
+# here, to take effect on both the rejection (below) and the substitution
+# (merge_configs).
+SELECTOR_FIELDS: tuple[str, ...] = ("k", "window")
+
 _BOUND_OPS: dict[str, tuple[object, str]] = {
     "ge": (operator.ge, ">="),
     "gt": (operator.gt, ">"),
@@ -59,10 +97,12 @@ def check_field_bounds(values: dict) -> None:
     message -- this is what closes C10/M27 on every path instead of just one.
 
     A value of ``None`` or ``False`` means "not specified" (dynamic/default
-    behavior) on the optional numeric fields (k, window, max_confs, memory)
-    and is skipped, matching both classes' existing sentinel conventions.
-    Fields missing from ``values`` are skipped too, so callers may pass a
-    partial mapping.
+    behavior) only for the fields in ``SENTINEL_FIELDS`` (k, window,
+    max_confs, memory) and is skipped there, matching both classes' existing
+    sentinel conventions. Every other bounded field has no "unset" meaning and
+    must reject ``None``/``False`` just like any other out-of-range value (see
+    ``SENTINEL_FIELDS``'s docstring). Fields missing from ``values`` are
+    skipped too, so callers may pass a partial mapping.
 
     Raises:
         ConfigurationError: naming the field and the received value.
@@ -71,7 +111,7 @@ def check_field_bounds(values: dict) -> None:
         if name not in values:
             continue
         value = values[name]
-        if value is None or value is False:
+        if name in SENTINEL_FIELDS and (value is None or value is False):
             continue
         cmp, symbol = _BOUND_OPS[kind]
         try:
@@ -96,7 +136,8 @@ def check_field_bounds(values: dict) -> None:
 
 
 def _check_selectors_mutually_exclusive(values: dict) -> None:
-    """Reject ``k`` and ``window`` when both are specified (M28).
+    """Reject more than one of ``SELECTOR_FIELDS`` (currently ``k``/
+    ``window``) being specified at once (M28).
 
     They are alternative conformer-selection strategies -- top-k vs. an
     energy window -- and ``ConformerRanker.run`` (ranking.py) only consults
@@ -125,12 +166,11 @@ def _check_selectors_mutually_exclusive(values: dict) -> None:
     already raised in the loop above, so a value reaching here is either
     unset or a valid, deliberately-specified one.
     """
-    k = values.get("k")
-    window = values.get("window")
-    if k and window:
+    provided = {f: values.get(f) for f in SELECTOR_FIELDS if values.get(f)}
+    if len(provided) > 1:
+        got = ", ".join(f"{name}={value!r}" for name, value in provided.items())
         raise ConfigurationError(
-            "Only one of k or window may be specified, got "
-            f"k={k!r} and window={window!r}"
+            f"Only one of {' or '.join(SELECTOR_FIELDS)} may be specified, got {got}"
         )
 
 

--- a/src/Auto3D/config.py
+++ b/src/Auto3D/config.py
@@ -5,6 +5,7 @@ This module provides typed configuration using dataclasses and Protocols
 for better type safety and IDE support.
 """
 
+import operator
 from dataclasses import dataclass
 from typing import Protocol, TypedDict, runtime_checkable
 
@@ -20,6 +21,63 @@ from Auto3D.constants import (
     DEFAULT_PATIENCE,
     DEFAULT_RMSD_THRESHOLD,
 )
+from Auto3D.exceptions import ConfigurationError
+
+# Single source of truth for the numeric bounds every entry point must
+# enforce (Auto3DOptions.__post_init__ below and CLIConfig's model
+# validator in cli/config_schema.py). Keeping one table -- rather than a
+# hand-maintained bound list in each place -- is the point of this phase:
+# a bound added/changed here takes effect on every path with no second edit.
+#
+# name -> (comparison, limit). A field's value must satisfy
+# ``value <comparison> limit``; see _BOUND_OPS for the supported set.
+FIELD_BOUNDS: dict[str, tuple[str, float]] = {
+    "k": ("ge", 1),
+    "window": ("gt", 0),
+    "mpi_np": ("ge", 1),
+    "opt_steps": ("ge", 1),
+    "convergence_threshold": ("gt", 0),
+    "patience": ("ge", 1),
+    "threshold": ("gt", 0),
+    "batchsize_atoms": ("ge", 1),
+    "memory": ("ge", 1),
+    "capacity": ("ge", 1),
+    "max_confs": ("ge", 1),
+}
+
+_BOUND_OPS: dict[str, tuple[object, str]] = {
+    "ge": (operator.ge, ">="),
+    "gt": (operator.gt, ">"),
+}
+
+
+def check_field_bounds(values: dict) -> None:
+    """Validate ``values`` (field name -> value) against ``FIELD_BOUNDS``.
+
+    Shared by Auto3DOptions.__post_init__ and CLIConfig's model validator so
+    both entry points reject the same out-of-range values with the same
+    message -- this is what closes C10/M27 on every path instead of just one.
+
+    A value of ``None`` or ``False`` means "not specified" (dynamic/default
+    behavior) on the optional numeric fields (k, window, max_confs, memory)
+    and is skipped, matching both classes' existing sentinel conventions.
+    Fields missing from ``values`` are skipped too, so callers may pass a
+    partial mapping.
+
+    Raises:
+        ConfigurationError: naming the field and the received value.
+    """
+    for name, (kind, limit) in FIELD_BOUNDS.items():
+        if name not in values:
+            continue
+        value = values[name]
+        if value is None or value is False:
+            continue
+        cmp, symbol = _BOUND_OPS[kind]
+        if not cmp(value, limit):
+            raise ConfigurationError(
+                f"{name} must be {symbol} {limit}, got {value!r}"
+            )
 
 
 def optimizer_worker_indices(
@@ -145,12 +203,7 @@ class Auto3DOptions:
         self.tauto_engine = self.tauto_engine.lower()
         self.isomer_engine = self.isomer_engine.lower()
         self.mode_oe = self.mode_oe.lower()
-        # Reject genuinely negative k/window. The default `False` (a bool, which
-        # is an int subclass) and 0 both mean "not specified" and are allowed.
-        if self.k is not None and self.k is not False and self.k < 0:
-            raise ValueError(f"k must be non-negative, got {self.k}")
-        if self.window is not None and self.window is not False and self.window < 0:
-            raise ValueError(f"window must be non-negative, got {self.window}")
+        check_field_bounds({name: getattr(self, name) for name in FIELD_BOUNDS})
 
     def __getitem__(self, key: str):
         """Allow dict-like access for backward compatibility."""

--- a/src/Auto3D/exceptions.py
+++ b/src/Auto3D/exceptions.py
@@ -38,14 +38,6 @@ class ModelError(Auto3DError):
     pass
 
 
-class ModelNotFoundError(ModelError):
-    """Raised when a requested model cannot be found.
-
-    This includes missing model files or invalid model names.
-    """
-    pass
-
-
 class ModelLoadError(ModelError):
     """Raised when a model fails to load.
 
@@ -65,29 +57,12 @@ class NumericalError(ModelError):
 
 
 class OptimizationError(Auto3DError):
-    """Base exception for optimization-related errors."""
-    pass
+    """Base exception for optimization-related errors.
 
-
-class ConvergenceError(OptimizationError):
-    """Raised when geometry optimization fails to converge.
-
-    This may indicate that the optimization parameters need adjustment
-    or that the molecular structure is problematic.
+    Raised directly (not through a subclass) when no 3D structure converges
+    for a molecule; see WorkflowOrchestrator._run_pipeline and
+    batch_opt/model_wrapper.py.
     """
-    pass
-
-
-class IsomerEnumerationError(Auto3DError):
-    """Raised when stereoisomer enumeration fails.
-
-    This includes failures in the RDKit or OpenEye isomer engines.
-    """
-    pass
-
-
-class TautomerEnumerationError(Auto3DError):
-    """Raised when tautomer enumeration fails."""
     pass
 
 
@@ -102,10 +77,26 @@ class FileFormatError(Auto3DError):
 class DependencyError(Auto3DError):
     """Raised when a required dependency is not available.
 
-    Some features require optional dependencies like OpenEye toolkits
-    or TorchANI. This error is raised when these are needed but not installed.
+    Some features require optional dependencies like OpenEye toolkits,
+    TorchANI, or ASE. This error is raised when these are needed but not
+    installed.
+
+    Attributes:
+        dependency_name: A short key identifying the missing dependency
+            (e.g. ``"openeye"``, ``"torchani"``, ``"ase"``). ``cli.errors.
+            get_error_hint`` looks this up in its own hints map to show an
+            install command; before this attribute existed it was read via
+            ``getattr(error, "dependency_name", "unknown")`` on every raise
+            site, so every dependency failure showed the same
+            "Install the missing dependency: unknown" hint (M26). Defaults to
+            ``"unknown"`` so a caller that raises ``DependencyError(msg)``
+            without naming a dependency still gets a (generic) hint rather
+            than a crash in the hint lookup.
     """
-    pass
+
+    def __init__(self, message: str, dependency_name: str | None = None) -> None:
+        super().__init__(message)
+        self.dependency_name = dependency_name or "unknown"
 
 
 class GPUError(Auto3DError):

--- a/src/Auto3D/models/preflight.py
+++ b/src/Auto3D/models/preflight.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-import requests
-
 from Auto3D.constants import DEFAULT_AIMNET_MODEL, MODEL_AIMNET, MODEL_ANI2X, MODEL_ANI2XT
 from Auto3D.exceptions import ConfigurationError, ModelLoadError
 
@@ -48,11 +46,22 @@ def resolve_engine_name(name: str) -> str:
 
     Args:
         name: An engine name: ``ANI2x``, ``ANI2xt``, ``AIMNET``, an aimnet
-            registry name or alias, or a path to a custom NNP file.
+            registry name or alias, or a path to a custom NNP file. The three
+            named engines (``ANI2x``, ``ANI2xt``, ``AIMNET``) are matched
+            case-insensitively -- ``ani2x``, ``ANI2X``, ``ani2xt``, and
+            ``aimnet`` are all accepted, matching ``ModelFactory.create``'s
+            own ``name.upper()`` comparison (``model_factory.py``). Registry
+            names/aliases are folded to lowercase before the registry lookup,
+            since ``resolve_registry_model_name`` does a plain, unfolded dict
+            lookup and the registry's own keys/aliases are lowercase-only
+            (e.g. ``aimnet2``, ``aimnet2-2025``); a custom NNP path is passed
+            through with its case untouched, since filesystem paths are
+            case-sensitive on most platforms.
 
     Returns:
-        The value unchanged for the named engines and custom paths, or the
-        resolved registry model name for an aimnet name or alias.
+        The canonical name for the named engines (``ANI2x``/``ANI2xt``), the
+        path unchanged for a custom NNP file, or the resolved registry model
+        name for an aimnet name or alias.
 
     Raises:
         ConfigurationError: If the name is none of those. The message lists
@@ -60,9 +69,24 @@ def resolve_engine_name(name: str) -> str:
             case this exists to catch and "not found in the registry" alone
             does not tell the user what they may write instead.
     """
-    if name in (MODEL_ANI2X, MODEL_ANI2XT):
-        return name
-    if Path(name).exists():
+    name_upper = name.upper()
+
+    # Named engines are resolved by identity FIRST, before any filesystem
+    # check -- mirroring ModelFactory.create's deliberate order
+    # (model_factory.py:109-116): a file that happens to share a reserved
+    # engine's name in the working directory must never hijack that name into
+    # being treated as a custom NNP path. "AIMNET" is included here for the
+    # same reason, even though it is not one of ModelFactory's two built-in
+    # ANI adapters -- it is still a reserved literal, and the aimnet registry
+    # branch below must not silently degrade into "whatever file happens to
+    # be named AIMNET".
+    if name_upper == MODEL_ANI2X.upper():
+        return MODEL_ANI2X
+    if name_upper == MODEL_ANI2XT.upper():
+        return MODEL_ANI2XT
+    is_aimnet_literal = name_upper == MODEL_AIMNET
+
+    if not is_aimnet_literal and Path(name).exists():
         return name
 
     from aimnet.calculators.model_registry import (
@@ -70,7 +94,7 @@ def resolve_engine_name(name: str) -> str:
         resolve_registry_model_name,
     )
 
-    candidate = DEFAULT_AIMNET_MODEL if name.upper() == MODEL_AIMNET else name
+    candidate = DEFAULT_AIMNET_MODEL if is_aimnet_literal else name.lower()
     try:
         return resolve_registry_model_name(candidate)
     except ValueError as exc:
@@ -139,6 +163,13 @@ def preflight_model(engine: str) -> None:
 
     # Deferred: only needed on this call path, and keeps the module's other
     # (pure, offline) functions importable without pulling in the model stack.
+    # `requests` is now also declared directly in pyproject.toml (previously
+    # it arrived only transitively, via aimnet's own `requests>=2.32.3`), but
+    # deferring the import here still matters on its own: `import Auto3D.utils`
+    # (which reaches this module through utils/validation.py) stays free of a
+    # dependency it does not otherwise need, regardless of how `requests`
+    # is declared.
+    import requests
     from aimnet.calculators.model_registry import get_registry_model_path
 
     # Resolved as a plain string before the try, and reused in every handler

--- a/src/Auto3D/ranking.py
+++ b/src/Auto3D/ranking.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pandas as pd
 from rdkit import Chem
 
+from Auto3D.config import SELECTOR_FIELDS, check_selectors_mutually_exclusive
 from Auto3D.exceptions import ConfigurationError
 from Auto3D.filtering import filter_unique_optimized
 from Auto3D.utils import ev2kcalpermol, filter_unique, hartree2ev
@@ -214,11 +215,20 @@ class ConformerRanker:
                 ConformerRanker directly).
         """
         logger.info("Begin to select structures that satisfy the requirements...")
-        if self.k and self.window:
-            raise ConfigurationError(
-                "Only one of k or window may be specified, got "
-                f"k={self.k!r} and window={self.window!r}"
-            )
+        # Delegated to Auto3D.config rather than re-implemented here. This was
+        # the third site that knew the k/window pair by name -- after
+        # Auto3DOptions and CLIConfig, both of which reach the same check via
+        # check_field_bounds -- and the copy had already drifted: its message
+        # read "got k=1 and window=5.0" where the shared one reads
+        # "got k=1, window=5.0", so the same misconfiguration was reported two
+        # different ways depending on whether the caller came through a config
+        # class or constructed ConformerRanker directly. Reading the field
+        # names from SELECTOR_FIELDS also means a third selector added to that
+        # tuple is rejected here too, instead of being accepted by
+        # ConformerRanker(...) alone while both config classes refuse it.
+        check_selectors_mutually_exclusive(
+            {name: getattr(self, name, None) for name in SELECTOR_FIELDS}
+        )
         results = []
 
         mols, names, energies = [], [], []

--- a/src/Auto3D/ranking.py
+++ b/src/Auto3D/ranking.py
@@ -14,6 +14,39 @@ from Auto3D.utils.stereo_check import stereo_preserved
 logger = get_logger(__name__)
 
 
+def species_id(name: str) -> str:
+    """Recover the species id from a conformer's ``_Name``.
+
+    Conformer names are ``<species_id>_<isomer>_<conformer>``: two trailing
+    integer components appended after the id every caller of this module
+    actually feeds it -- the SDF input path always (RDKitSdfIsomer names
+    "uniformly, including when there is only one isomer" per its docstring),
+    and the SMILES path (RDKitIsomer) with the default ``enumerate_isomer``
+    enabled (isomer index from ``write_enumerated_smi``, conformer index from
+    ``embed_conformer``).
+
+    Stripping on the FIRST underscore is wrong whenever ``species_id`` itself
+    contains an underscore -- notably ``smiles2smi``'s InChIKey-collision
+    disambiguation (``utils/file_ops.py``), which renames a duplicate input's
+    id to ``f"{inchikey}_{count}"`` (e.g. ``KEY_2``) specifically so it is not
+    dropped. Stripping the trailing two components with ``rsplit(..., 2)``
+    instead recovers ``species_id`` intact (embedded underscores and all), so
+    conformers of one species still group together AND a disambiguated id
+    like ``KEY_2`` stays distinct from ``KEY``.
+
+    Known residual gap (pre-existing, not introduced here): the SMILES path
+    with ``enumerate_isomer=False`` appends only ONE trailing component (the
+    conformer index, no isomer index), so a disambiguated id there produces a
+    name indistinguishable in shape from the isomer-enabled case (e.g.
+    ``KEY_2_0`` could be species "KEY_2" conformer 0, or species "KEY" isomer
+    2 conformer 0) -- this function cannot tell them apart without knowing
+    which mode produced the name. An InChIKey collision combined with
+    ``enumerate_isomer=False`` still mis-groups, exactly as it did before this
+    fix; unlike the default path, this combination has no test pinning it.
+    """
+    return name.strip().rsplit("_", 2)[0].strip()
+
+
 class ConformerRanker:
     """Select conformers that satisfy user-defined energy criteria.
 
@@ -109,7 +142,10 @@ class ConformerRanker:
                 out_mols = out_mols_
 
         if len(out_mols) == 0:
-            name = names[0].split("_")[0].strip()
+            # names[0] is already the group's species id (see species_id()
+            # above) -- no further splitting here, or a disambiguated id
+            # like "KEY_2" would misreport as "KEY" in this message.
+            name = names[0].strip()
             logger.info(f"No structure converged for {name}.")
         else:
             #Adding relative energies
@@ -143,7 +179,9 @@ class ConformerRanker:
         out_mols = []
 
         if len(out_mols_) == 0:
-            name = names[0].split("_")[0].strip()
+            # names[0] is already the group's species id -- see the note in
+            # top_k above.
+            name = names[0].strip()
             logger.info(f"No structure converged for {name}.")
         else:
             ref_energy = float(out_mols_[0].GetProp('E_tot'))
@@ -197,7 +235,7 @@ class ConformerRanker:
                     converged = False
                 if converged:
                     mols.append(mol)
-                    names.append(mol.GetProp('_Name').strip().split("_")[0].strip())
+                    names.append(species_id(mol.GetProp('_Name')))
                     energies.append(float(mol.GetProp('E_tot')))
 
         df = pd.DataFrame({"names": names, "energies": energies, "mols": mols})
@@ -224,9 +262,11 @@ class ConformerRanker:
                 mol.SetProp('E_tot(Hartree)', mol.GetProp('E_tot'))
                 mol.SetProp('E_rel(kcal/mol)', str(float(mol.GetProp('E_rel(eV)')) * ev2kcalpermol))
                 mol.ClearProp('E_rel(eV)')
-                #Remove _ in the molecule title
+                # Strip the trailing <isomer>_<conformer> suffix, keeping the
+                # species id intact (see species_id()) so a disambiguated
+                # "KEY_2" is not re-collapsed onto "KEY" in the final output.
                 t = mol.GetProp("_Name")
-                t_simplified = t.split("_")[0].strip()
+                t_simplified = species_id(t)
                 mol.SetProp("_Name", t_simplified)
                 f.write(mol)
         return results

--- a/src/Auto3D/ranking.py
+++ b/src/Auto3D/ranking.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pandas as pd
 from rdkit import Chem
 
+from Auto3D.exceptions import ConfigurationError
 from Auto3D.filtering import filter_unique_optimized
 from Auto3D.utils import ev2kcalpermol, filter_unique, hartree2ev
 from Auto3D.utils.chemistry import check_connectivity
@@ -202,18 +203,19 @@ class ConformerRanker:
             List of selected RDKit Mol objects.
 
         Raises:
-            ValueError: If neither k nor window is specified, or if both are
-                (top-k and energy-window selection are alternatives, not
-                composable -- only one is ever consulted below, so setting
-                both would silently make one of them inert; callers reaching
-                here through Auto3DOptions/CLIConfig already had this caught
-                earlier, at construction time, with ConfigurationError -- this
-                is the same guard for callers that construct ConformerRanker
-                directly).
+            ConfigurationError: If neither k nor window is specified, or if
+                both are (top-k and energy-window selection are alternatives,
+                not composable -- only one is ever consulted below, so
+                setting both would silently make one of them inert; callers
+                reaching here through Auto3DOptions/CLIConfig already had
+                this caught earlier, at construction time, with
+                ConfigurationError -- this is the same guard, raising the
+                same exception type, for callers that construct
+                ConformerRanker directly).
         """
         logger.info("Begin to select structures that satisfy the requirements...")
         if self.k and self.window:
-            raise ValueError(
+            raise ConfigurationError(
                 "Only one of k or window may be specified, got "
                 f"k={self.k!r} and window={self.window!r}"
             )
@@ -248,7 +250,7 @@ class ConformerRanker:
             elif self.window:
                 top_results = self.top_window(group, self.window)
             else:
-                raise ValueError('Parameter k or window needs to be '
+                raise ConfigurationError('Parameter k or window needs to be '
                                     'specified. Append "--k=1" if you'
                                     'only want one structure per SMILES')
             results += top_results

--- a/src/Auto3D/ranking.py
+++ b/src/Auto3D/ranking.py
@@ -164,9 +164,21 @@ class ConformerRanker:
             List of selected RDKit Mol objects.
 
         Raises:
-            ValueError: If neither k nor window is specified.
+            ValueError: If neither k nor window is specified, or if both are
+                (top-k and energy-window selection are alternatives, not
+                composable -- only one is ever consulted below, so setting
+                both would silently make one of them inert; callers reaching
+                here through Auto3DOptions/CLIConfig already had this caught
+                earlier, at construction time, with ConfigurationError -- this
+                is the same guard for callers that construct ConformerRanker
+                directly).
         """
         logger.info("Begin to select structures that satisfy the requirements...")
+        if self.k and self.window:
+            raise ValueError(
+                "Only one of k or window may be specified, got "
+                f"k={self.k!r} and window={self.window!r}"
+            )
         results = []
 
         mols, names, energies = [], [], []

--- a/src/Auto3D/tautomer.py
+++ b/src/Auto3D/tautomer.py
@@ -7,6 +7,7 @@ from rdkit import Chem
 
 from Auto3D.auto3D import main
 from Auto3D.config import Auto3DOptions
+from Auto3D.exceptions import ConfigurationError
 from Auto3D.utils import hartree2kcalpermol
 from Auto3D.utils.logging_config import get_logger
 
@@ -30,13 +31,21 @@ def select_tautomers(sdf: str, k: int | None = None, window: float | None = None
         decided by ZPE/entropy differences of 1-2 kcal/mol that can invert the
         electronic-energy ordering, so the "most stable" tautomer here is an
         electronic-energy estimate, not a free-energy one. Use the thermo module
-        (Auto3D.ASE.thermo) for a free-energy comparison when that matters."""
+        (Auto3D.ASE.thermo) for a free-energy comparison when that matters.
+
+    Raises:
+        ConfigurationError: If both k and window are given, if neither is
+            given, or if k < 1. ``auto3d tautomers`` already rejects the
+            both-given case in ``execute_tautomers`` before calling this
+            function, but ``select_tautomers``/``get_stable_tautomers`` are
+            also public Python API entry points that can be called directly,
+            bypassing that CLI-level guard."""
     logger.info("Begin to select stable tautomers based on their conformer energies...")
     results = []
     if (k is not None) and (window is not None):
-        raise ValueError("Only k OR window needs to be specified")
+        raise ConfigurationError("Only k OR window needs to be specified")
     if (k is not None) and (k < 1):
-        raise ValueError(f"tauto_k must be >= 1, got {k}")
+        raise ConfigurationError(f"tauto_k must be >= 1, got {k}")
 
     supplier = Chem.SDMolSupplier(sdf, removeHs=False)
     mols = [m for m in supplier if m is not None]
@@ -77,7 +86,7 @@ def select_tautomers(sdf: str, k: int | None = None, window: float | None = None
                     mol.SetProp("_Name", group_name)
                     out_mols.append(mol)
         else:
-            raise ValueError("Either k OR window needs to be specified")
+            raise ConfigurationError("Either k OR window needs to be specified")
         results += out_mols
         
 

--- a/src/Auto3D/utils/file_ops.py
+++ b/src/Auto3D/utils/file_ops.py
@@ -30,10 +30,19 @@ logger = get_logger(__name__)
 
 
 def iter_smi_records(path, *, on_malformed="skip"):
-    """Yield (line_no, smiles, mol_id) for each non-blank line of a .smi file.
+    """Yield (line_no, smiles, mol_id) for each non-blank, non-comment line of
+    a .smi file.
 
     A line is 'SMILES ID [extra columns ignored]'. Blank/whitespace-only lines
-    are skipped. on_malformed controls lines with fewer than 2 whitespace tokens:
+    are skipped, as are lines whose first non-whitespace character is '#'
+    (comments) -- matching cli.commands.validate.validate_smiles_file, so
+    `auto3d validate` and every consumer of this function (encode_ids and so
+    the whole run pipeline, plus the isomer/tautomer engines and the
+    input/output reconciliation helpers) agree on what a comment line is
+    (M25). A real SMILES token can never start with '#' (it is a bond symbol
+    between two atoms, never a leading character), so this cannot misclassify
+    a legitimate SMILES as a comment. on_malformed controls lines with fewer
+    than 2 whitespace tokens:
       - "skip": log a warning and skip the line (lenient; default)
       - "raise": raise InputValidationError naming the line
 
@@ -47,8 +56,8 @@ def iter_smi_records(path, *, on_malformed="skip"):
         whitespace-separated columns beyond the ID are intentionally ignored.
 
     Raises:
-        InputValidationError: If on_malformed == "raise" and a non-blank line
-            has fewer than 2 whitespace tokens.
+        InputValidationError: If on_malformed == "raise" and a non-blank,
+            non-comment line has fewer than 2 whitespace tokens.
         ValueError: If on_malformed is not "skip" or "raise".
     """
     if on_malformed not in ("skip", "raise"):
@@ -58,9 +67,12 @@ def iter_smi_records(path, *, on_malformed="skip"):
     with open(path) as f:
         data = f.readlines()
     for line_no, line in enumerate(data, start=1):
-        if not line.strip():
+        stripped = line.strip()
+        if not stripped:
             continue
-        parts = line.split()
+        if stripped.startswith("#"):
+            continue
+        parts = stripped.split()
         if len(parts) < 2:
             if on_malformed == "raise":
                 raise InputValidationError(

--- a/src/Auto3D/utils/stereochemistry.py
+++ b/src/Auto3D/utils/stereochemistry.py
@@ -194,9 +194,11 @@ def enantiomer_helper(smiles: list[str]) -> list[str]:
 def remove_enantiomers(inpath: str, out: str) -> dict[str, list[str]]:
     """Remove enantiomers from an input SMILES file.
 
-    Reads a SMILES file, groups SMILES by molecule ID (base name before
-    underscore), removes enantiomeric duplicates from each group, and
-    writes the filtered results to an output file.
+    Reads a SMILES file, groups SMILES by molecule ID (the id with its
+    trailing ``_<isomer_index>`` component -- appended by
+    ``RDKitIsomer.write_enumerated_smi`` -- removed), removes enantiomeric
+    duplicates from each group, and writes the filtered results to an output
+    file.
 
     Args:
         inpath: Path to input .smi file with format "SMILES ID" per line.
@@ -215,7 +217,14 @@ def remove_enantiomers(inpath: str, out: str) -> dict[str, list[str]]:
     smiles: dict[str, list[str]] = defaultdict(lambda: [])
     for line in data:
         vals = line.split()
-        smi, name = vals[0].strip(), vals[1].strip().split("_")[0].strip()
+        # Strip only the trailing isomer-index component write_enumerated_smi
+        # appends (rsplit, maxsplit=1), not everything after the first
+        # underscore: an id like "KEY_2" -- smiles2smi's disambiguation of a
+        # duplicate InChIKey (utils/file_ops.py), kept distinct from "KEY"
+        # specifically so it is not dropped -- must survive this grouping
+        # intact, or it silently merges back onto "KEY" here before ranking
+        # ever sees it (M17).
+        smi, name = vals[0].strip(), vals[1].strip().rsplit("_", 1)[0].strip()
         smiles[name].append(smi)
 
     for key, values in smiles.items():
@@ -454,7 +463,11 @@ def amend_configuration(smis: str) -> dict[str, list[str]]:
     dct: dict[str, list[str]] = defaultdict(lambda: [])
     for line in data:
         smi, idx = tuple(line.strip().split())
-        idx = idx.split("_")[0].strip()
+        # See the matching note in remove_enantiomers: strip only the
+        # trailing isomer-index component, not everything after the first
+        # underscore, so a disambiguated id like "KEY_2" is not merged back
+        # onto "KEY" here (M17).
+        idx = idx.rsplit("_", 1)[0].strip()
         dct[idx].append(smi)
 
     for key in dct.keys():

--- a/src/Auto3D/utils/validation.py
+++ b/src/Auto3D/utils/validation.py
@@ -15,6 +15,7 @@ from rdkit.Chem.rdMolDescriptors import (
     CalcNumUnspecifiedAtomStereoCenters,
 )
 
+from Auto3D.constants import BUILTIN_ANI_MODELS
 from Auto3D.exceptions import (
     ConfigurationError,
     DependencyError,
@@ -31,6 +32,72 @@ if TYPE_CHECKING:
     pass
 
 logger = get_logger(__name__)
+
+#: Elements ANI2x/ANI2xt were trained on. AIMNET (and any aimnet registry
+#: model) and a custom NNP path are not restricted to this set.
+ANI_ELEMENTS = frozenset({1, 6, 7, 8, 9, 16, 17})
+
+
+def _requires_aimnet(mol: Chem.Mol) -> bool:
+    """True if `mol` cannot be represented by ANI2x/ANI2xt.
+
+    A molecule needs AIMNET when it carries an element outside ANI_ELEMENTS or
+    a nonzero net formal charge. Single implementation of this test --
+    check_smi_format and check_sdf_format used to each inline it as their own
+    copy of the identical {1, 6, 7, 8, 9, 16, 17} literal, which is exactly
+    how the two would silently drift apart (C11).
+    """
+    elements = {a.GetAtomicNum() for a in mol.GetAtoms()}
+    charge = Chem.rdmolops.GetFormalCharge(mol)
+    return (not elements.issubset(ANI_ELEMENTS)) or charge != 0
+
+
+def check_engine_supports_molecules(
+    mols: Chem.Mol | list[Chem.Mol], optimizing_engine: str
+) -> None:
+    """Raise if `optimizing_engine` cannot represent every molecule in `mols`.
+
+    ANI2x/ANI2xt can only represent uncharged molecules built from
+    {H, C, N, O, F, S, Cl}. A charged or out-of-set species handed to either
+    is silently evaluated as a different, neutral, in-set species -- tens of
+    kcal/mol wrong energy and wrong forces, so a downstream "optimized"
+    geometry is wrong too (C11).
+
+    `check_input` already runs this check (via check_smi_format /
+    check_sdf_format, which call `_requires_aimnet` above) for main() and
+    smiles2mols. calc_spe, opt_geometry and calc_thermo take an SDF path
+    directly and never go through check_input, so they call this function
+    themselves instead.
+
+    AIMNET (and any aimnet registry name) and a path to a custom NNP are not
+    restricted by this element set, so this is a no-op for them.
+
+    Args:
+        mols: A single RDKit Mol or an iterable of them, read from the
+            caller's input SDF.
+        optimizing_engine: The engine name exactly as passed to
+            calc_spe/opt_geometry/calc_thermo (e.g. 'ANI2x', 'AIMNET', a
+            registry name, or a custom NNP path).
+
+    Raises:
+        ConfigurationError: `optimizing_engine` is ANI2x/ANI2xt (matched
+            case-insensitively, mirroring ModelFactory.create) and at least
+            one molecule is charged or contains an element outside the ANI
+            training set.
+    """
+    if optimizing_engine.upper() not in BUILTIN_ANI_MODELS:
+        return
+    mol_list = [mols] if isinstance(mols, Chem.Mol) else list(mols)
+    incompatible = [
+        mol.GetProp("_Name") if mol.HasProp("_Name") else "<unnamed>"
+        for mol in mol_list
+        if _requires_aimnet(mol)
+    ]
+    if incompatible:
+        raise ConfigurationError(
+            f"Only AIMNET can handle: {incompatible}, but {optimizing_engine} "
+            "was parsed to Auto3D."
+        )
 
 
 def check_input(args: Any) -> None:
@@ -156,7 +223,6 @@ def check_smi_format(args: Any) -> tuple[bool, list[str]]:
     Raises:
         InputValidationError: If a non-blank line lacks a SMILES and an ID.
     """
-    ANI_elements = {1, 6, 7, 8, 9, 16, 17}
     ANI = True
 
     smiles_all = []
@@ -205,9 +271,7 @@ def check_smi_format(args: Any) -> tuple[bool, list[str]]:
         if mol is None:
             logger.warning(f"Skipping invalid SMILES: {smiles}")
             continue
-        charge = Chem.rdmolops.GetFormalCharge(mol)
-        elements = set([a.GetAtomicNum() for a in mol.GetAtoms()])
-        if not elements.issubset(ANI_elements) or charge != 0:
+        if _requires_aimnet(mol):
             ANI = False
             only_aimnet_smiles.append(smiles)
     return ANI, only_aimnet_smiles
@@ -233,7 +297,6 @@ def check_sdf_format(args: Any) -> tuple[bool, list[str]]:
     Raises:
         ValueError: If molecule ID is empty (_Name property is empty).
     """
-    ANI_elements = {1, 6, 7, 8, 9, 16, 17}
     ANI = True
 
     supp = Chem.SDMolSupplier(args.path, removeHs=False)
@@ -247,9 +310,7 @@ def check_sdf_format(args: Any) -> tuple[bool, list[str]]:
             raise ValueError("Empty molecule ID (empty _Name property)")
         mols.append(mol)
 
-        charge = Chem.rdmolops.GetFormalCharge(mol)
-        elements = set([a.GetAtomicNum() for a in mol.GetAtoms()])
-        if not elements.issubset(ANI_elements) or charge != 0:
+        if _requires_aimnet(mol):
             ANI = False
             only_aimnet_ids.append(id)
 

--- a/src/Auto3D/utils/validation.py
+++ b/src/Auto3D/utils/validation.py
@@ -38,6 +38,52 @@ logger = get_logger(__name__)
 ANI_ELEMENTS = frozenset({1, 6, 7, 8, 9, 16, 17})
 
 
+def check_gpu_requested(use_gpu: bool) -> None:
+    """Raise if GPU was requested but no CUDA device is visible.
+
+    Single source of truth for Auto3D's GPU policy: **fatal, not a silent
+    fallback**. Before this function existed, ``use_gpu=True`` on a CPU-only
+    box produced three different behaviors depending on the entry point
+    (M23):
+
+    - ``main()`` (via ``WorkflowOrchestrator._validate_input`` ->
+      ``check_valid_configuration``) raised ``ConfigurationError``, which
+      shows the CLI's "run 'auto3d config init'" hint -- unrelated to a GPU
+      problem.
+    - ``smiles2mols`` reached ``check_input``'s own inline check and raised
+      ``GPUError`` (the right exception, right hint), but with different
+      wording than ``check_valid_configuration``'s message.
+    - ``auto3d energy``/``optimize``/``thermo`` (``calc_spe``/
+      ``opt_geometry``/``calc_thermo``) never checked at all: they fell back
+      to CPU through ``model_factory.get_device`` with no error and no
+      warning.
+
+    A scripted user who set ``use_gpu=True`` and silently got CPU has no way
+    to know their "GPU" results were actually computed on CPU -- possibly
+    orders of magnitude slower than they assumed, with no signal anything
+    was wrong. This function is called as the *first* check everywhere GPU
+    use is decided (``check_input``, ``check_valid_configuration``, and the
+    ``auto3d energy``/``optimize``/``thermo`` CLI commands in
+    ``cli/commands/properties.py``, which call the API functions directly
+    and never go through ``check_input``/``check_valid_configuration``), so
+    it fails fast -- before any worker is forked and before any compute is
+    spent -- with the same exception type and the same "--no-gpu" hint
+    regardless of entry point.
+
+    Args:
+        use_gpu: The ``use_gpu`` option requested by the caller.
+
+    Raises:
+        GPUError: `use_gpu` is True and `torch.cuda.is_available()` is False.
+    """
+    if use_gpu and not torch.cuda.is_available():
+        raise GPUError(
+            "No cuda device was detected, but use_gpu=True was requested. "
+            "Pass --no-gpu on the CLI (or set use_gpu=False in the Python "
+            "API) to run on CPU."
+        )
+
+
 def _requires_aimnet(mol: Chem.Mol) -> bool:
     """True if `mol` cannot be represented by ANI2x/ANI2xt.
 
@@ -128,11 +174,10 @@ def check_input(args: Any) -> None:
     """
     logger.info("Checking input file...")
 
-    # Check --use_gpu
-    gpu_flag = args.use_gpu
-    if gpu_flag:
-        if not torch.cuda.is_available():
-            raise GPUError("No cuda device was detected. Please set use_gpu=False.")
+    # Check --use_gpu. Delegates to check_gpu_requested so this and
+    # check_valid_configuration can never drift onto different wording or a
+    # different exception type again (M23).
+    check_gpu_requested(args.use_gpu)
 
     isomer_engine = args.isomer_engine
     if ("OE_LICENSE" not in os.environ) and (isomer_engine == "omega"):
@@ -233,6 +278,12 @@ def check_smi_format(args: Any) -> tuple[bool, list[str]]:
         data = f.readlines()
     for line in data:
         if line.isspace():
+            continue
+        # Skip '#'-prefixed comment lines, matching cli.commands.validate.
+        # validate_smiles_file and file_ops.iter_smi_records -- all three must
+        # agree on what counts as a comment vs. data, or `auto3d validate`
+        # would approve a file this function then rejects (M25).
+        if line.lstrip().startswith("#"):
             continue
         # Tolerate ragged rows the way the rest of the pipeline does: the chunk
         # loader reads only the first two whitespace columns (usecols=[0, 1]), so
@@ -364,6 +415,15 @@ def check_valid_configuration(
 
     Returns:
         List of error messages. Empty list if configuration is valid.
+
+    Raises:
+        GPUError: `use_gpu` is True and no CUDA device is visible. Raised
+            immediately (not folded into the returned `errors` list) so every
+            caller of this function -- main() via
+            WorkflowOrchestrator._validate_input, and smiles2mols -- gets the
+            same fatal GPUError, with the same "--no-gpu" hint, that
+            check_input already raised for this condition (M23). See
+            check_gpu_requested for the full rationale.
     """
     errors: list[str] = []
 
@@ -377,9 +437,13 @@ def check_valid_configuration(
     if not k and not window:
         errors.append("Either 'k' or 'window' must be specified for conformer selection.")
 
-    # Check GPU configuration
-    if use_gpu and not torch.cuda.is_available():
-        errors.append("GPU requested but CUDA is not available. Set use_gpu=False.")
+    # Check GPU configuration. Raises immediately rather than appending to
+    # `errors`: every caller wraps a non-empty `errors` list into a single
+    # ConfigurationError, which would show the CLI's "config init" hint --
+    # unrelated to a GPU problem. Also means the gpu_idx range check below
+    # only runs once CUDA is confirmed available, so an unavailable-CUDA box
+    # never sees a confusing second "0 available GPUs" message.
+    check_gpu_requested(use_gpu)
 
     if use_gpu:
         if isinstance(gpu_idx, int):

--- a/src/Auto3D/utils/validation.py
+++ b/src/Auto3D/utils/validation.py
@@ -138,7 +138,8 @@ def check_input(args: Any) -> None:
     if ("OE_LICENSE" not in os.environ) and (isomer_engine == "omega"):
         raise DependencyError(
             "Omega is used as the isomer engine, but OE_LICENSE is not detected. "
-            "Please use rdkit."
+            "Please use rdkit.",
+            dependency_name="openeye",
         )
 
     # Check the installation for open toolkits, torchani
@@ -147,7 +148,8 @@ def check_input(args: Any) -> None:
             from openeye import oechem  # noqa: F401
         except ImportError:
             raise DependencyError(
-                "Omega is used as isomer engine, but openeye toolkits are not installed."
+                "Omega is used as isomer engine, but openeye toolkits are not installed.",
+                dependency_name="openeye",
             )
 
     if args.optimizing_engine == "ANI2x":
@@ -155,7 +157,8 @@ def check_input(args: Any) -> None:
             import torchani  # noqa: F401
         except ImportError:
             raise DependencyError(
-                "ANI2x is used as optimizing engine, but TorchANI is not installed."
+                "ANI2x is used as optimizing engine, but TorchANI is not installed.",
+                dependency_name="torchani",
             )
 
     if Path(args.optimizing_engine).exists():
@@ -295,7 +298,7 @@ def check_sdf_format(args: Any) -> tuple[bool, list[str]]:
             - only_aimnet_ids: List of molecule IDs that require AIMNET
 
     Raises:
-        ValueError: If molecule ID is empty (_Name property is empty).
+        InputValidationError: If molecule ID is empty (_Name property is empty).
     """
     ANI = True
 
@@ -307,7 +310,10 @@ def check_sdf_format(args: Any) -> tuple[bool, list[str]]:
             continue
         id = mol.GetProp("_Name")
         if len(id) == 0:
-            raise ValueError("Empty molecule ID (empty _Name property)")
+            # Same defect as check_smi_format's missing-ID check above --
+            # both must raise the same Auto3DError subclass so the CLI shows
+            # the same hint and exit code regardless of input format.
+            raise InputValidationError("Empty molecule ID (empty _Name property)")
         mols.append(mol)
 
         if _requires_aimnet(mol):

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -93,6 +93,17 @@ class WorkflowOrchestrator:
             FileFormatError: If input file format is not supported.
             OptimizationError: If no structures converge.
         """
+        # Copy the caller's config once, up front (M16). _validate_input
+        # below mutates self.config (job_name, input_format); without this
+        # copy those mutations land on the exact object the caller still
+        # holds, so a second main(args) call with the same config in one
+        # process would see self.config.job_name already non-empty and
+        # reuse the first run's job_name instead of generating its own.
+        # This is what makes _run_pipeline's own `replace()` comment further
+        # down ("the caller's shared config is never mutated") true for the
+        # whole run, not just that one local copy.
+        self.config = replace(self.config)
+
         start_time = time.time()
 
         # Configure PyTorch settings (TF32, cuDNN benchmark)
@@ -327,8 +338,9 @@ class WorkflowOrchestrator:
         )
 
         # Per-run config carrying the memory-scaled batch size for optimization.
-        # Built with dataclasses.replace so the caller's shared config is never
-        # mutated (review findings #35/#36).
+        # Built with dataclasses.replace so self.config (itself already a
+        # private copy made at the top of run(), see M16) is left holding the
+        # unscaled value -- only the optimizer workers get the scaled one.
         opt_config = replace(
             self.config, batchsize_atoms=self.scaled_batchsize_atoms
         )

--- a/src/Auto3D/workflow_workers.py
+++ b/src/Auto3D/workflow_workers.py
@@ -55,13 +55,28 @@ def _attach_run_log_handlers(
 ) -> list[tuple[str, logging.Handler]]:
     """Attach a run-log QueueHandler onto every tree it must reach.
 
-    Returns the ``(logger_name, handler)`` pairs added, so a caller (chiefly
-    tests) can remove them again; production callers can ignore the return
-    value since these handlers live for the worker process's lifetime.
+    Idempotent per ``logging_queue``: if a tree already has a ``QueueHandler``
+    targeting this exact queue (e.g. a second in-process call to
+    ``isomer_wrapper``/``optim_rank_wrapper`` with the same queue, as tests --
+    not production -- sometimes do), that tree is left untouched instead of
+    growing a second handler that would deliver every subsequent record
+    twice. Production is unaffected: each run spawns a fresh worker process
+    with a fresh queue, so this only ever attaches once there.
+
+    Returns the ``(logger_name, handler)`` pairs newly added (never the ones
+    already present), so a caller (chiefly tests) can remove them again;
+    production callers can ignore the return value since these handlers live
+    for the worker process's lifetime.
     """
     added: list[tuple[str, logging.Handler]] = []
     for logger_name in _RUN_LOG_LOGGER_NAMES:
         tree_logger = logging.getLogger(logger_name)
+        already_attached = any(
+            isinstance(h, QueueHandler) and h.queue is logging_queue
+            for h in tree_logger.handlers
+        )
+        if already_attached:
+            continue
         handler = QueueHandler(logging_queue)
         tree_logger.addHandler(handler)
         tree_logger.setLevel(logging.INFO)

--- a/tests/test_SPE.py
+++ b/tests/test_SPE.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 import pytest
-from unittest.mock import patch, MagicMock
 from rdkit import Chem
 import torch
 from Auto3D.SPE import calc_spe
@@ -10,6 +9,15 @@ skip_ani2xt_test = False
 
 # Mark all tests in this module as slow (single-point energy calculations)
 pytestmark = pytest.mark.slow
+
+# Every calc_spe call below passes use_gpu=False on purpose. calc_spe's
+# `use_gpu` default is True, and Auto3D 4.0 made "GPU requested but no CUDA
+# device visible" FATAL rather than a silent CPU fallback
+# (Auto3D.utils.validation.check_gpu_requested, called first thing inside
+# calc_spe). The slow CI job runs on ubuntu-latest -- CPU-only, like every
+# runner in this repo -- so leaving the default in place would make each of
+# these raise GPUError instead of computing anything. Same reason
+# tests/test_thermo_reference.py passes use_gpu=False.
 
 folder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -128,7 +136,7 @@ class userNNP2(torch.nn.Module):
 def test_calc_spe_ani2xt():
     #load B97-3c results file
     path = os.path.join(folder, "tests/files/b973c.sdf")
-    out = calc_spe(path, "ANI2xt")
+    out = calc_spe(path, "ANI2xt", use_gpu=False)
     spe = {"817-2-473": -386.111, "510-2-443":-1253.812}
 
     mols = Chem.SDMolSupplier(out, removeHs=False)
@@ -144,7 +152,7 @@ def test_calc_spe_ani2x():
     #load wB97X/6-31G* output file
     path = os.path.join(folder, "tests/files/wb97x_dz.sdf")
     spe = {"817-2-473": -386.178, "510-2-443":-1254.007}
-    out = calc_spe(path, "ANI2x")
+    out = calc_spe(path, "ANI2x", use_gpu=False)
 
     #compare Auto3D output with the above
     mols = Chem.SDMolSupplier(out, removeHs=False)
@@ -160,7 +168,7 @@ def test_calc_spe_aimnet():
     path = os.path.join(folder, 'tests/files/cyclooctane.sdf')
     e_ref = -314.689736079491
 
-    out = calc_spe(path, 'AIMNET')
+    out = calc_spe(path, 'AIMNET', use_gpu=False)
     mol = next(Chem.SDMolSupplier(out, removeHs=False))
     e_out = float(mol.GetProp('E_hartree'))
     assert(abs(e_out - e_ref) <= 0.01)    
@@ -177,7 +185,7 @@ def test_calc_spe_userNNP1():
         myNNP_jit = torch.jit.script(myNNP)
         myNNP_jit.save(model_path)
 
-        out = calc_spe(path, model_path)
+        out = calc_spe(path, model_path, use_gpu=False)
 
     #compare Auto3D output with the above
     mols = Chem.SDMolSupplier(out, removeHs=False)
@@ -198,7 +206,7 @@ def test_calc_spe_userNNP2():
         myNNP = userNNP2()
         # AIMNet2-based models are not torch.jit.script-able; save eager.
         torch.save(myNNP, model_path)
-        out = calc_spe(path, model_path)
+        out = calc_spe(path, model_path, use_gpu=False)
 
     mol = next(Chem.SDMolSupplier(out, removeHs=False))
     e_out = float(mol.GetProp('E_hartree'))
@@ -207,25 +215,100 @@ def test_calc_spe_userNNP2():
     assert(abs(e_out - e_ref) <= 0.01)
 
 
-def test_calc_spe_uses_model_factory():
-    """calc_spe should use ModelFactory for model creation."""
-    with patch('Auto3D.SPE.create_model') as mock_factory:
-        mock_adapter = MagicMock()
-        mock_adapter.coord_pad = 0.0
-        mock_adapter.species_pad = 0
-        # Mock the forward method to return energies and forces
-        mock_adapter.forward.return_value = (
-            torch.tensor([0.0, 0.0]),  # energies
-            torch.zeros(2, 5, 3)  # forces
+def test_calc_spe_uses_model_factory(tmp_path, monkeypatch):
+    """calc_spe must build its model through Auto3D.model_factory.create_model,
+    and must use the adapter that factory returns.
+
+    The previous version of this test asserted nothing. It called
+    ``calc_spe("nonexistent.sdf", "AIMNET", gpu_idx=0)`` inside a bare
+    ``pytest.raises(Exception)`` and then checked ``mock_factory.called``.
+    Both halves were empty:
+
+    * ``pytest.raises(Exception)`` is satisfied by any of the several ways
+      that call fails *before* ``create_model`` is ever reached -- an
+      unresolvable engine name (SPE.py's ``resolve_engine_name``), the
+      ``GPUError`` ``check_gpu_requested`` raises for the ``use_gpu=True``
+      default on a CPU-only runner, or the ``OSError`` RDKit raises for the
+      missing input file. It could not tell "calc_spe used the factory" from
+      "calc_spe blew up for an unrelated reason".
+    * ``calc_spe`` reads the input SDF (SPE.py, the ``SDMolSupplier`` loop)
+      *before* it calls ``create_model``, so a nonexistent input guarantees
+      the factory is never called at all -- the assert is unsatisfiable on
+      every runner, GPU or not.
+
+    This version hands calc_spe a real (tiny) SDF and lets it run to
+    completion with the model machinery stubbed -- no NNP is loaded and
+    nothing is downloaded -- then asserts on the factory interaction itself:
+    the name and device it was handed, and the identity of the adapter the
+    rest of calc_spe consumed. Constructing the model any other way (or
+    calling the factory and then ignoring its return value) fails this test.
+    """
+    from rdkit.Chem import AllChem
+
+    import Auto3D.SPE as spe_mod
+
+    mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+    AllChem.EmbedMolecule(mol, randomSeed=42)
+    mol.SetProp("_Name", "ethanol")
+    sdf = tmp_path / "in.sdf"
+    with Chem.SDWriter(str(sdf)) as w:
+        w.write(mol)
+
+    class FakeAdapter:
+        coord_pad = 0.0
+        species_pad = 0
+
+    adapter = FakeAdapter()
+    factory_calls = []
+
+    def fake_create_model(model_name, device):
+        factory_calls.append((model_name, device))
+        return adapter
+
+    monkeypatch.setattr(spe_mod, "get_device", lambda *a, **k: torch.device("cpu"))
+    monkeypatch.setattr(spe_mod, "create_model", fake_create_model)
+
+    enforce_args = []
+
+    class FakeEnForce:
+        def __init__(self, model_adapter):
+            enforce_args.append(model_adapter)
+
+        def forward_batched(self, coords, numbers, charges):
+            n = coords.shape[0]
+            return torch.zeros(n, dtype=torch.float64), torch.zeros_like(coords)
+
+    monkeypatch.setattr(spe_mod, "EnForce_ANI", FakeEnForce)
+
+    pad_calls = []
+
+    def fake_pad(mols, model_name, device, coord_pad, species_pad):
+        pad_calls.append((coord_pad, species_pad))
+        n = len(mols)
+        return (
+            torch.zeros(n, 1, 3),
+            torch.zeros(n, 1, dtype=torch.long),
+            torch.zeros(n, dtype=torch.long),
+            torch.ones(n, 1, dtype=torch.bool),
         )
-        mock_factory.return_value = mock_adapter
 
-        # This will fail early but we just want to verify factory is called
-        with pytest.raises(Exception):  # Will fail on file not found
-            calc_spe("nonexistent.sdf", "AIMNET", gpu_idx=0)
+    monkeypatch.setattr(spe_mod, "pad_from_mols", fake_pad)
 
-        # Verify factory was called
-        assert mock_factory.called
+    out = calc_spe(
+        str(sdf), "AIMNET", use_gpu=False, out_path=str(tmp_path / "out.sdf")
+    )
+
+    # The factory is the only model-construction path, called exactly once,
+    # with the engine name the caller asked for and the device get_device
+    # resolved.
+    assert factory_calls == [("AIMNET", torch.device("cpu"))]
+    # ...and its return value is what calc_spe actually optimizes with:
+    # identity, not just "something adapter-shaped".
+    assert enforce_args == [adapter]
+    assert pad_calls == [(adapter.coord_pad, adapter.species_pad)]
+    # The run completed through the factory-produced model.
+    assert os.path.exists(out)
+    assert len(list(Chem.SDMolSupplier(out, removeHs=False))) == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_ase_geometry.py
+++ b/tests/test_ase_geometry.py
@@ -14,7 +14,11 @@ def test_opt_geometry_names_output_by_model(monkeypatch, tmp_path):
     monkeypatch.setattr(geo, "get_device", lambda *a, **k: torch.device("cpu"))
     monkeypatch.setattr(geo, "configure_torch", lambda *a, **k: None)
 
-    out = geo.opt_geometry(str(sdf), "AIMNET")
+    # use_gpu=False: this test is about the output filename, not GPU
+    # availability. The default use_gpu=True would make check_gpu_requested
+    # (called before get_device, which is stubbed here anyway) fail fast with
+    # GPUError on a CPU-only runner -- unrelated to what this test checks.
+    out = geo.opt_geometry(str(sdf), "AIMNET", use_gpu=False)
     assert out.endswith("mols_AIMNET_opt.sdf")
 
 
@@ -54,7 +58,10 @@ def test_opt_geometry_skips_none_and_missing_etot(monkeypatch, tmp_path):
     monkeypatch.setattr(geo, "get_device", lambda *a, **k: torch.device("cpu"))
     monkeypatch.setattr(geo, "configure_torch", lambda *a, **k: None)
 
-    out = geo.opt_geometry(str(sdf), "AIMNET")  # must not raise
+    # use_gpu=False: this test is about the None/missing-E_tot skip logic, not
+    # GPU availability -- see the sibling test above for why the default
+    # use_gpu=True would fail this on a CPU-only runner for an unrelated reason.
+    out = geo.opt_geometry(str(sdf), "AIMNET", use_gpu=False)  # must not raise
 
     # Read the written file as text (the rdkit.Chem.SDMolSupplier monkeypatch
     # is module-global, so re-reading via it would return the stub list, not

--- a/tests/test_chunk_manager.py
+++ b/tests/test_chunk_manager.py
@@ -367,13 +367,18 @@ class TestRaggedSmiAndChunkSizeClamp:
         input_file = tmp_path / "test_encoded.smi"
         input_file.write_text("CCO ethanol\nCCCO propanol\nCCCCO butanol\n")
 
-        # memory=1 GB * capacity=0.0 -> raw chunk_size 0.0 (degenerate).
+        # memory=1 GB * capacity=0.0 -> raw chunk_size 0.0 (degenerate). capacity
+        # is now bounds-checked (>= 1) at construction (Task 1, C10/M27 parity),
+        # so the degenerate value is set directly on the field afterward --
+        # Auto3DOptions is a plain mutable dataclass and only validates at
+        # __init__ -- to still exercise ChunkManager's own defensive clamp
+        # below for a value that reaches it by some other means.
         config = Auto3DOptions(
             path=str(tmp_path / "test.smi"),
             k=1,
             memory=1,
-            capacity=0.0,
         )
+        config.capacity = 0.0
         manager = ChunkManager(
             config=config,
             input_path=input_file,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,12 +201,20 @@ class TestCLIExceptionHandling:
     # Legacy YAML path now (a) checks the file exists and (b) maps exception
     # types to differentiated exit codes (see Auto3D.cli.errors.EXIT_CODES):
     # ConfigurationError -> 2, GPUError -> 4, generic Auto3DError/Optimization -> 1.
+    #
+    # optimizing_engine is 'ANI2xt' (a built-in name), not 'AIMNET', because
+    # this legacy path now runs through CLIConfig (Task 1, C10/M27 parity),
+    # whose engine validator resolves an aimnet-family name against the real
+    # `aimnet` package registry. 'ANI2xt' short-circuits that resolution
+    # (Auto3D.models.preflight.resolve_engine_name's first branch) with no
+    # import of `aimnet` at all, keeping this exception-mapping test from
+    # depending on that heavy optional dependency importing cleanly.
     _LEGACY_YAML = {
         'path': '/fake/path.smi', 'k': 1, 'window': None, 'memory': None,
         'capacity': 40, 'enumerate_tautomer': False, 'tauto_engine': 'rdkit',
         'pKaNorm': True, 'isomer_engine': 'rdkit', 'max_confs': None,
         'enumerate_isomer': True, 'mode_oe': 'classic', 'mpi_np': 4,
-        'optimizing_engine': 'AIMNET', 'use_gpu': False, 'gpu_idx': 0,
+        'optimizing_engine': 'ANI2xt', 'use_gpu': False, 'gpu_idx': 0,
         'opt_steps': 2000, 'convergence_threshold': 0.01, 'patience': 250,
         'threshold': 0.3, 'verbose': False, 'job_name': '',
     }

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -426,6 +426,38 @@ def test_run_cli_explicit_k_and_window_conflict_is_configuration_error(
     assert "Unexpected Error" not in result.output
 
 
+def test_run_cli_yaml_config_bounds_violation_is_configuration_error(
+    runner, tmp_path_cwd, monkeypatch
+):
+    """`auto3d run in.smi -c cfg.yaml` with `cfg.yaml` setting `k: 0` must
+    exit 2 as a ConfigurationError with a hint -- not exit 1 under
+    "Unexpected Error" as a raw pydantic ValidationError.
+
+    This is the load_yaml_config construction site specifically (as opposed
+    to test_run_cli_explicit_k_and_window_conflict_is_configuration_error,
+    which exercises merge_configs): the bad value comes from the config file
+    itself, before any CLI override is merged in. Before this fix,
+    `load_yaml_config` raised the pydantic error unwrapped, which
+    `execute_run`'s `except Auto3DError` clause does not catch.
+    """
+    from Auto3D.cli.app import app
+
+    smi = tmp_path_cwd / "in.smi"
+    smi.write_text("CCO mol1\n")
+    cfg = tmp_path_cwd / "cfg.yaml"
+    cfg.write_text("path: placeholder.smi\nk: 0\noptimizing_engine: ANI2xt\nuse_gpu: false\n")
+
+    import Auto3D.auto3D as a3d
+    monkeypatch.setattr(a3d, "main", lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("main() must not run when config validation fails")
+    ))
+
+    result = runner.invoke(app, ["run", str(smi), "-c", str(cfg)])
+
+    assert result.exit_code == 2, result.output
+    assert "Unexpected Error" not in result.output
+
+
 # Unit tests for the exit-code decision itself (Auto3D.cli.commands.run),
 # pinned without going through the CLI or a pipeline run at all.
 

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -458,6 +458,43 @@ def test_run_cli_yaml_config_bounds_violation_is_configuration_error(
     assert "Unexpected Error" not in result.output
 
 
+def test_run_cli_yaml_uncoercible_gpu_idx_is_configuration_error(
+    runner, tmp_path_cwd, monkeypatch
+):
+    """`auto3d run in.smi -c cfg.yaml` with `gpu_idx: {a: 1}` must exit 2 as
+    a ConfigurationError -- not exit 1 under "Unexpected Error".
+
+    Sibling of the `k: 0` case above, for the failure mode that case does not
+    reach: `k: 0` violates a bound and so becomes a pydantic
+    `ValidationError`, which `build_cli_config` already translated. A mapping
+    in `gpu_idx` instead makes `CLIConfig.parse_gpu_idx`'s own `int(v)` raise
+    `TypeError`, which pydantic re-raises untouched -- so it escaped
+    `build_cli_config`'s `except ValidationError`, escaped `execute_run`'s
+    `except Auto3DError`, and landed in the generic "Unexpected Error" panel
+    at exit 1. Same user mistake (a bad value in a config file), same
+    treatment required.
+    """
+    from Auto3D.cli.app import app
+
+    smi = tmp_path_cwd / "in.smi"
+    smi.write_text("CCO mol1\n")
+    cfg = tmp_path_cwd / "cfg.yaml"
+    cfg.write_text(
+        "path: placeholder.smi\nk: 1\ngpu_idx:\n  a: 1\n"
+        "optimizing_engine: ANI2xt\nuse_gpu: false\n"
+    )
+
+    import Auto3D.auto3D as a3d
+    monkeypatch.setattr(a3d, "main", lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("main() must not run when config validation fails")
+    ))
+
+    result = runner.invoke(app, ["run", str(smi), "-c", str(cfg)])
+
+    assert result.exit_code == 2, result.output
+    assert "Unexpected Error" not in result.output
+
+
 # Unit tests for the exit-code decision itself (Auto3D.cli.commands.run),
 # pinned without going through the CLI or a pipeline run at all.
 

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -360,6 +360,72 @@ def test_no_nonzero_exit_when_no_molecules_missing(runner, tmp_path_cwd, monkeyp
     assert result.exit_code == 0
 
 
+def test_run_cli_k_override_substitutes_file_window(runner, tmp_path_cwd, monkeypatch):
+    """`auto3d run in.smi -c cfg.yaml --k 1`, where cfg.yaml sets
+    `window: 5.0`, must succeed with k=1 winning -- not hard-fail the
+    mutual-exclusion rule because the CLI override was merged alongside the
+    file's selector instead of substituting for it.
+
+    `Auto3D.auto3D.main` is stubbed (captures the `Auto3DOptions` it would
+    have received) so this exercises the full `execute_run` ->
+    `load_yaml_config`/`merge_configs` -> `to_auto3d_options()` path without
+    a pipeline run or a loaded potential. `optimizing_engine: ANI2xt` avoids
+    importing the optional `aimnet` package (same reasoning as
+    `test_cli.py`'s `_LEGACY_YAML`).
+    """
+    from Auto3D.cli.app import app
+
+    smi = tmp_path_cwd / "in.smi"
+    smi.write_text("CCO mol1\n")
+    cfg = tmp_path_cwd / "cfg.yaml"
+    cfg.write_text(
+        "path: placeholder.smi\nwindow: 5.0\noptimizing_engine: ANI2xt\nuse_gpu: false\n"
+    )
+
+    import Auto3D.auto3D as a3d
+    from Auto3D.results import WorkflowResult
+
+    captured: dict = {}
+
+    def fake_main(options, **kwargs):
+        captured["options"] = options
+        return WorkflowResult("fake_out.sdf")
+
+    monkeypatch.setattr(a3d, "main", fake_main)
+
+    result = runner.invoke(
+        app, ["run", str(smi), "-c", str(cfg), "--k", "1", "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["options"].k == 1
+    assert not captured["options"].window  # file's window=5.0 must be cleared
+
+
+def test_run_cli_explicit_k_and_window_conflict_is_configuration_error(
+    runner, tmp_path_cwd, monkeypatch
+):
+    """`--k` and `--window` both passed explicitly on the CLI is a genuine
+    user conflict (not a file-vs-CLI merge artifact) and must still exit 2
+    as a ConfigurationError with a hint -- not exit 1 as a raw pydantic
+    ValidationError under "Unexpected Error".
+    """
+    from Auto3D.cli.app import app
+
+    smi = tmp_path_cwd / "in.smi"
+    smi.write_text("CCO mol1\n")
+
+    import Auto3D.auto3D as a3d
+    monkeypatch.setattr(a3d, "main", lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("main() must not run when config validation fails")
+    ))
+
+    result = runner.invoke(app, ["run", str(smi), "--k", "1", "--window", "2.0"])
+
+    assert result.exit_code == 2, result.output
+    assert "Unexpected Error" not in result.output
+
+
 # Unit tests for the exit-code decision itself (Auto3D.cli.commands.run),
 # pinned without going through the CLI or a pipeline run at all.
 

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -420,16 +420,6 @@ def test_error_hint_input_validation_error():
     assert "validate" in hint
 
 
-def test_error_hint_model_not_found_error():
-    """get_error_hint should return hint for ModelNotFoundError."""
-    from Auto3D.cli.errors import get_error_hint
-    from Auto3D.exceptions import ModelNotFoundError
-
-    hint = get_error_hint(ModelNotFoundError("test"))
-    assert hint is not None
-    assert "AIMNET" in hint
-
-
 def test_error_hint_gpu_error():
     """get_error_hint should return hint for GPUError."""
     from Auto3D.cli.errors import get_error_hint

--- a/tests/test_cli_commands_config.py
+++ b/tests/test_cli_commands_config.py
@@ -1,0 +1,27 @@
+"""Tests for Auto3D.cli.commands.config's module-level preset data.
+
+Presets are static data nobody re-reads once shipped -- exactly how the
+`thorough` preset shipped with both `k=10` and `window=5.0` set (M28), a
+combination `ConformerRanker.run` silently resolved by always preferring `k`,
+making `window` inert with no error, warning, or test failure. This module
+is the guard that would have caught that: every preset must be internally
+self-consistent.
+"""
+from __future__ import annotations
+
+from Auto3D.cli.commands.config import PRESETS
+
+
+def test_no_preset_sets_both_k_and_window():
+    """No shipped preset may set both k and window.
+
+    They are alternative conformer-selection strategies (top-k vs. an
+    energy window); ConformerRanker.run only consults one, so a preset
+    setting both would silently make one of them a dead key -- the exact
+    defect this test exists to prevent from shipping again.
+    """
+    for name, preset in PRESETS.items():
+        assert not ("k" in preset and "window" in preset), (
+            f"preset {name!r} sets both k and window, so one is silently "
+            f"inert: {preset!r}"
+        )

--- a/tests/test_cli_config_schema.py
+++ b/tests/test_cli_config_schema.py
@@ -89,6 +89,35 @@ use_gpu: false
     assert config.use_gpu is False
 
 
+def test_load_yaml_config_validation_failure_is_configuration_error(tmp_path):
+    """A bad value in the YAML file itself (not a CLI override) must raise
+    ConfigurationError from load_yaml_config, not a raw pydantic
+    ValidationError.
+
+    Before this fix, `merge_configs` (the sibling construction site) already
+    translated ValidationError -> ConfigurationError, but `load_yaml_config`
+    did not: `auto3d run in.smi -c cfg.yaml` with `cfg.yaml` setting `k: 0`
+    exited 1 under the generic "Unexpected Error" panel instead of exit 2
+    with the "run auto3d config init" hint, because `execute_run`
+    (cli/commands/run.py) only special-cases `Auto3DError` and an
+    untranslated `ValidationError` fell through to its `except Exception`
+    clause. Both `load_yaml_config` and `merge_configs` now go through the
+    shared `build_cli_config` helper.
+    """
+    from pydantic import ValidationError
+
+    from Auto3D.cli.config_schema import load_yaml_config
+    from Auto3D.exceptions import ConfigurationError
+
+    yaml_file = tmp_path / "bad_config.yaml"
+    yaml_file.write_text("path: input.smi\nk: 0\n")
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        load_yaml_config(yaml_file)
+    # Must be the translated ConfigurationError, not the raw pydantic error.
+    assert not isinstance(exc_info.value, ValidationError)
+
+
 def test_config_accepts_registry_and_path_engines(tmp_path):
     from Auto3D.cli.config_schema import CLIConfig
     for eng in ("AIMNET", "aimnet2-2025", "ANI2x"):

--- a/tests/test_cli_config_schema.py
+++ b/tests/test_cli_config_schema.py
@@ -97,6 +97,38 @@ def test_config_accepts_registry_and_path_engines(tmp_path):
     assert CLIConfig(path="x.smi", optimizing_engine=str(f)).optimizing_engine == str(f)
 
 
+@pytest.mark.parametrize(
+    "raw,canonical",
+    [
+        ("ani2x", "ANI2x"),
+        ("ANI2X", "ANI2x"),
+        ("ani2xt", "ANI2xt"),
+        ("ANI2XT", "ANI2xt"),
+        ("Aimnet2", "Aimnet2"),  # not a named engine: passes through verbatim
+        ("AIMNET", "AIMNET"),
+        ("aimnet", "AIMNET"),
+    ],
+)
+def test_config_accepts_case_insensitive_engine_names(raw, canonical):
+    """Regression: `ani2x`/`ANI2X`/`ani2xt`/`ANI2XT`/`Aimnet2` must all be
+    accepted by CLIConfig -- they were all rejected with "Unknown
+    optimizing_engine" once `_validate_engine` started delegating to
+    `resolve_engine_name`, which (before this fix) compared engine names with
+    exact, case-sensitive equality. `auto3d run in.smi --engine ani2x` and
+    any YAML with `optimizing_engine: ani2x` died on this.
+
+    The CLIConfig field itself preserves the caller's casing verbatim (see
+    test_config_accepts_registry_and_path_engines); `to_auto3d_options()` is
+    what normalizes the three named engines to their canonical mixed-case
+    spelling via `engine_map`, checked here.
+    """
+    from Auto3D.cli.config_schema import CLIConfig
+
+    config = CLIConfig(path="x.smi", optimizing_engine=raw)
+    assert config.optimizing_engine == raw
+    assert config.to_auto3d_options().optimizing_engine == canonical
+
+
 def test_config_rejects_garbage_engine():
     import pytest
     from Auto3D.cli.config_schema import CLIConfig

--- a/tests/test_cli_config_schema.py
+++ b/tests/test_cli_config_schema.py
@@ -308,6 +308,73 @@ def test_shipped_legacy_v2_parameters_yaml_loads():
     config.to_auto3d_options()  # must not raise either
 
 
+def test_shipped_legacy_v2_tauto_yaml_raises_configuration_error():
+    """``docs/legacy-v2/tauto.yaml`` carries keys from a removed feature and
+    must be rejected as an ``Auto3D.exceptions.ConfigurationError``, naming
+    them -- exactly what CHANGELOG.md and docs/source/migration-4.0.rst now
+    tell 4.0 users to catch.
+
+    Both documents previously said this raised a field-named
+    ``pydantic.ValidationError``, which stopped being true when the legacy
+    YAML path moved onto ``build_cli_config``: a reader who wrote
+    ``except pydantic.ValidationError`` around it would catch nothing and let
+    the error escape. This pins the type the migration guide promises, at the
+    exact file the guide names.
+    """
+    from pydantic import ValidationError
+
+    from Auto3D.cli.config_schema import load_yaml_config
+    from Auto3D.exceptions import Auto3DError, ConfigurationError
+
+    repo_root = Path(__file__).resolve().parent.parent
+    yaml_path = repo_root / "docs" / "legacy-v2" / "tauto.yaml"
+    assert yaml_path.exists(), "the migration guide names this file"
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        load_yaml_config(yaml_path)
+
+    # ConfigurationError is an Auto3DError, so `except Auto3DError` in
+    # cli/commands/run.py catches it -- exit 2 with a hint, not exit 1 under
+    # "Unexpected Error".
+    assert isinstance(exc_info.value, Auto3DError)
+    # ...and it is NOT the raw pydantic error the docs used to name.
+    assert not isinstance(exc_info.value, ValidationError)
+    # The field names survive the translation; that is the whole reason the
+    # message is worth showing.
+    assert "tauto_k" in str(exc_info.value)
+
+
+def test_build_cli_config_translates_non_pydantic_validator_errors():
+    """A value a field validator cannot coerce must still surface as
+    ``ConfigurationError``, not as whatever exception the coercion raised.
+
+    ``build_cli_config`` translated only ``ValidationError``. Pydantic turns a
+    ``ValueError``/``AssertionError`` raised inside a validator into a
+    field-named ``ValidationError``, but re-raises anything else untouched --
+    and ``CLIConfig.parse_gpu_idx`` calls ``int(v)``, which raises
+    ``TypeError`` for a mapping. So ``auto3d run in.smi -c cfg.yaml`` with
+    ``gpu_idx: {a: 1}`` leaked a bare ``TypeError`` past
+    ``cli/commands/run.py``'s ``except Auto3DError`` clause into its
+    ``except Exception`` fallback: "Unexpected Error" at exit code 1, for a
+    plain bad value in a config file -- the exact outcome
+    ``build_cli_config`` exists to eliminate.
+    """
+    from Auto3D.cli.config_schema import build_cli_config
+    from Auto3D.exceptions import ConfigurationError
+
+    with pytest.raises(ConfigurationError):
+        build_cli_config(path=Path("in.smi"), k=1, gpu_idx={"a": 1})
+
+    # A list element is coerced the same way, so the same leak was reachable
+    # through `gpu_idx: [0, {a: 1}]` too.
+    with pytest.raises(ConfigurationError):
+        build_cli_config(path=Path("in.smi"), k=1, gpu_idx=[0, {"a": 1}])
+
+    # Still valid input must still be accepted -- the new except clause must
+    # not swallow anything that used to work.
+    assert build_cli_config(path=Path("in.smi"), k=1, gpu_idx="0,1").gpu_idx == [0, 1]
+
+
 def test_cliconfig_covers_all_auto3doptions_fields():
     """Guard against config-layer drift: every user-facing Auto3DOptions field
     must be reachable from the CLI/YAML via CLIConfig. ``input_format`` is set

--- a/tests/test_cli_config_schema.py
+++ b/tests/test_cli_config_schema.py
@@ -163,6 +163,64 @@ def test_merge_cli_overrides():
     assert merged.use_gpu is False
 
 
+def test_merge_configs_cli_k_overrides_file_window():
+    """`--k` on the CLI must substitute the config file's `window`, not
+    accumulate alongside it.
+
+    `auto3d run in.smi -c cfg.yaml --k 1` with `cfg.yaml` setting
+    `window: 5.0` used to hard-fail the mutual-exclusion rule (M28) because
+    the override was added to the base dict instead of substituting for the
+    file's other selector -- reproduced directly here via `merge_configs`.
+    """
+    from Auto3D.cli.config_schema import CLIConfig, merge_configs
+
+    base = CLIConfig(path=Path("test.smi"), window=5.0)
+    merged = merge_configs(base, {"k": 1})
+
+    assert merged.k == 1
+    assert merged.window is None
+
+
+def test_merge_configs_cli_window_overrides_file_k():
+    """Same substitution, the other direction: `--window` must clear the
+    file's `k`."""
+    from Auto3D.cli.config_schema import CLIConfig, merge_configs
+
+    base = CLIConfig(path=Path("test.smi"), k=10)
+    merged = merge_configs(base, {"window": 2.5})
+
+    assert merged.window == 2.5
+    assert merged.k is None
+
+
+def test_merge_configs_explicit_cli_conflict_still_raises():
+    """Two explicit, genuinely conflicting CLI selectors (`--k` AND
+    `--window` both passed) must still be rejected -- the substitution
+    added by this fix only clears the *other* source's selector, not a
+    selector the same override dict explicitly sets."""
+    from Auto3D.cli.config_schema import CLIConfig, merge_configs
+    from Auto3D.exceptions import ConfigurationError
+
+    base = CLIConfig(path=Path("test.smi"))
+    with pytest.raises(ConfigurationError):
+        merge_configs(base, {"k": 1, "window": 2.0})
+
+
+def test_merge_configs_validation_failure_is_configuration_error():
+    """A CLIConfig validation failure surfacing from merge_configs must be a
+    ConfigurationError (exit 2, with a hint), not a raw pydantic
+    ValidationError (which cli/commands/run.py's `except Auto3DError`
+    clause does not catch, so it fell through to the generic "Unexpected
+    Error" exit-1 path instead).
+    """
+    from Auto3D.cli.config_schema import CLIConfig, merge_configs
+    from Auto3D.exceptions import ConfigurationError
+
+    base = CLIConfig(path=Path("test.smi"), k=1)
+    with pytest.raises(ConfigurationError):
+        merge_configs(base, {"threshold": -1})
+
+
 def test_config_exposes_batchsize_and_tf32():
     """batchsize_atoms and allow_tf32 are accepted by CLIConfig and forwarded to
     Auto3DOptions (so the shipped parameters.yaml loads via `auto3d run -c`)."""
@@ -186,6 +244,39 @@ def test_shipped_parameters_yaml_loads():
     assert cfg.k == 1
     assert cfg.window is None
     cfg.to_auto3d_options()  # must not raise
+
+
+def test_shipped_legacy_v2_parameters_yaml_loads():
+    """docs/legacy-v2/parameters.yaml (``k: 1`` / ``window: False``) must
+    validate through the exact construction ``auto3Dcli._run_legacy_yaml``
+    uses -- ``yaml.safe_load`` + the "None"-string-to-None conversion +
+    ``CLIConfig(**parameters)`` (auto3Dcli.py, around the ``CLIConfig(
+    **parameters)`` call) -- not the pipeline itself. Before this fix,
+    ``window: False`` was coerced by Pydantic to ``0.0`` ahead of
+    ``CLIConfig``'s bound-check model validator, which then rejected it as
+    a non-positive window: this exact file, run through this exact CLI
+    entry point, raised ``ValidationError`` and exited 1 on this branch
+    while working unmodified on `main`.
+    """
+    import yaml as yaml_mod
+
+    from Auto3D.cli.config_schema import CLIConfig
+
+    repo_root = Path(__file__).resolve().parent.parent
+    yaml_path = repo_root / "docs" / "legacy-v2" / "parameters.yaml"
+
+    with open(yaml_path) as f:
+        parameters = yaml_mod.safe_load(f)
+    for key, val in list(parameters.items()):
+        if val == "None":
+            parameters[key] = None
+
+    config = CLIConfig(**parameters)  # must not raise
+    assert config.k == 1
+    assert config.window is None  # False normalized to CLIConfig's own sentinel
+    assert config.memory is None
+    assert config.max_confs is None
+    config.to_auto3d_options()  # must not raise either
 
 
 def test_cliconfig_covers_all_auto3doptions_fields():

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -62,6 +62,68 @@ def test_auto3derror_verbose1_shows_traceback(capsys):
     assert "ConfigurationError" in captured.err
 
 
+# --- M26: DependencyError's hint must be reachable, not just its type -------
+#
+# Before this fix, DependencyError defined no `dependency_name` and none of
+# its four raise sites set one, so `get_error_hint`'s
+# `getattr(error, "dependency_name", "unknown")` always fell through to
+# "unknown" and the openeye/torchani/ase entries in its hints map were dead.
+# A test asserting only `pytest.raises(DependencyError)` would not catch that
+# regression -- these pin the actual hint text handle_error prints.
+
+def test_dependency_error_hint_pins_openeye_install(capsys):
+    from Auto3D.exceptions import DependencyError
+
+    with pytest.raises(SystemExit) as exc_info:
+        handle_error(
+            DependencyError("OE_LICENSE not detected", dependency_name="openeye"),
+            verbose=0,
+        )
+    assert exc_info.value.code == 3  # DependencyError -> 3, unchanged mapping
+
+    captured = capsys.readouterr()
+    assert "conda install -c openeye openeye-toolkits" in captured.err
+    assert "unknown" not in captured.err
+
+
+def test_dependency_error_hint_pins_torchani_install(capsys):
+    from Auto3D.exceptions import DependencyError
+
+    with pytest.raises(SystemExit):
+        handle_error(
+            DependencyError("TorchANI is not installed", dependency_name="torchani"),
+            verbose=0,
+        )
+    captured = capsys.readouterr()
+    assert "pip install torchani" in captured.err
+    assert "unknown" not in captured.err
+
+
+def test_dependency_error_hint_pins_ase_install(capsys):
+    from Auto3D.exceptions import DependencyError
+
+    with pytest.raises(SystemExit):
+        handle_error(
+            DependencyError("ASE is not installed", dependency_name="ase"),
+            verbose=0,
+        )
+    captured = capsys.readouterr()
+    assert "pip install ase" in captured.err
+    assert "unknown" not in captured.err
+
+
+def test_dependency_error_without_dependency_name_falls_back_to_unknown(capsys):
+    """A DependencyError raised without naming a dependency (e.g. by future or
+    third-party code) must still produce a hint, not crash the hint lookup --
+    this is the one case where "unknown" is the correct, honest answer."""
+    from Auto3D.exceptions import DependencyError
+
+    with pytest.raises(SystemExit):
+        handle_error(DependencyError("something is missing"), verbose=0)
+    captured = capsys.readouterr()
+    assert "Install the missing dependency: unknown" in captured.err
+
+
 def test_unexpected_error_verbose0_identifies_type_and_points_to_verbose(capsys):
     """Judgment call: even at verbose=0, an unexpected (non-Auto3DError)
     failure must name the exception type and say how to get more, because

--- a/tests/test_cli_property_commands.py
+++ b/tests/test_cli_property_commands.py
@@ -84,6 +84,12 @@ def test_thermo_without_ase_raises_dependency_error(sdf, monkeypatch):
     res = runner.invoke(app, ["thermo", str(sdf), "--no-gpu"])
     assert res.exit_code == 3  # DependencyError -> exit 3
     assert "Traceback" not in res.output
+    # M26: DependencyError used to carry no dependency_name, so this hint was
+    # unreachable and every dependency failure showed "Install the missing
+    # dependency: unknown" -- pin the actual install hint the user sees, not
+    # just the exit code (which would still pass on that regression).
+    assert "pip install ase" in res.output
+    assert "unknown" not in res.output
 
 
 # --- engine-name validation (M21 / C11) --------------------------------------
@@ -146,14 +152,14 @@ def test_exit_code_mapping():
         DependencyError,
         GPUError,
         InputValidationError,
-        ModelNotFoundError,
+        ModelLoadError,
         OptimizationError,
     )
     assert exit_code_for(ConfigurationError("x")) == 2
     assert exit_code_for(InputValidationError("x")) == 2
     assert exit_code_for(DependencyError("x")) == 3
     assert exit_code_for(GPUError("x")) == 4
-    assert exit_code_for(ModelNotFoundError("x")) == 5
+    assert exit_code_for(ModelLoadError("x")) == 5  # ModelError subclass -> 5
     assert exit_code_for(OptimizationError("x")) == 1  # generic
     assert exit_code_for(RuntimeError("x")) == 1
 

--- a/tests/test_cli_property_commands.py
+++ b/tests/test_cli_property_commands.py
@@ -324,6 +324,52 @@ def test_models_test_non_finite_exit_code(monkeypatch):
     assert res.exit_code == 5  # NumericalError (ModelError) -> 5
 
 
+def test_models_test_rejects_when_gpu_requested_without_cuda(monkeypatch):
+    """`models test` reached model_factory.get_device directly and never went
+    through check_gpu_requested, so it silently fell back to CPU on a CPU-only
+    box instead of failing like `energy`/`optimize`/`thermo` -- the last M23
+    gap (see cli/commands/models.py). Simulate the CPU-only box by patching
+    torch.cuda.is_available where check_gpu_requested reads it, and confirm
+    create_model is never reached: the check must happen before any real work
+    (before the model would even be constructed, let alone downloaded)."""
+    with patch("Auto3D.utils.validation.torch.cuda.is_available", return_value=False), \
+         patch("Auto3D.model_factory.create_model") as m:
+        res = runner.invoke(app, ["models", "test", "AIMNET"])  # gpu defaults to True
+    assert res.exit_code == 4  # GPUError -> exit 4
+    assert "--no-gpu" in res.output
+    m.assert_not_called()
+
+
+def test_models_test_no_gpu_still_works_without_cuda(monkeypatch):
+    """--no-gpu must keep working on a CPU-only box (not a blanket failure)."""
+    import torch
+
+    class _StubAdapter:
+        def forward(self, coords, species, charges):
+            return torch.zeros(1), torch.zeros(1, 5, 3)
+
+    monkeypatch.setattr("Auto3D.utils.validation.torch.cuda.is_available", lambda: False)
+    monkeypatch.setattr("Auto3D.model_factory.get_device", lambda *a, **k: torch.device("cpu"))
+    monkeypatch.setattr("Auto3D.model_factory.create_model", lambda *a, **k: _StubAdapter())
+    res = runner.invoke(app, ["models", "test", "AIMNET", "--no-gpu"])
+    assert res.exit_code == 0, res.output
+
+
+def test_models_test_gpu_works_when_cuda_present(monkeypatch):
+    """--gpu (the default) must still succeed when CUDA is actually available."""
+    import torch
+
+    class _StubAdapter:
+        def forward(self, coords, species, charges):
+            return torch.zeros(1), torch.zeros(1, 5, 3)
+
+    monkeypatch.setattr("Auto3D.utils.validation.torch.cuda.is_available", lambda: True)
+    monkeypatch.setattr("Auto3D.model_factory.get_device", lambda *a, **k: torch.device("cpu"))
+    monkeypatch.setattr("Auto3D.model_factory.create_model", lambda *a, **k: _StubAdapter())
+    res = runner.invoke(app, ["models", "test", "AIMNET"])  # gpu defaults to True
+    assert res.exit_code == 0, res.output
+
+
 def test_run_interactive_forwards_progress_callback(smi):
     """Interactive `auto3d run` supplies a live-progress callback to main()."""
     from Auto3D.results import WorkflowResult

--- a/tests/test_cli_property_commands.py
+++ b/tests/test_cli_property_commands.py
@@ -145,6 +145,64 @@ def test_tautomers_rejects_unknown_engine_before_doing_any_work(smi):
     m.assert_not_called()
 
 
+# --- GPU policy: fatal, not a silent CPU fallback (M23) ---------------------
+#
+# calc_spe/opt_geometry/calc_thermo call model_factory.get_device directly and
+# never went through check_input/check_valid_configuration, so a CPU-only box
+# used to fall back to CPU silently -- no error, no warning -- while `auto3d
+# run`/smiles2mols raised (a ConfigurationError with an unrelated "config
+# init" hint, or GPUError, depending on entry point). This dev box has 8 CUDA
+# devices (see task-7 brief), so the no-CUDA case is simulated by patching
+# torch.cuda.is_available where check_gpu_requested (the single source of
+# truth for this check, Auto3D.utils.validation) reads it. The mocked API
+# function must never be called: the check must happen before any real work.
+
+def test_energy_rejects_when_gpu_requested_without_cuda(sdf):
+    with patch("Auto3D.utils.validation.torch.cuda.is_available", return_value=False), \
+         patch("Auto3D.SPE.calc_spe") as m:
+        res = runner.invoke(app, ["energy", str(sdf)])  # gpu defaults to True
+    assert res.exit_code == 4  # GPUError -> exit 4
+    assert "--no-gpu" in res.output
+    m.assert_not_called()
+
+
+def test_optimize_rejects_when_gpu_requested_without_cuda(sdf):
+    with patch("Auto3D.utils.validation.torch.cuda.is_available", return_value=False), \
+         patch("Auto3D.ASE.geometry.opt_geometry") as m:
+        res = runner.invoke(app, ["optimize", str(sdf)])
+    assert res.exit_code == 4
+    assert "--no-gpu" in res.output
+    m.assert_not_called()
+
+
+def test_thermo_rejects_when_gpu_requested_without_cuda(sdf):
+    with patch("Auto3D.utils.validation.torch.cuda.is_available", return_value=False), \
+         patch("Auto3D.ASE.thermo.calc_thermo") as m:
+        res = runner.invoke(app, ["thermo", str(sdf)])
+    assert res.exit_code == 4
+    assert "--no-gpu" in res.output
+    m.assert_not_called()
+
+
+def test_energy_no_gpu_still_works_without_cuda(sdf):
+    """--no-gpu must keep working on a CPU-only box (not a blanket failure)."""
+    with patch("Auto3D.utils.validation.torch.cuda.is_available", return_value=False), \
+         patch("Auto3D.SPE.calc_spe", return_value="out_E.sdf") as m:
+        res = runner.invoke(app, ["energy", str(sdf), "--no-gpu"])
+    assert res.exit_code == 0, res.output
+    m.assert_called_once()
+
+
+def test_run_rejects_when_gpu_requested_without_cuda(smi):
+    """`auto3d run` must fail the same way, before any worker is forked or any
+    model is touched: check_valid_configuration (called from
+    WorkflowOrchestrator._validate_input) raises before preflight_model."""
+    with patch("Auto3D.utils.validation.torch.cuda.is_available", return_value=False):
+        res = runner.invoke(app, ["run", str(smi), "--k", "1"])
+    assert res.exit_code == 4  # GPUError -> exit 4, not 2 (ConfigurationError)
+    assert "--no-gpu" in res.output
+
+
 def test_exit_code_mapping():
     from Auto3D.cli.errors import exit_code_for
     from Auto3D.exceptions import (

--- a/tests/test_cli_property_commands.py
+++ b/tests/test_cli_property_commands.py
@@ -135,13 +135,23 @@ def test_thermo_rejects_unknown_engine_before_doing_any_work(sdf):
 
 def test_tautomers_rejects_unknown_engine_before_doing_any_work(smi):
     """tautomers already routes optimizing_engine through CLIConfig, so this
-    was not part of the M21 gap -- confirming it stays closed."""
+    was not part of the M21 gap -- confirming it stays closed.
+
+    This is also a CLIConfig construction site (execute_tautomers builds one
+    directly from CLI args): before build_cli_config existed, the
+    ValueError->pydantic ValidationError this raises fell through
+    execute_tautomers's blanket `except Exception` as an unmapped exit code 1
+    "Unexpected Error" instead of exit 2 with a hint -- the same divergence
+    fixed for load_yaml_config/merge_configs, just not previously pinned here
+    (this test only asserted `exit_code != 0` before this fix).
+    """
     with patch("Auto3D.tautomer.get_stable_tautomers") as m:
         res = runner.invoke(
             app, ["tautomers", str(smi), "--no-gpu", "--engine", "aimnet2-2025x"]
         )
-    assert res.exit_code != 0
+    assert res.exit_code == 2  # ConfigurationError -> exit 2
     assert "aimnet2-2025x" in res.output
+    assert "Unexpected Error" not in res.output
     m.assert_not_called()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -206,6 +206,72 @@ def test_default_and_valid_k_window_accepted():
     Auto3DOptions(path="x.smi", k=False)  # False is "not specified", allowed
 
 
+def test_false_sentinel_accepted_on_every_bound_field_both_entry_points():
+    """False must mean "not specified" for k/window/memory/max_confs on BOTH
+    Auto3DOptions and CLIConfig, not just one.
+
+    Before this fix, Pydantic coerced `False` -> `0`/`0.0` (bool is an int
+    subclass) *before* CLIConfig's `_check_bounds` model validator ever saw
+    the value, so `check_field_bounds`'s `value is False` skip (config.py)
+    never fired on the CLIConfig path -- CLIConfig rejected all four fields
+    set to `False` (as an out-of-range 0/0.0) while Auto3DOptions (a plain
+    dataclass with no such coercion step) silently accepted them. Reproduced
+    live before this fix:
+    ``CLIConfig(path=Path("x.smi"), k=1, window=False)`` raised
+    ValidationError while
+    ``Auto3DOptions(path="x.smi", k=1, window=False)`` did not raise. The
+    shipped ``docs/legacy-v2/parameters.yaml`` sets exactly this
+    (``k: 1`` / ``window: False``), so this divergence broke a real,
+    in-repo example, not just a hypothetical one.
+    """
+    from pathlib import Path
+
+    from Auto3D.cli.config_schema import CLIConfig
+    from Auto3D.config import Auto3DOptions
+
+    # Auto3DOptions: all four False, together and individually.
+    opts = Auto3DOptions(
+        path="x.smi", k=False, window=False, memory=False, max_confs=False
+    )
+    assert opts.k is False
+    assert opts.window is False
+    assert opts.memory is False
+    assert opts.max_confs is False
+
+    # CLIConfig: same four fields, same False values -- must validate too,
+    # and must normalize False to CLIConfig's own "unset" sentinel (None).
+    cfg = CLIConfig(
+        path=Path("x.smi"), k=False, window=False, memory=False, max_confs=False
+    )
+    assert cfg.k is None
+    assert cfg.window is None
+    assert cfg.memory is None
+    assert cfg.max_confs is None
+
+    # And individually, mixed with a real value for the other selector, the
+    # way the shipped legacy example does (k=1, window=False).
+    Auto3DOptions(path="x.smi", k=1, window=False)
+    CLIConfig(path=Path("x.smi"), k=1, window=False)
+
+
+def test_non_numeric_threshold_raises_configuration_error():
+    """A non-numeric bound value (e.g. threshold="0.3", a str) must raise
+    ConfigurationError, not a bare TypeError.
+
+    `operator.gt`/`operator.ge` (config.py's `_BOUND_OPS`) raise TypeError
+    when compared against a str, which used to propagate unhandled from
+    `check_field_bounds` -- an untyped exception unlike every range check
+    beside it, and one the CLI's `handle_error` shows as an opaque
+    "Unexpected Error" (exit 1) instead of a configuration problem with a
+    hint (exit 2).
+    """
+    from Auto3D.config import Auto3DOptions
+    from Auto3D.exceptions import ConfigurationError
+
+    with pytest.raises(ConfigurationError):
+        Auto3DOptions(path="x.smi", k=1, threshold="0.3")
+
+
 class TestOptimizerWorkerIndices:
     """One optimizer process per GPU on GPU; a single worker otherwise.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -166,14 +166,30 @@ def test_capacity_default_matches_across_layers():
 
 def test_negative_k_rejected():
     from Auto3D.config import Auto3DOptions
-    with pytest.raises(ValueError):
+    from Auto3D.exceptions import ConfigurationError
+    with pytest.raises(ConfigurationError):
         Auto3DOptions(path="x.smi", k=-1)
 
 
 def test_negative_window_rejected():
     from Auto3D.config import Auto3DOptions
-    with pytest.raises(ValueError):
+    from Auto3D.exceptions import ConfigurationError
+    with pytest.raises(ConfigurationError):
         Auto3DOptions(path="x.smi", window=-0.5)
+
+
+def test_zero_k_rejected():
+    """k=0 used to be treated as "not specified" (falsy) and silently
+    accepted, but CLIConfig has always rejected it (its k >= 1 bound applies
+    to any non-None value, and 0 is not None) -- Auto3DOptions must match,
+    per Task 1's "one set of bounds, on every path". Only None/False mean
+    "not specified" now; see test_default_and_valid_k_window_accepted for
+    those sentinels.
+    """
+    from Auto3D.config import Auto3DOptions
+    from Auto3D.exceptions import ConfigurationError
+    with pytest.raises(ConfigurationError):
+        Auto3DOptions(path="x.smi", k=0)
 
 
 def test_default_and_valid_k_window_accepted():
@@ -182,7 +198,7 @@ def test_default_and_valid_k_window_accepted():
     Auto3DOptions(path="x.smi")
     Auto3DOptions(path="x.smi", k=5)
     Auto3DOptions(path="x.smi", window=2.0)
-    Auto3DOptions(path="x.smi", k=0)  # 0 is "not specified", allowed
+    Auto3DOptions(path="x.smi", k=False)  # False is "not specified", allowed
 
 
 class TestOptimizerWorkerIndices:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,7 +60,6 @@ class TestAuto3DOptions:
         config = Auto3DOptions(
             path="/path/to/input.smi",
             k=5,
-            window=2.0,
             verbose=True,
             job_name="test_job",
             use_gpu=False,
@@ -69,11 +68,17 @@ class TestAuto3DOptions:
 
         assert config.path == "/path/to/input.smi"
         assert config.k == 5
-        assert config.window == 2.0
         assert config.verbose is True
         assert config.job_name == "test_job"
         assert config.use_gpu is False
         assert config.optimizing_engine == "ANI2x"
+
+    def test_custom_window_value(self):
+        """window (used alone, not alongside k -- see TestMutuallyExclusiveSelectors
+        in test_config_parity.py) can be set to a custom value."""
+        config = Auto3DOptions(path="/path/to/input.smi", window=2.0)
+
+        assert config.window == 2.0
 
     def test_dict_access(self):
         """Test that config can be accessed like a dict."""

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -216,16 +216,6 @@ class TestDuplicateInchikeyInputs:
     finding it claims to.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="M17: smiles2smi disambiguates a repeated InChIKey as 'KEY_2' "
-        "specifically so the input is not dropped (utils/file_ops.py:117-127), "
-        "but the pipeline's grouping steps (remove_enantiomers and "
-        "ranking.run) key on _Name.split('_')[0], mapping the disambiguated "
-        "id back onto the first input -- the two merge into one ranking "
-        "group and, with k=1, reorder_sdf finds no molecule for the "
-        "disambiguated id and the second input silently vanishes",
-    )
     def test_duplicate_smiles_both_survive(self, isolated_input, monkeypatch):
         """Two identical SMILES (same InChIKey) must each yield a structure
         in the output -- not collapse into a single winner.

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -17,7 +17,11 @@ smiles2mols already ran via check_input. Task 4 (M15) closed
 enumerate_tautomer/a non-rdkit isomer_engine instead of silently ignoring
 them, calls check_valid_configuration the same way main() does, and takes a
 private copy of its config argument up front so it never mutates the
-caller's object.
+caller's object. `TestAuxiliaryEntryPointGPUGuard` closes the sibling gap for
+the GPU policy: calc_spe, opt_geometry and calc_thermo now also call
+`Auto3D.utils.validation.check_gpu_requested` directly, so `use_gpu=True`
+without CUDA is fatal through the Python API too, not only through the CLI
+wrappers in cli/commands/properties.py.
 """
 from __future__ import annotations
 
@@ -118,6 +122,63 @@ class TestAuxiliaryEntryPointGuards:
 
         with pytest.raises(Auto3DError):
             calc_spe(str(sdf), "ANI2x", out_path=str(job_dir / "out.sdf"))
+
+
+class TestAuxiliaryEntryPointGPUGuard:
+    """calc_spe / opt_geometry / calc_thermo must also run
+    `Auto3D.utils.validation.check_gpu_requested` directly, not only through
+    their CLI wrappers (cli/commands/properties.py).
+
+    Each function reaches `model_factory.get_device`, which never raises --
+    it silently returns `torch.device('cpu')` -- so before this guard, a
+    scripted `use_gpu=True` call to any of the three on a CPU-only box would
+    silently compute on CPU with no signal anything was wrong. Same shape as
+    `TestAuxiliaryEntryPointGuards` above (a check present at the CLI, absent
+    for direct Python-API callers), now closed for the GPU policy too.
+
+    This dev box has 8 CUDA devices, so the no-CUDA case is simulated by
+    patching `torch.cuda.is_available` where check_gpu_requested (the single
+    source of truth for this check) reads it -- the same technique
+    tests/test_validation.py::TestGpuPolicyIsUniform and
+    tests/test_cli_property_commands.py's GPU-policy tests already use.
+    check_gpu_requested is called before get_device/create_model/optimizing/
+    _load_hessian_model/model_name2model_calculator in each function, so none
+    of that model machinery needs to be stubbed here: the guard fires before
+    any of it runs, and before the input SDF path is even read.
+    """
+
+    def test_calc_spe_rejects_gpu_request_without_cuda(self, job_dir):
+        from unittest.mock import patch
+
+        from Auto3D.exceptions import GPUError
+        from Auto3D.SPE import calc_spe
+
+        with patch("Auto3D.utils.validation.torch.cuda.is_available", return_value=False):
+            with pytest.raises(GPUError, match="No cuda device") as exc_info:
+                calc_spe(str(job_dir / "nonexistent.sdf"), "AIMNET")
+        assert "--no-gpu" in str(exc_info.value)
+
+    def test_opt_geometry_rejects_gpu_request_without_cuda(self, job_dir):
+        from unittest.mock import patch
+
+        from Auto3D.ASE.geometry import opt_geometry
+        from Auto3D.exceptions import GPUError
+
+        with patch("Auto3D.utils.validation.torch.cuda.is_available", return_value=False):
+            with pytest.raises(GPUError, match="No cuda device") as exc_info:
+                opt_geometry(str(job_dir / "nonexistent.sdf"), "AIMNET")
+        assert "--no-gpu" in str(exc_info.value)
+
+    def test_calc_thermo_rejects_gpu_request_without_cuda(self, job_dir):
+        from unittest.mock import patch
+
+        from Auto3D.ASE.thermo import calc_thermo
+        from Auto3D.exceptions import GPUError
+
+        with patch("Auto3D.utils.validation.torch.cuda.is_available", return_value=False):
+            with pytest.raises(GPUError, match="No cuda device") as exc_info:
+                calc_thermo(str(job_dir / "nonexistent.sdf"), "AIMNET")
+        assert "--no-gpu" in str(exc_info.value)
 
 
 class TestSmiles2MolsHonesty:

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -123,6 +123,101 @@ class TestAuxiliaryEntryPointGuards:
         with pytest.raises(Auto3DError):
             calc_spe(str(sdf), "ANI2x", out_path=str(job_dir / "out.sdf"))
 
+    def test_opt_geometry_rejects_charged_input_for_ani(self, job_dir, monkeypatch):
+        """opt_geometry must run the same check_engine_supports_molecules
+        guard as calc_spe -- only calc_spe's copy was pinned before this.
+
+        `optimizing` (batch_opt.batchopt, imported into Auto3D.ASE.geometry)
+        is stubbed with a fake that just copies the input through, the same
+        defensive reason test_calc_spe_rejects_charged_input_for_ani stubs
+        calc_spe's model machinery: if the guard is missing, execution must
+        not reach a real ANI2x model load, it must instead reach this
+        harmless fake and return normally -- which is the "guard missing"
+        signal this test watches for.
+        """
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        import Auto3D.ASE.geometry as geometry_mod
+        from Auto3D.ASE.geometry import opt_geometry
+
+        mol = Chem.AddHs(Chem.MolFromSmiles("CC(=O)[O-]"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        mol.SetProp("_Name", "acetate")
+        mol.SetProp("E_tot", "0.0")
+
+        sdf = job_dir / "charged.sdf"
+        with Chem.SDWriter(str(sdf)) as w:
+            w.write(mol)
+
+        class _FakeOptEngine:
+            def __init__(self, in_f, out_f, model_name, device, config, *a, **k):
+                self.in_f = in_f
+                self.out_f = out_f
+
+            def run(self):
+                mols = [
+                    m for m in Chem.SDMolSupplier(self.in_f, removeHs=False)
+                    if m is not None
+                ]
+                with Chem.SDWriter(self.out_f) as w:
+                    for m in mols:
+                        m.SetProp("E_tot", "0.0")
+                        w.write(m)
+
+        monkeypatch.setattr(geometry_mod, "optimizing", _FakeOptEngine)
+
+        with pytest.raises(Auto3DError):
+            opt_geometry(
+                str(sdf), "ANI2x", use_gpu=False, out_path=str(job_dir / "out.sdf")
+            )
+
+    def test_calc_thermo_rejects_charged_input_for_ani(self, job_dir, monkeypatch):
+        """calc_thermo must run the same check_engine_supports_molecules
+        guard as calc_spe -- only calc_spe's copy was pinned before this.
+
+        `_load_hessian_model` and `model_name2model_calculator` are stubbed
+        with fakes that never load real weights: if the guard is missing,
+        execution reaches these fakes instead of a real ANI2x model, and the
+        fake model's deliberate failure is swallowed by calc_thermo's own
+        per-molecule `except Exception` (thermo.py), so calc_thermo returns
+        normally with the molecule recorded as failed rather than raising --
+        exactly the "guard missing" signal this test watches for.
+        """
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        import Auto3D.ASE.thermo as thermo_mod
+        from Auto3D.ASE.thermo import calc_thermo
+
+        mol = Chem.AddHs(Chem.MolFromSmiles("CC(=O)[O-]"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        mol.SetProp("_Name", "acetate")
+
+        sdf = job_dir / "charged.sdf"
+        with Chem.SDWriter(str(sdf)) as w:
+            w.write(mol)
+
+        class _FakeCalculator:
+            def set_charge(self, charge):
+                pass
+
+        class _FakeModel:
+            def __call__(self, *a, **k):
+                raise RuntimeError("stub model: guard should have fired first")
+
+        monkeypatch.setattr(thermo_mod, "_load_hessian_model", lambda *a, **k: None)
+        monkeypatch.setattr(
+            thermo_mod,
+            "model_name2model_calculator",
+            lambda *a, **k: (_FakeModel(), _FakeCalculator()),
+        )
+
+        with pytest.raises(Auto3DError):
+            calc_thermo(
+                str(sdf), "ANI2x", use_gpu=False, out_path=str(job_dir / "out.sdf")
+            )
+
 
 class TestAuxiliaryEntryPointGPUGuard:
     """calc_spe / opt_geometry / calc_thermo must also run
@@ -324,6 +419,21 @@ class TestDuplicateInchikeyInputs:
         assert len(mols) == 2, (
             f"expected one output structure per input (2), got {len(mols)}: "
             f"{[m.GetProp('_Name') for m in mols]}"
+        )
+        # M17: the second "CCO" is disambiguated to "<inchikey>_2" by
+        # smiles2smi's InChIKey-collision handling (utils/file_ops.py), and
+        # ranking.species_id must recover that suffix intact (rsplit on the
+        # last two "_"-delimited components) rather than strip everything
+        # after the FIRST underscore -- which would collapse both outputs
+        # back onto the bare InChIKey. `len(mols) == 2` alone does not catch
+        # that regression: both mols still "survive", just under the same
+        # name. Reverting ranking.species_id to the old `split("_")[0]`
+        # makes this fail (both mols come back named identically) while
+        # leaving len(mols) == 2 true.
+        names = [m.GetProp("_Name") for m in mols]
+        assert len(set(names)) == 2, (
+            f"expected 2 distinct output names (InChIKey disambiguation "
+            f"must survive ranking), got {names}"
         )
 
 

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -1,49 +1,38 @@
 """The same configuration must be validated identically through every door.
 
-auto3d run -c goes through CLIConfig and gets extra="forbid", Literal engine
-validation, and every Field bound. Auto3DOptions validates only k and window,
-and the legacy `auto3d config.yaml` path constructs Auto3DOptions directly --
-so the Python API that scientific users script against is the least protected
-(C10, M27), and three auxiliary entry points skip the element/charge guard
-entirely (C11).
+Task 1 (C10, M27) closed the gap: Auto3D.config.FIELD_BOUNDS is the single
+table of numeric bounds, enforced by Auto3DOptions.__post_init__ directly and
+by CLIConfig's `_check_bounds` model validator (both call
+`Auto3D.config.check_field_bounds`). `auto3d run -c` and the legacy
+`auto3d config.yaml` invocation (auto3Dcli._run_legacy_yaml) both build a
+CLIConfig and convert it with `.to_auto3d_options()`, so both also get
+extra="forbid", the engine registry check, and Literal validation -- the
+legacy path no longer constructs Auto3DOptions directly. Three auxiliary
+entry points still skip the element/charge guard entirely (C11, Task 6+).
 """
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
+from Auto3D.cli.config_schema import CLIConfig
 from Auto3D.config import Auto3DOptions
-from Auto3D.exceptions import Auto3DError
+from Auto3D.exceptions import Auto3DError, ConfigurationError
 
 
 class TestAuto3DOptionsBounds:
     """Auto3DOptions must enforce what CLIConfig enforces."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C10: threshold=-1 is accepted, which sets pruneRmsThresh=-1 and "
-        "makes `rmsd < -1` never true, silently disabling duplicate-conformer "
-        "removal while presenting the output as deduplicated",
-    )
     def test_negative_threshold_is_rejected(self, isolated_input):
         """A non-positive RMSD threshold must raise, not silently disable dedup."""
         with pytest.raises(Auto3DError):
             Auto3DOptions(path=isolated_input("smiles2.smi"), k=1, threshold=-1)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="M27: max_confs has no Field(ge=1) in any path, so max_confs=0 "
-        "reaches EmbedMultipleConfs(numConfs=0) and every molecule yields nothing",
-    )
     def test_zero_max_confs_is_rejected(self, isolated_input):
         """max_confs must be at least 1."""
         with pytest.raises(Auto3DError):
             Auto3DOptions(path=isolated_input("smiles2.smi"), k=1, max_confs=0)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C10: convergence_threshold=0 makes `fmax > opttol` permanently "
-        "true, so every structure burns the full 2000-step budget",
-    )
     def test_zero_convergence_threshold_is_rejected(self, isolated_input):
         """A zero force threshold is unsatisfiable and must be refused."""
         with pytest.raises(Auto3DError):
@@ -300,3 +289,131 @@ class TestDuplicateInchikeyInputs:
             f"expected one output structure per input (2), got {len(mols)}: "
             f"{[m.GetProp('_Name') for m in mols]}"
         )
+
+
+class TestValidationParityAcrossEntryPoints:
+    """Phase 5's exit criterion, asserted directly: the same configuration
+    must be judged identically by `auto3d run -c`, the legacy
+    `auto3d config.yaml` invocation, and the Python API's
+    `Auto3DOptions(**yaml)`.
+    """
+
+    @staticmethod
+    def _params(isolated_input) -> dict:
+        # optimizing_engine is 'ANI2xt' (a built-in name), not the default
+        # 'AIMNET', so resolving it never imports the optional `aimnet`
+        # package -- see the matching note on tests/test_cli.py's
+        # _LEGACY_YAML for why that import is avoided in tests.
+        return {
+            "path": isolated_input("smiles2.smi"),
+            "k": 1,
+            "window": None,
+            "memory": None,
+            "capacity": 42,
+            "enumerate_tautomer": False,
+            "tauto_engine": "rdkit",
+            "pKaNorm": True,
+            "isomer_engine": "rdkit",
+            "max_confs": None,
+            "enumerate_isomer": True,
+            "mode_oe": "classic",
+            "mpi_np": 4,
+            "optimizing_engine": "ANI2xt",
+            "use_gpu": False,
+            "gpu_idx": 0,
+            "opt_steps": 2000,
+            "convergence_threshold": 0.01,
+            "patience": 250,
+            "threshold": 0.3,
+            "batchsize_atoms": 1024,
+            "allow_tf32": False,
+            "verbose": False,
+            "job_name": "",
+        }
+
+    @staticmethod
+    def _run_legacy_and_capture(tmp_path, params, monkeypatch):
+        """Drive auto3Dcli._run_legacy_yaml against a real YAML file built
+        from `params` (using the same "None"-string encoding the shipped
+        parameters.yaml example uses), with Auto3D.auto3D.main stubbed out
+        so no pipeline actually runs.
+
+        Returns (options, error): `options` is the Auto3DOptions that would
+        have been passed to main() on success; `error` is the exception
+        _run_legacy_yaml caught and handed to handle_error on failure.
+        Exactly one of the two is None.
+        """
+        import yaml as yaml_mod
+
+        from Auto3D.auto3Dcli import _run_legacy_yaml
+
+        text_params = dict(params)
+        for key in ("window", "memory", "max_confs"):
+            if text_params[key] is None:
+                text_params[key] = "None"
+        yaml_path = tmp_path / "legacy_params.yaml"
+        yaml_path.write_text(yaml_mod.dump(text_params))
+
+        captured: dict = {}
+
+        def fake_main(options, **kwargs):
+            captured["options"] = options
+            return "fake_output.sdf"
+
+        monkeypatch.setattr("Auto3D.auto3D.main", fake_main)
+
+        errors: list[Exception] = []
+        monkeypatch.setattr(
+            "Auto3D.cli.errors.handle_error",
+            lambda error, verbose=0: errors.append(error),
+        )
+
+        _run_legacy_yaml(str(yaml_path))
+        if errors:
+            return None, errors[0]
+        return captured["options"], None
+
+    def test_valid_config_agrees_across_entry_points(
+        self, tmp_path, isolated_input, monkeypatch
+    ):
+        """A config every path accepts must produce the same Auto3DOptions."""
+        params = self._params(isolated_input)
+
+        via_cliconfig = CLIConfig(**params).to_auto3d_options()
+        via_api = Auto3DOptions(**params)
+        via_legacy, error = self._run_legacy_and_capture(tmp_path, params, monkeypatch)
+
+        assert error is None, f"legacy YAML path rejected a valid config: {error}"
+        # k/window are "not specified" via either None (CLIConfig's sentinel)
+        # or False (Auto3DOptions's own sentinel) -- both falsy, both meaning
+        # the same thing to ranking.py's `if self.k: ... elif self.window:`
+        # -- so compare truthiness for those two, exact value for the rest.
+        for field in ("k", "window"):
+            assert bool(getattr(via_cliconfig, field)) == bool(getattr(via_api, field)), field
+            assert bool(getattr(via_legacy, field)) == bool(getattr(via_api, field)), field
+        for field in (
+            "threshold", "convergence_threshold", "max_confs",
+            "optimizing_engine", "opt_steps", "mpi_np", "patience",
+            "batchsize_atoms", "memory", "capacity",
+        ):
+            assert getattr(via_cliconfig, field) == getattr(via_api, field), field
+            assert getattr(via_legacy, field) == getattr(via_api, field), field
+
+    def test_negative_threshold_rejected_by_all_three_entry_points(
+        self, tmp_path, isolated_input, monkeypatch
+    ):
+        """threshold=-1 (C10) must be rejected by every entry point -- not
+        silently accepted through one door while another guards it.
+        """
+        params = self._params(isolated_input)
+        params["threshold"] = -1
+
+        with pytest.raises(ConfigurationError):
+            Auto3DOptions(**params)
+
+        with pytest.raises(ValidationError):
+            CLIConfig(**params)
+
+        options, error = self._run_legacy_and_capture(tmp_path, params, monkeypatch)
+        assert options is None, "legacy YAML path accepted threshold=-1"
+        assert isinstance(error, ValidationError)

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -12,7 +12,12 @@ the last gap: calc_spe, opt_geometry and calc_thermo now call
 `Auto3D.utils.validation.check_engine_supports_molecules` (the guard
 extracted from check_smi_format/check_sdf_format's formerly-duplicated
 element set) and `resolve_engine_name`, the same two checks main() and
-smiles2mols already ran via check_input.
+smiles2mols already ran via check_input. Task 4 (M15) closed
+`TestSmiles2MolsHonesty`'s gap: smiles2mols now raises ConfigurationError for
+enumerate_tautomer/a non-rdkit isomer_engine instead of silently ignoring
+them, calls check_valid_configuration the same way main() does, and takes a
+private copy of its config argument up front so it never mutates the
+caller's object.
 """
 from __future__ import annotations
 
@@ -156,12 +161,6 @@ class TestSmiles2MolsHonesty:
         monkeypatch.setattr(auto3D_mod, "ranking", _StubRank)
         monkeypatch.setattr(auto3D_mod, "reorder_sdf", lambda *a, **k: [])
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="M15: enumerate_tautomer, isomer_engine and mode_oe have no effect "
-        "-- there is no TautomerProcessor in the function and the RDKit engine is "
-        "hardcoded at auto3D.py:131",
-    )
     def test_unsupported_option_raises(self, isolated_input, monkeypatch):
         """Requesting tautomer enumeration must raise rather than be ignored.
 
@@ -181,12 +180,6 @@ class TestSmiles2MolsHonesty:
         with pytest.raises((Auto3DError, NotImplementedError)):
             smiles2mols(["CCO"], args)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="M15: auto3D.py:117 sets args['path'] = path0 and :125 sets "
-        "args.input_format on the caller's object, leaving path pointing into a "
-        "deleted TemporaryDirectory",
-    )
     def test_caller_config_is_not_mutated(self, isolated_input, monkeypatch):
         """smiles2mols must not modify the config object it was given.
 

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -44,12 +44,6 @@ class TestAuto3DOptionsBounds:
 class TestMutuallyExclusiveSelectors:
     """k and window are documented as mutually exclusive; passing both must raise."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="M28: ConformerRanker.run tests `if self.k:` before "
-        "`elif self.window:`, so window is silently ignored -- which is why the "
-        "shipped 'thorough' preset's window: 5.0 has no effect",
-    )
     def test_k_and_window_together_raise(self, isolated_input):
         """select_tautomers raises for this; the conformer ranker must too."""
         with pytest.raises(Auto3DError):

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -175,8 +175,20 @@ class TestAuxiliaryEntryPointGuards:
 
         monkeypatch.setattr(spe_mod, "pad_from_mols", fake_pad)
 
-        with pytest.raises(Auto3DError):
-            calc_spe(str(sdf), "ANI2x", out_path=str(job_dir / "out.sdf"))
+        # `use_gpu=False` and `ConfigurationError` (not the base `Auto3DError`)
+        # are both load-bearing. check_gpu_requested runs at SPE.py:61, well
+        # before the C11 guard at SPE.py:115, and raises GPUError -- also an
+        # Auto3DError. So with the default `use_gpu=True` on a CPU-only box
+        # (every CI runner; this dev box has 8 CUDA devices and hides it) this
+        # call raised GPUError at validation.py:80, `pytest.raises(Auto3DError)`
+        # swallowed it, and the test passed green having never reached the
+        # charged-input guard it exists to pin. GPUError and ConfigurationError
+        # are siblings, so narrowing the expected type makes the wrong reason
+        # structurally unable to satisfy this test.
+        with pytest.raises(ConfigurationError):
+            calc_spe(
+                str(sdf), "ANI2x", use_gpu=False, out_path=str(job_dir / "out.sdf")
+            )
 
     def test_opt_geometry_rejects_charged_input_for_ani(self, job_dir, monkeypatch):
         """opt_geometry must run the same check_engine_supports_molecules
@@ -222,7 +234,11 @@ class TestAuxiliaryEntryPointGuards:
 
         monkeypatch.setattr(geometry_mod, "optimizing", _FakeOptEngine)
 
-        with pytest.raises(Auto3DError):
+        # ConfigurationError, not the base Auto3DError: see the note in
+        # test_calc_spe_rejects_charged_input_for_ani. This test already passes
+        # use_gpu=False, but the narrow type is what keeps a GPUError (or any
+        # other unrelated Auto3DError) from satisfying it if that ever changes.
+        with pytest.raises(ConfigurationError):
             opt_geometry(
                 str(sdf), "ANI2x", use_gpu=False, out_path=str(job_dir / "out.sdf")
             )
@@ -268,7 +284,11 @@ class TestAuxiliaryEntryPointGuards:
             lambda *a, **k: (_FakeModel(), _FakeCalculator()),
         )
 
-        with pytest.raises(Auto3DError):
+        # ConfigurationError, not the base Auto3DError: see the note in
+        # test_calc_spe_rejects_charged_input_for_ani. This test already passes
+        # use_gpu=False, but the narrow type is what keeps a GPUError (or any
+        # other unrelated Auto3DError) from satisfying it if that ever changes.
+        with pytest.raises(ConfigurationError):
             calc_thermo(
                 str(sdf), "ANI2x", use_gpu=False, out_path=str(job_dir / "out.sdf")
             )

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -25,11 +25,13 @@ wrappers in cli/commands/properties.py.
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
 from Auto3D.cli.config_schema import CLIConfig
-from Auto3D.config import Auto3DOptions
+from Auto3D.config import FIELD_BOUNDS, SENTINEL_FIELDS, Auto3DOptions
 from Auto3D.exceptions import Auto3DError, ConfigurationError
 
 
@@ -61,6 +63,59 @@ class TestMutuallyExclusiveSelectors:
         """select_tautomers raises for this; the conformer ranker must too."""
         with pytest.raises(Auto3DError):
             Auto3DOptions(path=isolated_input("smiles2.smi"), k=10, window=5.0)
+
+
+class TestSentinelScopeParityAllElevenFields:
+    """``check_field_bounds``'s None/False "not specified" skip must be scoped
+    to exactly ``SENTINEL_FIELDS`` (k, window, memory, max_confs) -- the four
+    optional fields -- on BOTH Auto3DOptions and CLIConfig, for every one of
+    the eleven ``FIELD_BOUNDS`` entries, not just those four.
+
+    Before this fix, the skip in ``check_field_bounds`` applied to all eleven
+    ``FIELD_BOUNDS`` keys unconditionally. That accidentally let
+    ``Auto3DOptions(path="x.smi", threshold=None)`` (and the same for
+    mpi_np/opt_steps/convergence_threshold/patience/batchsize_atoms/capacity)
+    through silently, while ``CLIConfig(path=Path("x.smi"), threshold=None)``
+    always raised -- those seven fields are typed as plain ``int``/``float``
+    (not ``| None``) on CLIConfig, so pydantic's own type validation rejects
+    ``None`` there regardless of what ``check_field_bounds`` does, and
+    ``False`` reaches ``check_field_bounds`` already coerced to ``0``/``0.0``
+    by pydantic (bool is an int subclass) and fails the bound. Reproduced live
+    before this fix: ``Auto3DOptions(path="x.smi", threshold=None)`` did not
+    raise while ``CLIConfig(path=Path("x.smi"), threshold=None)`` did.
+
+    This iterates ``Auto3D.config.FIELD_BOUNDS``/``SENTINEL_FIELDS`` directly
+    (rather than hand-listing the eleven field names a second time here) so a
+    field added to one set without the other trips this test immediately,
+    instead of silently reintroducing the entry-point divergence this test
+    exists to close.
+    """
+
+    @staticmethod
+    def _kwargs(field: str, value) -> dict:
+        # A minimal, valid override set with only `field` set to `value` --
+        # every other field stays at its (valid) default, so a rejection can
+        # only be attributed to `field`.
+        return {field: value}
+
+    @pytest.mark.parametrize("value", [None, False], ids=["None", "False"])
+    @pytest.mark.parametrize("field", sorted(FIELD_BOUNDS))
+    def test_sentinel_scope_agrees_across_entry_points(self, field, value, isolated_input):
+        path = isolated_input("smiles2.smi")
+        auto3d_kwargs = {"path": path, **self._kwargs(field, value)}
+        cli_kwargs = {"path": Path(path), **self._kwargs(field, value)}
+
+        if field in SENTINEL_FIELDS:
+            # Optional field: None/False means "not specified" on both paths.
+            Auto3DOptions(**auto3d_kwargs)  # must not raise
+            CLIConfig(**cli_kwargs)  # must not raise
+        else:
+            # Non-optional field: None/False has no "unset" meaning and must
+            # be rejected on both paths -- not just one.
+            with pytest.raises(ConfigurationError):
+                Auto3DOptions(**auto3d_kwargs)
+            with pytest.raises(ValidationError):
+                CLIConfig(**cli_kwargs)
 
 
 class TestAuxiliaryEntryPointGuards:
@@ -562,4 +617,9 @@ class TestValidationParityAcrossEntryPoints:
 
         options, error = self._run_legacy_and_capture(tmp_path, params, monkeypatch)
         assert options is None, "legacy YAML path accepted threshold=-1"
-        assert isinstance(error, ValidationError)
+        # ConfigurationError, not a raw pydantic ValidationError: the legacy
+        # path now builds its CLIConfig via build_cli_config (Task 3), which
+        # translates ValidationError into ConfigurationError so `handle_error`
+        # shows exit code 2 with a hint instead of the generic "Unexpected
+        # Error" panel at exit 1 -- the same fix `auto3d run -c` already got.
+        assert isinstance(error, ConfigurationError)

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -7,8 +7,12 @@ by CLIConfig's `_check_bounds` model validator (both call
 `auto3d config.yaml` invocation (auto3Dcli._run_legacy_yaml) both build a
 CLIConfig and convert it with `.to_auto3d_options()`, so both also get
 extra="forbid", the engine registry check, and Literal validation -- the
-legacy path no longer constructs Auto3DOptions directly. Three auxiliary
-entry points still skip the element/charge guard entirely (C11, Task 6+).
+legacy path no longer constructs Auto3DOptions directly. Task 3 (C11) closed
+the last gap: calc_spe, opt_geometry and calc_thermo now call
+`Auto3D.utils.validation.check_engine_supports_molecules` (the guard
+extracted from check_smi_format/check_sdf_format's formerly-duplicated
+element set) and `resolve_engine_name`, the same two checks main() and
+smiles2mols already ran via check_input.
 """
 from __future__ import annotations
 
@@ -53,12 +57,6 @@ class TestMutuallyExclusiveSelectors:
 class TestAuxiliaryEntryPointGuards:
     """calc_spe / opt_geometry / calc_thermo must run the same guard as main()."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="C11: check_input's charge/element guard runs only in main() and "
-        "smiles2mols, so a charged species handed to ANI2x is evaluated as the "
-        "neutral molecule -- tens of kcal/mol wrong, with wrong forces",
-    )
     def test_calc_spe_rejects_charged_input_for_ani(self, job_dir, monkeypatch):
         """A carboxylate must be refused by ANI2x, not silently neutralized.
 

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -274,5 +274,16 @@ class TestSameFileGuard:
 
         monkeypatch.setattr(spe_mod, "pad_from_mols", fake_pad)
 
+        # use_gpu=False: this test is about the missing same-file guard (C14),
+        # not GPU availability. The default use_gpu=True made check_gpu_requested
+        # (which now runs before any of the same-file logic below it) raise
+        # GPUError -- itself an Auto3DError -- on a CPU-only runner, which
+        # satisfied this test's `pytest.raises((Auto3DError, ValueError))` for
+        # the wrong reason and turned the intended XFAIL into an XPASS (a hard
+        # failure under strict=True). use_gpu=False does not weaken what this
+        # test proves: it lets calc_spe run past the GPU check (as it always
+        # does on a GPU-equipped box) so the test again exercises -- and still
+        # finds absent -- the same-file guard itself, consistently regardless
+        # of whether CUDA is present.
         with pytest.raises((Auto3DError, ValueError)):
-            spe_mod.calc_spe(str(sdf), "AIMNET", out_path=str(sdf))
+            spe_mod.calc_spe(str(sdf), "AIMNET", out_path=str(sdf), use_gpu=False)

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -202,8 +202,13 @@ class TestOptGeometryDurability:
         monkeypatch.setattr(geometry.Chem, "SDWriter", FlakyWriter)
 
         with pytest.raises(Exception):
+            # Model name must resolve (C11 added an engine-name guard inside
+            # opt_geometry itself): "fake-model" was never load-bearing here
+            # -- FakeOptimizing.__init__ doesn't even store it -- the point of
+            # this test is durability of the input file against a failed
+            # rewrite, not the model name, so a valid engine name is used.
             geometry.opt_geometry(
-                str(sdf), "fake-model", out_path=str(outpath), use_gpu=False
+                str(sdf), "AIMNET", out_path=str(outpath), use_gpu=False
             )
 
         assert "bytes" in completed, "the fake optimizer never ran"

--- a/tests/test_isomer_engine_hardening.py
+++ b/tests/test_isomer_engine_hardening.py
@@ -301,7 +301,11 @@ class TestSpeFiltersAndAligns:
         inpath = tmp_path / "in.sdf"
         inpath.write_text("")  # contents irrelevant; supplier is faked
 
-        out = spe_mod.calc_spe(str(inpath), "AIMNET")
+        # use_gpu=False: this test is about the None-filtering/index-alignment
+        # logic, not GPU availability -- the default use_gpu=True would make
+        # check_gpu_requested (called before get_device, which is stubbed
+        # here anyway) fail fast with GPUError on a CPU-only runner.
+        out = spe_mod.calc_spe(str(inpath), "AIMNET", use_gpu=False)
 
         assert captured["n"] == 2  # only the two valid mols reached the model
 
@@ -346,7 +350,9 @@ class TestSpeFiltersAndAligns:
         inpath.write_text("")  # contents irrelevant; supplier is faked
 
         # Must not raise (no cryptic max() error); returns the output path.
-        out = spe_mod.calc_spe(str(inpath), "AIMNET")
+        # use_gpu=False for the same reason as the sibling test above: this is
+        # about the all-filtered empty-input path, not GPU availability.
+        out = spe_mod.calc_spe(str(inpath), "AIMNET", use_gpu=False)
         assert out is not None
         # An output file is produced (empty SDF -> no molecule records).
         assert os.path.exists(out)

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -64,6 +64,43 @@ def test_get_logger_warning_reaches_worker_style_handler():
             logging.getLogger(logger_name).removeHandler(handler)
 
 
+def test_attach_run_log_handlers_is_idempotent_per_queue():
+    """A second call with the same queue must not double-attach.
+
+    Production always calls `_attach_run_log_handlers` once per fresh worker
+    process with a fresh queue, so this never mattered there. But tests that
+    call worker functions (`isomer_wrapper`/`optim_rank_wrapper`) directly,
+    in-process, can call it more than once with the same queue -- and before
+    this fix, each call unconditionally added another `QueueHandler`, so a
+    single logged message was enqueued once per call. Reproduced directly
+    against the real function (not a hand copy of its logic).
+    """
+    from Auto3D.workflow_workers import _attach_run_log_handlers
+
+    q: queue.Queue = queue.Queue()
+    first = _attach_run_log_handlers(q)
+    second = _attach_run_log_handlers(q)
+    try:
+        assert first, "first call should attach at least one handler"
+        assert second == [], (
+            "a second call with the same queue must attach nothing new"
+        )
+
+        mod_logger = get_logger("Auto3D.test_logging_config_idempotent")
+        mod_logger.setLevel(logging.INFO)
+        mod_logger.warning("only once, even after a repeat attach call")
+
+        queued = []
+        while not q.empty():
+            queued.append(q.get_nowait())
+        assert len(queued) == 1, f"expected exactly one queued record, got {len(queued)}"
+    finally:
+        for logger_name, handler in first:
+            logging.getLogger(logger_name).removeHandler(handler)
+        for logger_name, handler in second:
+            logging.getLogger(logger_name).removeHandler(handler)
+
+
 def test_run_log_handlers_do_not_duplicate_records():
     """A single warning must be delivered exactly once through the run-log
     queue, and exactly once via root propagation.

--- a/tests/test_model_preflight.py
+++ b/tests/test_model_preflight.py
@@ -277,6 +277,146 @@ class TestEngineNameResolution:
         model.write_bytes(b"")
         assert resolve_engine_name(str(model)) == str(model)
 
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("ani2x", "ANI2x"),
+            ("ANI2X", "ANI2x"),
+            ("AnI2x", "ANI2x"),
+            ("ani2xt", "ANI2xt"),
+            ("ANI2XT", "ANI2xt"),
+            ("aimnet", "aimnet2-wb97m-d3_0"),
+            ("AIMNET", "aimnet2-wb97m-d3_0"),
+            ("Aimnet2", "aimnet2-wb97m-d3_0"),
+        ],
+    )
+    def test_named_engines_are_case_insensitive(self, name, expected):
+        """C-regression: ani2x/ANI2X/ani2xt/ANI2XT/Aimnet2 must all resolve.
+
+        Measured before this fix: 'ANI2x', 'AIMNET', and 'aimnet2' resolved,
+        but 'ani2x', 'ANI2X', 'ani2xt', 'ANI2XT', and 'Aimnet2' were all
+        rejected with "Unknown optimizing_engine" -- a regression from
+        before resolve_engine_name existed, when a prefix/case-insensitive
+        match accepted all of these. `auto3d run in.smi --engine ani2x` and
+        any YAML with `optimizing_engine: ani2x` died on this.
+        """
+        from Auto3D.models.preflight import resolve_engine_name
+
+        assert resolve_engine_name(name) == expected
+
+    def test_mixed_case_registry_alias_resolves(self):
+        """A mixed-case registry alias (not just the three named engines)
+        must also resolve, since resolve_registry_model_name itself does a
+        plain, unfolded dict lookup against lowercase-only registry keys."""
+        from Auto3D.models.preflight import resolve_engine_name
+
+        assert resolve_engine_name("AIMNET2-2025") == "aimnet2-b973c-2025-d3_0"
+        assert resolve_engine_name("Aimnet2-Nse") == "aimnet2-nse_0"
+
+
+class TestNamedEngineNotHijackedByCwdFile:
+    """A cwd file sharing a reserved engine's name must not hijack it.
+
+    ``ModelFactory.create`` (model_factory.py:109-116) deliberately checks
+    built-in engine names before ``Path(name).exists()``, precisely so a file
+    in the working directory cannot hijack a reserved name. ``resolve_engine_name``
+    used to check ``Path(name).exists()`` before consulting AIMNET's name at
+    all, so a file named literally ``AIMNET`` in the current working directory
+    made pre-flight skip the registry/model check entirely, treating "AIMNET"
+    as a custom NNP path instead of the aimnet registry default. Reproduced
+    here with no aimnet internals mocked -- creating the file and changing cwd
+    is enough, since this is all offline path/dict logic.
+    """
+
+    def test_file_named_aimnet_in_cwd_still_resolves_to_the_registry(
+        self, tmp_path, monkeypatch
+    ):
+        from Auto3D.models.preflight import resolve_engine_name
+
+        (tmp_path / "AIMNET").write_bytes(b"not a model")
+        monkeypatch.chdir(tmp_path)
+
+        assert resolve_engine_name("AIMNET") == "aimnet2-wb97m-d3_0"
+
+    def test_file_named_ani2x_in_cwd_still_resolves_to_the_builtin(
+        self, tmp_path, monkeypatch
+    ):
+        from Auto3D.models.preflight import resolve_engine_name
+
+        (tmp_path / "ANI2x").write_bytes(b"not a model")
+        monkeypatch.chdir(tmp_path)
+
+        assert resolve_engine_name("ANI2x") == "ANI2x"
+
+    def test_file_named_ani2xt_in_cwd_still_resolves_to_the_builtin(
+        self, tmp_path, monkeypatch
+    ):
+        from Auto3D.models.preflight import resolve_engine_name
+
+        (tmp_path / "ANI2xt").write_bytes(b"not a model")
+        monkeypatch.chdir(tmp_path)
+
+        assert resolve_engine_name("ANI2xt") == "ANI2xt"
+
+    def test_unrelated_cwd_file_is_still_usable_as_a_custom_path(
+        self, tmp_path, monkeypatch
+    ):
+        """The fix must not disable custom-NNP-by-path for names that are not
+        reserved engine identifiers."""
+        from Auto3D.models.preflight import resolve_engine_name
+
+        custom = tmp_path / "my_custom_model.pt"
+        custom.write_bytes(b"not a model")
+        monkeypatch.chdir(tmp_path)
+
+        assert resolve_engine_name("my_custom_model.pt") == "my_custom_model.pt"
+
+
+class TestRequestsImportedLazily:
+    """`requests` must not be imported at module scope in preflight.py.
+
+    utils/validation.py imports preflight, and utils/__init__.py imports
+    that, so a module-scope `import requests` here made `import Auto3D.utils`
+    hard-fail without `requests` installed -- even though every other heavy
+    import in this module (aimnet.calculators.model_registry) is already
+    deferred into a function body. `requests` arrives only transitively via
+    aimnet's own dependency, so this module must not assume it is present
+    before entering a function.
+    """
+
+    def test_no_module_scope_requests_import(self):
+        import ast
+        import inspect
+
+        import Auto3D.models.preflight as preflight_mod
+
+        source = inspect.getsource(preflight_mod)
+        tree = ast.parse(source)
+
+        for node in tree.body:  # only top-level (module-scope) statements
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+                assert "requests" not in names, (
+                    "requests is imported at module scope in preflight.py"
+                )
+            if isinstance(node, ast.ImportFrom):
+                assert node.module != "requests", (
+                    "requests is imported at module scope in preflight.py"
+                )
+
+    def test_requests_not_a_module_attribute(self):
+        """Confirms the import really was moved, not just reformatted: if
+        `requests` were still imported at module scope, it would be bound as
+        a module-level attribute regardless of the exact import statement
+        shape (covers `import requests as X`, wildcard imports, etc. that the
+        AST check above does not enumerate)."""
+        import Auto3D.models.preflight as preflight_mod
+
+        assert not hasattr(preflight_mod, "requests"), (
+            "preflight module has a module-level `requests` attribute -- "
+            "the import was not fully moved into a function body"
+        )
+
 
 class TestUnwritableCacheDirectory:
     """A cache directory that cannot be created must be named, not double-faulted.

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -370,6 +370,76 @@ class TestConformerRankerTopWindow:
         assert len(results) >= 1
 
 
+class TestConformerRankerSelectorExclusivity:
+    """``ConformerRanker`` must reject a k+window combination the same way --
+    and with the same words -- as ``Auto3DOptions``/``CLIConfig``.
+
+    ``ConformerRanker.run`` consults exactly one selector
+    (``if self.k: ... elif self.window: ...``), so a caller who sets both
+    silently gets top-k and an inert window. Both config classes catch that at
+    construction time via ``Auto3D.config.check_field_bounds``; ``run`` is the
+    guard for callers who build a ``ConformerRanker`` directly. It used to
+    carry its own hand-written copy of the check, which had already drifted
+    from the shared one ("got k=1 and window=5.0" vs "got k=1, window=5.0"),
+    so the same misconfiguration was described two different ways depending on
+    which door the caller came through.
+    """
+
+    @staticmethod
+    def _ranker(tmp_path, **kwargs):
+        from Auto3D.ranking import ConformerRanker
+
+        # A real, readable input SDF -- not a missing path and not a 0-byte
+        # file, both of which make RDKit raise OSError. With the guard removed,
+        # `run` then proceeds to completion and returns [] instead of raising,
+        # so `pytest.raises` fails for the right reason rather than being
+        # satisfied by an unrelated file error. The single record is marked
+        # not-converged so `run` selects nothing and the result is [].
+        input_path = tmp_path / "input.sdf"
+        _write_mols_to_sdf(
+            [_create_mol_with_energy("C", -10.0, "mol_1", converged=False)],
+            str(input_path),
+        )
+        return ConformerRanker(
+            input_path=str(input_path),
+            out_path=str(tmp_path / "output.sdf"),
+            threshold=0.3,
+            **kwargs,
+        )
+
+    def test_k_and_window_together_raise(self, tmp_path):
+        from Auto3D.exceptions import ConfigurationError
+
+        ranker = self._ranker(tmp_path, k=1, window=5.0)
+        with pytest.raises(ConfigurationError, match="Only one of k or window"):
+            ranker.run()
+
+    def test_message_is_identical_to_the_config_classes(self, tmp_path):
+        """The wording must come from the one shared implementation.
+
+        Reverting `run` to its own inlined check reintroduces the "and"/","
+        drift and fails this comparison; a message reworded in
+        `Auto3D.config` alone can no longer leave `ranking.py` behind.
+        """
+        from Auto3D.config import Auto3DOptions
+        from Auto3D.exceptions import ConfigurationError
+
+        smi = tmp_path / "in.smi"
+        smi.write_text("CCO mol1\n")
+
+        with pytest.raises(ConfigurationError) as from_ranker:
+            self._ranker(tmp_path, k=1, window=5.0).run()
+        with pytest.raises(ConfigurationError) as from_config:
+            Auto3DOptions(path=str(smi), k=1, window=5.0)
+
+        assert str(from_ranker.value) == str(from_config.value)
+
+    def test_one_selector_alone_is_accepted(self, tmp_path):
+        """The guard must reject only the combination, not either selector."""
+        assert self._ranker(tmp_path, k=1).run() == []
+        assert self._ranker(tmp_path, window=5.0).run() == []
+
+
 class TestConformerRankerValidation:
     """Tests for input validation with proper ValueError exceptions."""
 

--- a/tests/test_tautomer_select.py
+++ b/tests/test_tautomer_select.py
@@ -36,6 +36,7 @@ def test_select_tautomers_rejects_nonpositive_k(tmp_path):
     from rdkit import Chem
     from rdkit.Chem import AllChem
 
+    from Auto3D.exceptions import ConfigurationError
     from Auto3D.tautomer import select_tautomers
 
     sdf = tmp_path / "in.sdf"
@@ -46,5 +47,49 @@ def test_select_tautomers_rejects_nonpositive_k(tmp_path):
         m.SetProp("E_tot", "-1.0")
         w.write(m)
 
-    with pytest.raises(ValueError, match="tauto_k"):
+    with pytest.raises(ConfigurationError, match="tauto_k"):
         select_tautomers(str(sdf), k=0)
+
+
+def test_select_tautomers_rejects_k_and_window_together(tmp_path):
+    """M29: this used to be a bare ValueError, not an Auto3DError -- so the
+    CLI's differentiated exit code/hint never applied to a direct Python API
+    call, only to the CLI's own pre-check in execute_tautomers."""
+    import pytest
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    from Auto3D.exceptions import ConfigurationError
+    from Auto3D.tautomer import select_tautomers
+
+    sdf = tmp_path / "in.sdf"
+    with Chem.SDWriter(str(sdf)) as w:
+        m = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        AllChem.EmbedMolecule(m, randomSeed=1)
+        m.SetProp("_Name", "molA@taut1")
+        m.SetProp("E_tot", "-1.0")
+        w.write(m)
+
+    with pytest.raises(ConfigurationError, match="Only k OR window"):
+        select_tautomers(str(sdf), k=1, window=2.0)
+
+
+def test_select_tautomers_rejects_neither_k_nor_window(tmp_path):
+    """Same M29 gap as above, for the neither-given branch."""
+    import pytest
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    from Auto3D.exceptions import ConfigurationError
+    from Auto3D.tautomer import select_tautomers
+
+    sdf = tmp_path / "in.sdf"
+    with Chem.SDWriter(str(sdf)) as w:
+        m = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        AllChem.EmbedMolecule(m, randomSeed=1)
+        m.SetProp("_Name", "molA@taut1")
+        m.SetProp("E_tot", "-1.0")
+        w.write(m)
+
+    with pytest.raises(ConfigurationError, match="Either k OR window"):
+        select_tautomers(str(sdf))

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -13,6 +13,19 @@ from Auto3D.ASE.thermo import calc_thermo
 # Mark all tests in this module as slow (thermodynamic calculations)
 pytestmark = pytest.mark.slow
 
+# Every opt_geometry/calc_thermo call below passes use_gpu=False on purpose.
+# Both default to use_gpu=True, and Auto3D 4.0 made "GPU requested but no CUDA
+# device visible" FATAL rather than a silent CPU fallback
+# (Auto3D.utils.validation.check_gpu_requested, called first thing inside each
+# function). The slow CI job runs on ubuntu-latest -- CPU-only, like every
+# runner in this repo -- so leaving the default in place would make each of
+# these raise GPUError instead of computing anything. `gpu_idx` is deliberately
+# NOT passed alongside it: get_device ignores gpu_idx entirely once
+# use_gpu=False (model_factory.get_device returns torch.device('cpu')), so
+# `gpu_idx=0, use_gpu=False` would read as a contradiction while meaning
+# nothing -- and 0 was the default anyway. Same shape as
+# tests/test_thermo_reference.py.
+
 folder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 try:
@@ -159,7 +172,7 @@ def test_calc_thermo_aimnet():
     reference_H = -314.45168666
 
     #compare Auto3D output with the above
-    out = calc_thermo(path, "AIMNET", opt_tol=0.003)
+    out = calc_thermo(path, "AIMNET", opt_tol=0.003, use_gpu=False)
     mol = next(Chem.SDMolSupplier(out, removeHs=False))
 
     G_out = float(mol.GetProp("G_hartree"))
@@ -245,7 +258,7 @@ def test_vib_hessian_includes_external_dispersion():
 
 def test_opt_geometry1():
     path = os.path.join(folder, "tests/files/DA.sdf")
-    out = opt_geometry(path, 'ANI2x', gpu_idx=0, opt_tol=0.1, opt_steps=5000)
+    out = opt_geometry(path, 'ANI2x', opt_tol=0.1, opt_steps=5000, use_gpu=False)
     try:
         os.remove(out)
     except OSError:
@@ -253,7 +266,7 @@ def test_opt_geometry1():
 
 def test_opt_geometry2():
     path = os.path.join(folder, "tests/files/DA.sdf")
-    out = opt_geometry(path, 'ANI2xt', gpu_idx=0, opt_tol=0.1, opt_steps=5000)
+    out = opt_geometry(path, 'ANI2xt', opt_tol=0.1, opt_steps=5000, use_gpu=False)
     try:
         os.remove(out)
     except OSError:
@@ -261,7 +274,7 @@ def test_opt_geometry2():
 
 def test_opt_geometry3():
     path = os.path.join(folder, "tests/files/DA.sdf")
-    out = opt_geometry(path, 'AIMNET', gpu_idx=0, opt_tol=0.1, opt_steps=5000)
+    out = opt_geometry(path, 'AIMNET', opt_tol=0.1, opt_steps=5000, use_gpu=False)
     try:
         os.remove(out)
     except OSError:
@@ -274,11 +287,11 @@ def test_opt_geometry_with_patience_and_batchsize():
     out = opt_geometry(
         path,
         'AIMNET',
-        gpu_idx=0,
         opt_tol=0.1,
         opt_steps=100,
         patience=50,
         batchsize_atoms=512,
+        use_gpu=False,
     )
     assert os.path.exists(out)
     try:
@@ -295,7 +308,7 @@ def test_opt_geometry4():
         myNNP_jit = torch.jit.script(myNNP)
         myNNP_jit.save(model_path)
     
-        out = opt_geometry(path, model_path, gpu_idx=0, opt_tol=0.1, opt_steps=5000)
+        out = opt_geometry(path, model_path, opt_tol=0.1, opt_steps=5000, use_gpu=False)
     try:
         os.remove(out)
     except OSError:
@@ -309,7 +322,7 @@ def test_opt_geometry5():
         # AIMNet2-based models are not torch.jit.script-able; save eager.
         torch.save(myNNP, model_path)
     
-        out = opt_geometry(path, model_path, gpu_idx=0, opt_tol=0.1, opt_steps=5000)
+        out = opt_geometry(path, model_path, opt_tol=0.1, opt_steps=5000, use_gpu=False)
     try:
         os.remove(out)
     except OSError:
@@ -329,14 +342,14 @@ def test_calc_thermo_userNNP1():
         myNNP = userNNP1()
         myNNP_jit = torch.jit.script(myNNP)
         myNNP_jit.save(model_path)
-        out = calc_thermo(path, model_path, opt_tol=0.003)
+        out = calc_thermo(path, model_path, opt_tol=0.003, use_gpu=False)
     mol = next(Chem.SDMolSupplier(out, removeHs=False))
 
     G_out = float(mol.GetProp("G_hartree"))
     H_out = float(mol.GetProp("H_hartree"))
 
     # compute thermodynamic properties with ani2x
-    out2 = calc_thermo(path, "ANI2x", opt_tol=0.003)
+    out2 = calc_thermo(path, "ANI2x", opt_tol=0.003, use_gpu=False)
     mol2 = next(Chem.SDMolSupplier(out2, removeHs=False))
     G_out2 = float(mol2.GetProp("G_hartree"))
     H_out2 = float(mol2.GetProp("H_hartree"))
@@ -365,7 +378,7 @@ def test_calc_thermo_userNNP2():
         myNNP = userNNP2()
         # AIMNet2-based models are not torch.jit.script-able; save eager.
         torch.save(myNNP, model_path)
-        out = calc_thermo(path, model_path, opt_tol=0.003)
+        out = calc_thermo(path, model_path, opt_tol=0.003, use_gpu=False)
     mol = next(Chem.SDMolSupplier(out, removeHs=False))
 
     G_out = float(mol.GetProp("G_hartree"))

--- a/tests/test_validate_run_parity.py
+++ b/tests/test_validate_run_parity.py
@@ -1,0 +1,123 @@
+# tests/test_validate_run_parity.py
+"""M25 parity: `auto3d validate` must reject exactly what the runner rejects.
+
+Before this fix, cli.commands.validate.validate_smiles_file did not require an
+ID column (it took parts[0] with no length check), while file_ops.encode_ids
+(via iter_smi_records, on_malformed="raise") always has -- so a SMILES-only
+file passed `auto3d validate` and then failed the run, whose own error hint
+told the user to run the validator that had just approved it. The two also
+disagreed on '#'-prefixed comment lines: validate_smiles_file has always
+skipped them; iter_smi_records had no comment handling at all and would try
+to parse '#' as data.
+
+These tests check both directions for both defects: a file that passes
+`validate_smiles_file` must not fail `encode_ids`, and a file that fails one
+must fail the other.
+"""
+from __future__ import annotations
+
+import pytest
+
+from Auto3D.cli.commands.validate import validate_smiles_file
+from Auto3D.exceptions import InputValidationError
+from Auto3D.utils.file_ops import encode_ids
+
+
+def _validator_accepts(path) -> bool:
+    return validate_smiles_file(path).valid
+
+
+def _runner_accepts(path) -> bool:
+    """True if encode_ids -- the runner's entry point for a .smi file, called
+    from WorkflowOrchestrator._validate_input before any worker is forked --
+    accepts `path` without raising."""
+    try:
+        encode_ids(str(path))
+    except InputValidationError:
+        return False
+    return True
+
+
+class TestValidateRunnerParity:
+    """Every case here must agree in both directions: validator and runner
+    both accept, or both reject. Disagreement in either direction is exactly
+    M25 (a validator more permissive than the runner is worse than none)."""
+
+    def test_well_formed_file_passes_both(self, tmp_path):
+        p = tmp_path / "ok.smi"
+        p.write_text("CCO ethanol\nCC(=O)O acetic_acid\n")
+        assert _validator_accepts(p)
+        assert _runner_accepts(p)
+
+    def test_id_less_line_fails_both(self, tmp_path):
+        """M25's headline defect: a SMILES with no ID column. validate used
+        to approve this (cli/commands/validate.py:42 took parts[0] with no
+        length check); the runner has always rejected it."""
+        p = tmp_path / "no_id.smi"
+        p.write_text("CCO\n")
+        assert not _validator_accepts(p)
+        assert not _runner_accepts(p)
+
+    def test_id_less_line_among_valid_lines_fails_both(self, tmp_path):
+        """Same defect, but mixed with otherwise-valid data -- the common
+        real-world shape (one bad line in an otherwise fine file)."""
+        p = tmp_path / "mixed.smi"
+        p.write_text("CCO ethanol\nCC(=O)O\n")  # second line has no ID
+        assert not _validator_accepts(p)
+        assert not _runner_accepts(p)
+
+    def test_comment_line_passes_both(self, tmp_path):
+        """A '#'-prefixed line is a comment to both, not data -- even a
+        single-token comment with no space, which (absent comment handling)
+        would otherwise look exactly like the ID-less defect above."""
+        p = tmp_path / "with_comment.smi"
+        p.write_text("#comment\nCCO ethanol\n")
+        assert _validator_accepts(p)
+        assert _runner_accepts(p)
+
+    def test_multi_word_comment_line_passes_both(self, tmp_path):
+        p = tmp_path / "with_wordy_comment.smi"
+        p.write_text("# this is a comment about the file below\nCCO ethanol\n")
+        assert _validator_accepts(p)
+        assert _runner_accepts(p)
+
+    def test_comment_only_file_passes_both(self, tmp_path):
+        p = tmp_path / "comment_only.smi"
+        p.write_text("# nothing but a comment\n")
+        assert _validator_accepts(p)
+        assert _runner_accepts(p)
+
+
+class TestValidateCheckSmiFormatParity:
+    """check_smi_format (utils/validation.py) is the other runner-side check
+    that reads the raw user .smi file directly (via check_input, called from
+    both main() and smiles2mols) -- it must agree with the validator too."""
+
+    @staticmethod
+    def _check_smi_format_accepts(path) -> bool:
+        from types import SimpleNamespace
+
+        from Auto3D.utils.validation import check_smi_format
+
+        args = SimpleNamespace(path=str(path), enumerate_isomer=True)
+        try:
+            check_smi_format(args)
+        except InputValidationError:
+            return False
+        return True
+
+    def test_id_less_line_fails_both(self, tmp_path):
+        p = tmp_path / "no_id.smi"
+        p.write_text("CCO\n")
+        assert not _validator_accepts(p)
+        assert not self._check_smi_format_accepts(p)
+
+    def test_comment_line_passes_both(self, tmp_path):
+        p = tmp_path / "with_comment.smi"
+        p.write_text("#comment\nCCO ethanol\n")
+        assert _validator_accepts(p)
+        assert self._check_smi_format_accepts(p)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -37,8 +37,11 @@ class TestCheckInputExceptions:
         args.path = "/fake/path.smi"
 
         with patch.dict('os.environ', {}, clear=True):
-            with pytest.raises(DependencyError, match="OE_LICENSE"):
+            with pytest.raises(DependencyError, match="OE_LICENSE") as exc_info:
                 check_input(args)
+        # M26: dependency_name must be set so cli/errors.get_error_hint can
+        # show the openeye install hint instead of falling back to "unknown".
+        assert exc_info.value.dependency_name == "openeye"
 
     def test_omega_without_openeye_raises_dependency_error(self):
         """Should raise DependencyError when omega used but openeye not installed."""
@@ -55,8 +58,9 @@ class TestCheckInputExceptions:
             # Import of openeye should fail
             with patch.dict('sys.modules', {'openeye': None, 'openeye.oechem': None}):
                 with patch('builtins.__import__', side_effect=ImportError("No module named 'openeye'")):
-                    with pytest.raises(DependencyError, match="openeye"):
+                    with pytest.raises(DependencyError, match="openeye") as exc_info:
                         check_input(args)
+        assert exc_info.value.dependency_name == "openeye"
 
     def test_ani2x_without_torchani_raises_dependency_error(self):
         """Should raise DependencyError when ANI2x used but torchani not installed."""
@@ -78,8 +82,9 @@ class TestCheckInputExceptions:
             return original_import(name, *args, **kwargs)
 
         with patch('builtins.__import__', side_effect=mock_import):
-            with pytest.raises(DependencyError, match="TorchANI"):
+            with pytest.raises(DependencyError, match="TorchANI") as exc_info:
                 check_input(args)
+        assert exc_info.value.dependency_name == "torchani"
 
     def test_custom_nnp_load_failure_raises_model_load_error(self, tmp_path):
         """Should raise ModelLoadError when custom NNP cannot be loaded."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -195,3 +195,72 @@ class TestCheckValidConfigurationGpuIndex:
              patch('Auto3D.utils.validation.torch.cuda.device_count', return_value=4):
             errors = check_valid_configuration(path=str(p), k=1, use_gpu=True, gpu_idx=0)
         assert errors == []
+
+
+class TestGpuPolicyIsUniform:
+    """M23: a CPU-only box must get the same fatal GPUError, with the same
+    '--no-gpu' hint, no matter which entry point is used. This box has 8 CUDA
+    devices (see task-7 brief), so the no-CUDA case is simulated throughout by
+    patching torch.cuda.is_available in Auto3D.utils.validation, where
+    check_gpu_requested (the single source of truth for this check) reads it.
+    """
+
+    def test_check_gpu_requested_raises_gpu_error_without_cuda(self):
+        from Auto3D.utils.validation import check_gpu_requested
+        with patch('Auto3D.utils.validation.torch.cuda.is_available', return_value=False):
+            with pytest.raises(GPUError, match="No cuda device") as exc_info:
+                check_gpu_requested(True)
+        assert "--no-gpu" in str(exc_info.value)
+
+    def test_check_gpu_requested_noop_when_use_gpu_false(self):
+        """use_gpu=False must never raise, CUDA available or not."""
+        from Auto3D.utils.validation import check_gpu_requested
+        with patch('Auto3D.utils.validation.torch.cuda.is_available', return_value=False):
+            check_gpu_requested(False)  # must not raise
+
+    def test_check_gpu_requested_noop_when_cuda_available(self):
+        from Auto3D.utils.validation import check_gpu_requested
+        with patch('Auto3D.utils.validation.torch.cuda.is_available', return_value=True):
+            check_gpu_requested(True)  # must not raise
+
+    def test_check_valid_configuration_raises_gpu_error_not_configuration_error(
+        self, tmp_path
+    ):
+        """Before this fix, check_valid_configuration folded the no-CUDA
+        finding into its generic `errors` list, so every caller (main() via
+        WorkflowOrchestrator._validate_input, and smiles2mols) wrapped it in
+        a ConfigurationError -- showing the CLI's unrelated 'auto3d config
+        init' hint instead of GPUError's '--no-gpu' hint (M23). It must now
+        raise GPUError directly, matching check_input."""
+        from Auto3D.utils.validation import check_valid_configuration
+        p = tmp_path / "in.smi"
+        p.write_text("CCO mol\n")
+        with patch('Auto3D.utils.validation.torch.cuda.is_available', return_value=False):
+            with pytest.raises(GPUError):
+                check_valid_configuration(path=str(p), k=1, use_gpu=True)
+
+    def test_check_input_and_check_valid_configuration_agree(self, tmp_path):
+        """The two entry points main() and smiles2mols reach check_input and
+        check_valid_configuration respectively -- both must raise the exact
+        same exception type for the same no-CUDA condition."""
+        from Auto3D.utils.validation import check_input, check_valid_configuration
+
+        p = tmp_path / "in.smi"
+        p.write_text("CCO mol\n")
+        args = MagicMock()
+        args.use_gpu = True
+        args.isomer_engine = "rdkit"
+        args.optimizing_engine = "AIMNET"
+        args.opt_steps = 100
+        args.input_format = "smi"
+        args.path = str(p)
+
+        with patch('Auto3D.utils.validation.torch.cuda.is_available', return_value=False):
+            with pytest.raises(GPUError) as exc_via_check_input:
+                check_input(args)
+            with pytest.raises(GPUError) as exc_via_check_valid_configuration:
+                check_valid_configuration(path=str(p), k=1, use_gpu=True)
+
+        assert type(exc_via_check_input.value) is type(
+            exc_via_check_valid_configuration.value
+        )

--- a/tests/test_validation_errors.py
+++ b/tests/test_validation_errors.py
@@ -2,8 +2,12 @@
 
 These tests verify that validation functions raise real exceptions (not
 AssertionError) for invalid input data, ensuring reliable validation even with
-Python's -O flag. The .smi reader raises the structured InputValidationError so
-the CLI's `except Auto3DError` path produces an actionable hint.
+Python's -O flag. Both the .smi and .sdf readers raise the structured
+InputValidationError for the same empty-ID defect, so the CLI's
+`except Auto3DError` path produces an actionable hint regardless of input
+format. (check_sdf_format used to raise a bare ValueError here -- an
+asymmetry with check_smi_format's InputValidationError for the same defect,
+fixed as part of M26/M29.)
 """
 import tempfile
 from pathlib import Path
@@ -122,8 +126,10 @@ class TestCheckSmiFormatErrors:
 class TestCheckSdfFormatErrors:
     """Tests for error handling in check_sdf_format function."""
 
-    def test_empty_molecule_id_raises_value_error(self):
-        """Empty molecule ID should raise ValueError, not AssertionError."""
+    def test_empty_molecule_id_raises_input_validation_error(self):
+        """Empty molecule ID should raise the structured InputValidationError,
+        not a bare ValueError -- matching check_smi_format's missing-ID error
+        for the same defect (the .smi/.sdf asymmetry named in M26/M29)."""
         # Create a simple SDF with empty _Name property
         mol = Chem.MolFromSmiles("CCO")
         mol = Chem.AddHs(mol)
@@ -139,7 +145,7 @@ class TestCheckSdfFormatErrors:
             args.path = f.name
             args.enumerate_isomer = False
 
-            with pytest.raises(ValueError, match="[Ee]mpty.*ID|[Ee]mpty.*_Name"):
+            with pytest.raises(InputValidationError, match="[Ee]mpty.*ID|[Ee]mpty.*_Name"):
                 check_sdf_format(args)
 
         Path(f.name).unlink()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -477,6 +477,69 @@ def test_run_pipeline_does_not_mutate_shared_batchsize():
     assert opt_configs, "optimizer did not receive the memory-scaled batchsize"
 
 
+def test_two_runs_do_not_reuse_job_name(tmp_path, monkeypatch):
+    """A second main(args) call in the same process must not reuse the first
+    run's job_name (M16).
+
+    main() builds a fresh WorkflowOrchestrator(args) on every call but the
+    two calls share the same Auto3DOptions object. Before this fix, run()
+    validated and mutated that shared object directly (job_name/input_format,
+    see _validate_input), so a second call would see job_name already
+    non-empty and skip generating its own -- silently reusing the first
+    run's job_name. run() now copies the shared config once at its own top,
+    so each run's mutations land on a private copy and the shared object
+    passed in is never touched.
+
+    Exercises WorkflowOrchestrator directly (constructing it twice with the
+    same shared config, exactly as two main(args) calls would) rather than
+    calling main() twice end-to-end: a real run loads an optimizing model and
+    forks worker processes, both disallowed on this box. Only Phase 1
+    (_validate_input) is relevant to this defect, so every later phase is
+    stubbed to stop the pipeline the moment it is reached -- optimizing_engine
+    is pinned to 'ANI2xt' (bundled, no registry/network lookup) so even Phase
+    1's real preflight_model check stays offline.
+    """
+    from Auto3D.config import Auto3DOptions
+    from Auto3D.workflow import WorkflowOrchestrator
+
+    smi = tmp_path / "mol.smi"
+    smi.write_text("CCO ethanol\n")
+    shared_config = Auto3DOptions(
+        path=str(smi), k=1, use_gpu=False, optimizing_engine="ANI2xt"
+    )
+    assert shared_config.job_name == ""
+
+    class _StopAfterValidateError(Exception):
+        pass
+
+    def _stub_setup_job_directory(self):
+        raise _StopAfterValidateError()
+
+    monkeypatch.setattr(
+        WorkflowOrchestrator, "_setup_job_directory", _stub_setup_job_directory
+    )
+
+    orch1 = WorkflowOrchestrator(shared_config)
+    with pytest.raises(_StopAfterValidateError):
+        orch1.run()
+    first_job_name = orch1.config.job_name
+    assert first_job_name != ""
+
+    orch2 = WorkflowOrchestrator(shared_config)
+    with pytest.raises(_StopAfterValidateError):
+        orch2.run()
+    second_job_name = orch2.config.job_name
+    assert second_job_name != ""
+
+    assert second_job_name != first_job_name, (
+        "second run reused the first run's job_name -- the shared config "
+        "object was mutated in place (M16)"
+    )
+    # The object the caller still holds a reference to must show no trace of
+    # either run's mutation.
+    assert shared_config.job_name == ""
+
+
 def test_smiles2mols_uses_args_threshold(monkeypatch):
     """smiles2mols must pass args.threshold (not a hardcoded value) to the
     isomer engine, matching main()'s candidate-pool behavior (review #35/#36)."""


### PR DESCRIPTION
Phase 5 of the 4.0.0 audit remediation: one set of validation rules, enforced identically through every entry point.

## What was wrong

The same configuration was validated differently depending on which door it came through. `Auto3DOptions(...)`, `CLIConfig(...)`, `auto3d run -c cfg.yaml` and the legacy `auto3d cfg.yaml` invocation each had their own partial copy of the rules, so a config accepted by one was rejected by another — and a `use_gpu=True` request on a machine without CUDA silently computed on CPU instead of failing.

## What changed

- **One bounds table.** `Auto3D.config.FIELD_BOUNDS` is now the single source, enforced by `Auto3DOptions.__post_init__` and by a `CLIConfig` model validator that both call `check_field_bounds`. `SENTINEL_FIELDS` and `SELECTOR_FIELDS` likewise replace the field lists that had been duplicated across `config_schema.py`, `ranking.py`, and `merge_configs`.
- **`False` still means "unset" — for the four fields where it always did.** `k`, `window`, `memory` and `max_confs` accept `False`/`None` as "not set"; the shipped `docs/legacy-v2/parameters.yaml` (`k: 1`, `window: False`) keeps working. The check is an identity test on `v is False`, so a genuine `0` is still rejected for every bounded field.
- **GPU requested but unavailable is now fatal everywhere.** `check_gpu_requested` is the single source of truth, called from the CLI wrappers *and* directly from `calc_spe` / `opt_geometry` / `calc_thermo`, so scripted Python-API callers get the same signal the CLI already gave.
- **Configuration errors exit 2 with a hint, not 1 with "Unexpected Error."** All five `CLIConfig` construction sites route through a new `build_cli_config`, which translates pydantic's `ValidationError` into `ConfigurationError`. One of those sites (the `tautomers` command) was live-broken before this.

All breaking changes are documented in `CHANGELOG.md` and `docs/source/migration-4.0.rst`.

## Testing

924 passed, 10 skipped, 2 xfailed — verified identical with CUDA present and with `CUDA_VISIBLE_DEVICES=""`.

That second run is the point. Making the GPU request fatal broke tests that had relied on the silent CPU fallback, in two waves: first six in the fast tier, then sixteen call sites in the slow tier. Every CI runner is CPU-only while the development box has 8 GPUs, so the suite was green locally and would have gone red on merge, twice.

Three related tests were also tightened from `pytest.raises(Auto3DError)` to `ConfigurationError`. `GPUError` is a subclass of `Auto3DError`, so the GPU guard — which runs first — was satisfying assertions meant to pin the charged-input guard, and those tests passed on every CI runner without ever reaching their subject. `ConfigurationError` and `GPUError` are siblings, so the wrong reason can no longer satisfy them.

The 2 remaining xfails are C14 durability tripwires, scheduled for the next phase.
