### PR TITLE
Expose run's per-run options and accept a settings-only config

### DIFF
--- a/src/Auto3D/cli/app.py
+++ b/src/Auto3D/cli/app.py
@@ -105,6 +105,84 @@ app.add_typer(config_app, name="config")
 app.add_typer(models_app, name="models")
 
 
+# Shared option annotations for the two conformer-generation commands --------
+#
+# `run` (-> Auto3D.auto3D.main) drives these pipeline stages through
+# `Auto3DOptions`, so each knob is declared once here rather than inline. Declaring them per command is
+# how the CLI acquired the divergences this phase is closing -- `--opt-tol`,
+# `--opt-steps`, `--patience` and `--batchsize-atoms` existed on `optimize`
+# and on nothing else, though `run` is where they matter most.
+#
+# All default to None, never to the field's default value: `merge_configs`
+# applies only non-None overrides, so None means "not specified on the command
+# line" and a value set in a `-c` config file survives. A flag defaulting to
+# the schema default would silently overwrite the config file with it.
+#
+# Deliberately NOT given flags on either command (still reachable via `-c`):
+#   pKaNorm  -- only meaningful with tauto_engine='oechem', and it is an
+#               ionization-state policy that belongs with the rest of the
+#               tautomer setup, not a per-invocation switch.
+#   mode_oe  -- only meaningful with isomer_engine='omega' (needs an OpenEye
+#               license); picking an Omega mode is part of that setup.
+#   capacity -- "SMILES per 1GB", a tuning constant for the chunking
+#               heuristic, paired with `memory` and not independently useful.
+
+EnumerateTautomerFlag = Annotated[
+    bool | None,
+    typer.Option(
+        "--enumerate-tautomer/--no-enumerate-tautomer",
+        help="Enumerate tautomers before generating conformers.",
+    ),
+]
+TautoEngineOption = Annotated[
+    str | None,
+    typer.Option("--tauto-engine", help="Tautomer enumeration engine: rdkit or oechem."),
+]
+IsomerEngineOption = Annotated[
+    str | None,
+    typer.Option("--isomer-engine", help="3D isomer engine: rdkit or omega (needs OpenEye)."),
+]
+EnumerateIsomerFlag = Annotated[
+    bool | None,
+    typer.Option(
+        "--enumerate-isomer/--no-enumerate-isomer",
+        help="Enumerate cis/trans and R/S isomers.",
+    ),
+]
+MaxConfsOption = Annotated[
+    int | None,
+    typer.Option("--max-confs", help="Max conformers per molecule (default: heavy atoms - 1)."),
+]
+ThresholdOption = Annotated[
+    float | None,
+    typer.Option("--threshold", help="RMSD threshold for duplicate removal (Angstrom)."),
+]
+MpiNpOption = Annotated[
+    int | None,
+    typer.Option("--mpi-np", help="CPU cores used for isomer generation."),
+]
+RunOptStepsOption = Annotated[
+    int | None,
+    typer.Option("--opt-steps", help="Max optimization steps per structure."),
+]
+RunOptTolOption = Annotated[
+    float | None,
+    typer.Option("--opt-tol", help="Max-force convergence threshold (eV/A)."),
+]
+RunPatienceOption = Annotated[
+    int | None,
+    typer.Option("--patience", help="Drop a conformer after this many non-improving steps."),
+]
+RunBatchsizeAtomsOption = Annotated[
+    int | None,
+    typer.Option("--batchsize-atoms", help="Atoms per optimization batch per GB."),
+]
+RunTf32Flag = Annotated[
+    bool | None,
+    typer.Option("--tf32/--no-tf32", help="Allow TF32 matmul on Ampere+ GPUs (faster, less precise)."),
+]
+
+
 def version_callback(value: bool) -> None:
     """Print version and exit."""
     if value:
@@ -175,6 +253,22 @@ def run(
         str | None,
         typer.Option("--job-name", help="Name for the output folder/run."),
     ] = None,
+    enumerate_tautomer: EnumerateTautomerFlag = None,
+    tauto_engine: TautoEngineOption = None,
+    isomer_engine: IsomerEngineOption = None,
+    enumerate_isomer: EnumerateIsomerFlag = None,
+    max_confs: MaxConfsOption = None,
+    threshold: ThresholdOption = None,
+    mpi_np: MpiNpOption = None,
+    opt_steps: RunOptStepsOption = None,
+    opt_tol: RunOptTolOption = None,
+    patience: RunPatienceOption = None,
+    batchsize_atoms: RunBatchsizeAtomsOption = None,
+    memory: Annotated[
+        int | None,
+        typer.Option("--memory", help="RAM available to Auto3D in GB (default: auto-detect)."),
+    ] = None,
+    tf32: RunTf32Flag = None,
     save_intermediate: Annotated[
         bool,
         typer.Option(
@@ -206,6 +300,19 @@ def run(
         gpu=gpu,
         gpu_idx=gpu_idx,
         job_name=job_name,
+        enumerate_tautomer=enumerate_tautomer,
+        tauto_engine=tauto_engine,
+        isomer_engine=isomer_engine,
+        enumerate_isomer=enumerate_isomer,
+        max_confs=max_confs,
+        threshold=threshold,
+        mpi_np=mpi_np,
+        opt_steps=opt_steps,
+        opt_tol=opt_tol,
+        patience=patience,
+        batchsize_atoms=batchsize_atoms,
+        memory=memory,
+        tf32=tf32,
         save_intermediate=save_intermediate,
         verbose=verbose,
         quiet=quiet,

--- a/src/Auto3D/cli/commands/config.py
+++ b/src/Auto3D/cli/commands/config.py
@@ -182,6 +182,14 @@ def execute_config_validate(config_file: Path, verbose: int = 0) -> None:
     from the run -- a script gating on 2 got the wrong answer from the
     checker. Routing through ``handle_error`` means the exception the runner
     would raise picks the code here too, whatever it is.
+
+    A config file with no ``path`` key is valid here, because it is valid to
+    ``auto3d run INPUT -c <file>``: every modern entry point supplies the
+    input on the command line and overrides whatever ``path`` the file
+    carries. This command used to reject exactly that shape -- the reusable,
+    settings-only config -- with ``path / Field required``, so the natural way
+    to write a config validated as invalid and then ran fine. See
+    ``CLIConfig.path``.
     """
     try:
         if not config_file.exists():
@@ -209,8 +217,17 @@ def execute_config_validate(config_file: Path, verbose: int = 0) -> None:
 
         warnings: list[str] = []
 
+        # Say where the input comes from, so "valid" is not mistaken for
+        # "complete": a settings-only file is valid for `auto3d run INPUT -c`
+        # and invalid for the deprecated `auto3d <config.yaml>` form, which
+        # has no other source of an input path.
+        input_line = (
+            str(config.path) if config.path is not None
+            else "supplied on the command line (no 'path' key)"
+        )
         console.print(Panel(
             f"[green]Valid configuration[/green]\n\n"
+            f"Input: {input_line}\n"
             f"Engine: {config.optimizing_engine}\n"
             f"GPU: {'Enabled' if config.use_gpu else 'Disabled'}\n"
             f"Output: {'k=' + str(config.k) if config.k else 'window=' + str(config.window)}",

--- a/src/Auto3D/cli/commands/run.py
+++ b/src/Auto3D/cli/commands/run.py
@@ -60,12 +60,31 @@ def execute_run(
     gpu: bool | None = None,
     gpu_idx: str | None = None,
     job_name: str | None = None,
+    enumerate_tautomer: bool | None = None,
+    tauto_engine: str | None = None,
+    isomer_engine: str | None = None,
+    enumerate_isomer: bool | None = None,
+    max_confs: int | None = None,
+    threshold: float | None = None,
+    mpi_np: int | None = None,
+    opt_steps: int | None = None,
+    opt_tol: float | None = None,
+    patience: int | None = None,
+    batchsize_atoms: int | None = None,
+    memory: int | None = None,
+    tf32: bool | None = None,
     save_intermediate: bool = False,
     verbose: int = 0,
     quiet: bool = False,
     json_output: bool = False,
 ) -> None:
     """Execute the main conformer generation workflow.
+
+    Every pipeline override below is ``None`` when the flag was not given, and
+    only non-None entries reach ``merge_configs`` -- so a value set in a ``-c``
+    config file survives a flag the user did not pass, and a flag the user did
+    pass wins. See ``cli/app.py`` for which ``Auto3DOptions`` fields are
+    deliberately left to ``-c`` rather than given a flag.
 
     Args:
         input_file: Path to input .smi or .sdf file.
@@ -76,6 +95,22 @@ def execute_run(
         gpu: GPU enable/disable override.
         gpu_idx: GPU index override.
         job_name: Output folder/run name override.
+        enumerate_tautomer: Enumerate tautomers before conformer generation.
+        tauto_engine: Tautomer engine ('rdkit' or 'oechem').
+        isomer_engine: 3D isomer engine ('rdkit' or 'omega').
+        enumerate_isomer: Enumerate cis/trans and R/S isomers.
+        max_confs: Max conformers per molecule.
+        threshold: RMSD threshold for duplicate removal (Angstrom).
+        mpi_np: CPU cores for isomer generation.
+        opt_steps: Max optimization steps per structure.
+        opt_tol: Max-force convergence threshold, i.e.
+            ``Auto3DOptions.convergence_threshold``. Spelled ``--opt-tol`` to
+            match ``auto3d optimize``/``auto3d thermo``, which already used
+            that name for the same quantity.
+        patience: Steps without improvement before a conformer is dropped.
+        batchsize_atoms: Atoms per optimization batch per GB.
+        memory: RAM available to Auto3D in GB.
+        tf32: Allow TF32 matmul on Ampere+ GPUs (Auto3DOptions.allow_tf32).
         save_intermediate: Keep all intermediate metadata (Auto3DOptions.verbose).
         verbose: Logging verbosity level (0-2).
         quiet: Suppress non-error output.
@@ -125,6 +160,21 @@ def execute_run(
                 "use_gpu": gpu,
                 "gpu_idx": gpu_idx,
                 "job_name": job_name,
+                "enumerate_tautomer": enumerate_tautomer,
+                "tauto_engine": tauto_engine,
+                "isomer_engine": isomer_engine,
+                "enumerate_isomer": enumerate_isomer,
+                "max_confs": max_confs,
+                "threshold": threshold,
+                "mpi_np": mpi_np,
+                "opt_steps": opt_steps,
+                # --opt-tol is the CLI spelling of convergence_threshold, the
+                # same quantity `auto3d optimize --opt-tol` already named.
+                "convergence_threshold": opt_tol,
+                "patience": patience,
+                "batchsize_atoms": batchsize_atoms,
+                "memory": memory,
+                "allow_tf32": tf32,
                 # --save-intermediate maps to Auto3DOptions.verbose (save metadata).
                 # Only override when set, so a config-file `verbose: true` is preserved.
                 "verbose": True if save_intermediate else None,

--- a/src/Auto3D/cli/config_schema.py
+++ b/src/Auto3D/cli/config_schema.py
@@ -34,9 +34,27 @@ from Auto3D.models.preflight import resolve_engine_name
 class CLIConfig(BaseModel):
     """Validated configuration for Auto3D CLI."""
 
-    # Required
-    path: Path
-    """Path to input .smi or .sdf file."""
+    # Input
+    path: Path | None = None
+    """Path to input .smi or .sdf file, or None for a settings-only config.
+
+    Optional, because the input is supplied on the command line by every
+    modern entry point: ``auto3d run INPUT -c cfg.yaml``,
+    ``auto3d tautomers INPUT -c cfg.yaml`` and ``auto3d smiles ... -c
+    cfg.yaml`` all override whatever ``path`` the file carries (``run``
+    explicitly excludes the key -- see ``cli/commands/run.py``). Requiring it
+    here made the natural reusable config -- settings only, input per run --
+    the one shape the CLI refused: ``auto3d config validate cfg.yaml`` and
+    ``auto3d run in.smi -c cfg.yaml`` both died on ``path / Field required``
+    for a file that describes a perfectly runnable set of options.
+
+    What "optional" must NOT mean is "runnable without an input", so the
+    obligation moves to :meth:`to_auto3d_options`, which refuses to build an
+    ``Auto3DOptions`` with no path. The deprecated ``auto3d config.yaml``
+    form -- the one entry point with no other source of an input path --
+    therefore still fails, as a ``ConfigurationError`` at exit 2 exactly as
+    before, and now says which key is missing instead of quoting pydantic.
+    """
 
     # Output control
     k: int | None = Field(None, description="Top-k conformers per molecule")
@@ -153,8 +171,40 @@ class CLIConfig(BaseModel):
             raise ValueError(str(exc)) from exc
         return self
 
-    def to_auto3d_options(self) -> Auto3DOptions:
-        """Convert to Auto3DOptions for core workflow."""
+    def to_auto3d_options(self, allow_missing_path: bool = False) -> Auto3DOptions:
+        """Convert to Auto3DOptions for core workflow.
+
+        Args:
+            allow_missing_path: Permit ``path=None``. Exactly one caller sets
+                it: ``auto3d smiles`` (``cli/commands/smiles.py``), which
+                takes its molecules from the command line and hands the
+                options to ``smiles2mols`` -- and ``smiles2mols`` writes the
+                SMILES to a temporary ``.smi`` and assigns ``args.path``
+                itself before validating anything, so any path supplied here
+                is discarded unread. Supplying a placeholder instead would put
+                a path in the options object that names no file the user ever
+                mentioned, which is worse than declaring the absence.
+
+        Raises:
+            ConfigurationError: ``path`` is unset and ``allow_missing_path``
+                is False. ``path`` is optional on this model so a
+                settings-only config file is valid (see the field's
+                docstring), but an ``Auto3DOptions`` with no input is not
+                runnable through ``main()`` -- it would fail inside
+                ``check_valid_configuration`` on ``path=None``. This is the
+                single place that obligation is discharged, so every consumer
+                (``run``/``tautomers``, the legacy YAML form, a direct caller)
+                gets the same refusal.
+        """
+        if self.path is None and not allow_missing_path:
+            raise ConfigurationError(
+                "No input path: this configuration sets options only.",
+                hint=(
+                    "Add a 'path:' key to the config file, or supply the "
+                    "input on the command line, e.g. 'auto3d run mols.smi "
+                    "-c config.yaml'."
+                ),
+            )
         # Map built-in engine names back to the canonical form expected by
         # Auto3DOptions; registry names and custom paths pass through verbatim.
         #
@@ -171,7 +221,9 @@ class CLIConfig(BaseModel):
         engine = engine_map.get(self.optimizing_engine.upper(), self.optimizing_engine)
 
         return Auto3DOptions(
-            path=str(self.path),
+            # `str(None)` would be the literal "None", a path that looks real
+            # and names nothing; keep the absence an absence.
+            path=str(self.path) if self.path is not None else None,
             k=self.k if self.k else False,
             window=self.window if self.window else False,
             enumerate_tautomer=self.enumerate_tautomer,

--- a/tests/test_cli_app.py
+++ b/tests/test_cli_app.py
@@ -358,17 +358,53 @@ def test_config_validate_invalid(runner, tmp_path_cwd):
     `auto3d run -c` rejects this same file with 2, and a pre-flight checker
     that answers a different number than the run it predicts is useless as a
     script gate.
+
+    The config here is invalid on its *values* (`k: 0` violates FIELD_BOUNDS).
+    It used to be a file whose only defect was a missing `path`, which is no
+    longer a defect at all -- see
+    test_config_validate_accepts_a_settings_only_config below.
     """
     from Auto3D.cli.app import app
 
-    # Create an invalid config file (missing required 'path')
     config_file = tmp_path_cwd / "invalid.yaml"
-    config_file.write_text("k: 5\noptimizing_engine: AIMNET\n")
+    config_file.write_text("path: mols.smi\nk: 0\noptimizing_engine: AIMNET\n")
 
     result = runner.invoke(app, ["config", "validate", str(config_file)])
 
     assert result.exit_code == 2
     assert "Validation Passed" not in result.output
+
+
+def test_config_validate_accepts_a_settings_only_config(runner, tmp_path_cwd):
+    """A config with no `path` is valid, because `auto3d run INPUT -c` is.
+
+    Every modern entry point supplies the input on the command line and
+    overrides whatever `path` the file carries, so the reusable settings-only
+    config is the shape users actually want. `config validate` used to reject
+    it with `path / Field required` -- a pre-flight checker calling invalid
+    the one file shape that runs fine.
+
+    The paired `run` invocation is what makes this a parity assertion rather
+    than a claim about the validator alone: both must agree.
+    """
+    from unittest.mock import patch
+
+    from Auto3D.cli.app import app
+
+    cfg = tmp_path_cwd / "settings_only.yaml"
+    cfg.write_text("k: 5\noptimizing_engine: AIMNET\nuse_gpu: false\n")
+
+    result = runner.invoke(app, ["config", "validate", str(cfg)])
+    assert result.exit_code == 0, result.output
+    assert "Validation Passed" in result.output
+
+    # And the run it predicts really does accept it.
+    smi = tmp_path_cwd / "mols.smi"
+    smi.write_text("CCO m1\n")
+    with patch("Auto3D.auto3D.main", return_value="out.sdf") as m:
+        run_result = runner.invoke(app, ["run", str(smi), "-c", str(cfg), "--no-gpu"])
+    assert run_result.exit_code == 0, run_result.output
+    assert m.called, "run rejected the config that config validate approved"
 
 
 def test_run_requires_input(runner):
@@ -975,3 +1011,50 @@ def test_config_validate_missing_file(runner, tmp_path_cwd):
     result = runner.invoke(app, ["config", "validate", "nonexistent.yaml"])
     assert result.exit_code == 2
     assert "does not exist" in result.output
+
+
+@pytest.mark.parametrize(
+    "flag,value,field,expected",
+    [
+        ("--max-confs", "5", "max_confs", 5),
+        ("--threshold", "0.7", "threshold", 0.7),
+        ("--mpi-np", "2", "mpi_np", 2),
+        ("--opt-steps", "77", "opt_steps", 77),
+        ("--opt-tol", "0.05", "convergence_threshold", 0.05),
+        ("--patience", "33", "patience", 33),
+        ("--batchsize-atoms", "512", "batchsize_atoms", 512),
+        ("--isomer-engine", "rdkit", "isomer_engine", "rdkit"),
+        ("--tauto-engine", "rdkit", "tauto_engine", "rdkit"),
+    ],
+)
+def test_run_forwards_each_new_flag_to_auto3d_options(
+    runner, tmp_path_cwd, flag, value, field, expected
+):
+    """Each flag must reach the field it names, not merely be accepted.
+
+    `run` exposed 7 of 23 Auto3DOptions fields; the rest were YAML-only even
+    though `optimize`/`thermo` exposed their equivalents. Adding a flag that
+    Typer accepts but `execute_run` never forwards would be invisible to a
+    test that only checks the exit code -- the command would still exit 0 and
+    the option would silently do nothing, which is the defect class this
+    codebase keeps finding. Asserting on the constructed Auto3DOptions is what
+    makes dropping the flag from the override dict fail this test.
+    """
+    from unittest.mock import patch
+
+    from Auto3D.cli.app import app
+
+    smi = tmp_path_cwd / "mols.smi"
+    smi.write_text("CCO m1\n")
+
+    with patch("Auto3D.auto3D.main", return_value="out.sdf") as m:
+        result = runner.invoke(
+            app, ["run", str(smi), "--k", "1", "--no-gpu", flag, value]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert m.called, f"{flag} prevented the run from starting"
+    options = m.call_args[0][0]
+    assert getattr(options, field) == expected, (
+        f"{flag}={value} did not reach Auto3DOptions.{field}"
+    )


### PR DESCRIPTION
Two of the five CLI/API capability gaps found by the parity analysis. The other three — CLI routes for `smiles2mols` and `select_tautomers`, and `-c/--config` for `tautomers` — were deliberately left out of scope.

## `auto3d run` exposes the options it was missing

`run` exposed 7 of 23 `Auto3DOptions` fields. The other 16 were YAML-only, even though `optimize` and `thermo` already exposed their equivalents as flags — so the command where `opt_steps`, `opt_tol`, `patience` and `batchsize_atoms` matter most was the one command that could not set them without writing a config file first.

Added, for the options that are genuinely per-run choices: `--enumerate-tautomer`, `--tauto-engine`, `--isomer-engine`, `--enumerate-isomer`, `--max-confs`, `--threshold`, `--mpi-np`, `--opt-steps`, `--opt-tol`, `--patience`, `--batchsize-atoms`, `--memory`, `--tf32`.

Each defaults to `None`, so `merge_configs` applies it only when given and a `-c` config file's value survives otherwise. All flow through `build_cli_config`, so they get `FIELD_BOUNDS`, the engine registry check and `extra="forbid"`.

## `config validate` accepts a settings-only config

`config validate` required a `path` key. But `auto3d run INPUT -c cfg.yaml` supplies the input on the command line and overrides whatever `path` the file carries — so the reusable settings-only config, which is the shape users actually want, **validated as invalid and then ran fine**. A pre-flight checker that calls the one working shape invalid is worse than no checker.

`CLIConfig.path` is now optional, and `config validate` states where the input will come from so "valid" is not mistaken for "complete".

## A test that pinned the defect

`test_config_validate_invalid` broke, and it was right to: its "invalid" config was invalid *only* because it lacked `path` — exactly the shape being fixed. It now uses a config invalid on its **values** (`k: 0`), and a new test asserts the settings-only shape is accepted by `config validate` *and* by the `run` it predicts. That pairing is the point: parity, not a claim about the validator in isolation.

## Testing

**1046 passed, 10 skipped, 0 xfailed** — identical across plain, `CUDA_VISIBLE_DEVICES=""`, and `FORCE_COLOR=1`.

Every new flag is pinned by a parametrized test asserting it reaches the `Auto3DOptions` field it names. **Verified by mutation:** dropping `threshold` from the override dict fails exactly that one parametrization. Without that assertion, a flag Typer accepts but `execute_run` never forwards would exit 0 and silently do nothing — the defect class this codebase keeps producing.
