### PR TITLE
Fix three defects that produced wrong numbers

### DIFF
--- a/.claude/review-manifests/review-2026-06-11-pr92.json
+++ b/.claude/review-manifests/review-2026-06-11-pr92.json
@@ -1,0 +1,26 @@
+{
+  "review_id": "review-2026-06-11-pr92",
+  "review_source": "multi-review of PR #92 (hardening/module-audit), 2026-06-11",
+  "commit": "4b7ff241845ed15b85360bc16bfd4f240b19e75e",
+  "findings_total": 10,
+  "fixed": 10,
+  "skipped": 0,
+  "skipped_reasons": {},
+  "agents": {
+    "code-reviewer": 5,
+    "computational-chemist": 2,
+    "architect-reviewer": 2,
+    "refactoring-specialist": 7
+  },
+  "files_modified": [
+    "src/Auto3D/utils/file_ops.py",
+    "src/Auto3D/isomer_engine.py",
+    "src/Auto3D/SPE.py",
+    "src/Auto3D/ranking.py",
+    "src/Auto3D/utils/chemistry.py",
+    "src/Auto3D/utils/__init__.py",
+    "src/Auto3D/batch_opt/batchopt.py",
+    "src/Auto3D/batch_opt/padding.py",
+    "src/Auto3D/batch_opt/ANI2xt_no_rep.py"
+  ]
+}

--- a/.claude/review-manifests/review-2026-08-02-error-hunt-summary.md
+++ b/.claude/review-manifests/review-2026-08-02-error-hunt-summary.md
@@ -1,0 +1,80 @@
+# Error hunt, 2026-08-02 — summary
+
+Three systematic sweeps of Auto3D at `main` c5d7fe6, run **after** the
+six-phase audit remediation closed all 14 Critical findings of
+`review-2026-07-30-package-audit.md`.
+
+Full reports, alongside this file:
+`review-2026-08-02-hunt-chemistry.md`,
+`review-2026-08-02-hunt-silent-fallbacks.md`,
+`review-2026-08-02-hunt-vacuous-tests.md`.
+
+## Why this hunt was run
+
+The remediation closed every finding **one audit recorded**. Two facts said
+that was not the same as the package being correct:
+
+1. **The audit's search method was incomplete by construction.** It found the
+   same-file-overwrite hazard by grepping `check_gpu_requested` call sites,
+   which can only return functions that are *already guarded*. Three
+   destructive writers were invisible to it; all three were later found by
+   searching for the **operation** instead, and all three destroyed user data.
+2. **One finding was recorded backwards.** C12 claimed the published custom-NNP
+   contract contradicted the code; the reverse was true, and implementing it as
+   written would have rejected every working custom NNP at load.
+
+So these sweeps searched by operation and by defect *shape*, not by a list.
+
+## Result
+
+| Sweep | Findings |
+|---|---|
+| Chemistry and numerics | 2 Critical, 6 Major, 8 Minor |
+| Silent fallbacks | 4 High, 4 Medium, 7 Low |
+| Tests that name a guarantee they do not provide | 118 (45 load-bearing) |
+
+**None of these was on the original audit's list.**
+
+## The finding that recontextualizes the rest
+
+**24 of the 66 slow-marked tests (36%) contain no assertion at all** — 19 of
+20 in `test_auto3D.py`, 6 of 11 in `test_thermo.py`. Independently confirmed
+by AST scan. They call `main()` or `opt_geometry()` and clean up.
+
+These are the most expensive tests in the project — full NNP pipelines on CPU
+in CI — and the **only** ones that exercise the real potentials. Mutation:
+making `opt_geometry` a no-op that returns a path it never wrote leaves them
+green; emitting the *unoptimized* embedded geometry with an arbitrary `E_tot`
+leaves all nineteen `test_auto3D.py` tests green.
+
+Their names claim engine-combination coverage (`test_auto3D_rdkit_ani2xt`,
+`test_auto3D_sdf_omega_aimnet`); their docstrings honestly say "check that the
+program runs".
+
+**Consequence for anyone reading this repo's history:** "the slow NNP tier
+passed" was cited as evidence of correctness on several merges during the
+remediation. It is evidence the pipeline does not crash. It is not evidence
+that any number is right.
+
+## The three defects that produce wrong numbers
+
+1. **`ASE/thermo.py:338`** — `set_charge` never calls `self.reset()`, and ASE's
+   `check_state` compares only positions/numbers/cell/pbc. Two records with the
+   same geometry and different formal charge share cached energy *and forces*.
+   A vertical IP/EA input reports one molecule's electronic energy with
+   another's Hessian. **20-90 kcal/mol.**
+2. **`models/adapter.py:272`** — `mask = species != self.species_pad`, the last
+   sentinel-derived atom mask, in direct violation of the rule C13 wrote into
+   `padding.py:40-48`. With `species_pad = 0`, an R-group `*` atom (Z=0) is
+   deleted as padding: `*CCO` is scored as 8 atoms, not 9. Wrong species, and
+   the dummy atom is frozen at zero force for the whole optimization.
+3. **`batch_opt/batchopt.py:334` vs `ASE/geometry.py:113`** — `E_tot` written in
+   **eV** by one writer and **Hartree** by the other; all five consumers assume
+   eV. `ConformerRanker(window=2.0)` on `opt_geometry` output applies a window
+   **27.2x too wide**.
+
+## Method note, for the next sweep
+
+Search by **operation** and by defect **shape**, never by callers of an
+existing guard. Every defect above was found that way; none was reachable from
+the previous audit's method.

--- a/.claude/review-manifests/review-2026-08-02-hunt-chemistry.md
+++ b/.claude/review-manifests/review-2026-08-02-hunt-chemistry.md
@@ -1,0 +1,488 @@
+# Chemistry-correctness hunt: Auto3D (branch `main`, 2026-08-02)
+
+Scope: defects that produce a **plausible but wrong number** — a conformer that is
+still a conformer, a ΔG that is still a number. Analysis only; no source file was
+modified (`git status` clean at start and end). No neural network potential was
+loaded and no model download was triggered; every demonstration uses RDKit, numpy,
+ASE 3.27.0, and hermetic stub models.
+
+Each finding is marked **DEMONSTRATED** (a wrong number was produced) or
+**REASONED**.
+
+---
+
+## Count by severity
+
+| Severity | Count |
+|---|---|
+| Critical | 2 |
+| Major | 6 |
+| Minor | 8 |
+
+---
+
+## Critical
+
+### C1. `src/Auto3D/models/adapter.py:272` — the last sentinel-derived atom mask deletes real atoms — DEMONSTRATED
+
+```python
+b, n = species.shape[0], species.shape[1]
+mask = species != self.species_pad                     # (B, N) real-atom mask
+```
+
+`AIMNet2Adapter` is constructed with `species_pad=0` (`adapter.py:238`) and rebuilds
+its real-atom mask by comparing species against that sentinel. Atomic number **0** is
+not a padding value — it is a wildcard / R-group / attachment-point atom, written `*`
+or `[3*]` in SMILES and extremely common in fragment and med-chem SMILES files.
+
+`batch_opt/padding.py` already computes and returns an **explicit** `atom_mask`
+(exactly to eliminate this class of bug — audit C13) and threads it through
+`ensemble_opt` → `n_steps`. It is never passed to the adapter, which re-derives its
+own mask from the sentinel and disagrees:
+
+```
+*CCO      Z=[0, 6, 6, 8, 1, 1, 1, 1, 1]   needs_aimnet=True
+          pad_from_mols atom_mask says 9 real atoms;
+          AIMNet2Adapter's `species != 0` says 8      <-- atom silently DELETED
+[*]c1ccccc1                                12 real -> 11
+[3*]C(=O)N                                  6 real ->  5
+```
+
+Consequences:
+
+1. The reported `E_tot` is the energy of a **different chemical species** — the
+   molecule minus the dummy atom, evaluated as a closed-shell neutral.
+2. `forces = torch.zeros(...); forces[mask] = forces_flat` gives the dummy atom
+   **exactly zero force**, so it is frozen at its ETKDG position for the entire FIRE
+   optimization while every other atom relaxes around it. It also never contributes
+   to `fmax`, so the structure converges happily.
+3. `check_connectivity` skips pairs with an element outside its radii table
+   (`utils/chemistry.py:363`), and 0 is outside it, so the resulting geometry is not
+   flagged either.
+4. This path is **forced**, not merely reachable: `_requires_aimnet`
+   (`utils/validation.py:98`) returns True for any Z ∉ {1,6,7,8,9,16,17}, so
+   `check_engine_supports_molecules` refuses ANI2x/ANI2xt for a dummy-containing
+   molecule and routes it to AIMNET — the one engine with this mask.
+
+Correct behavior: pass the explicit `atom_mask` into the adapter's `forward`, or use
+a `species_pad` that cannot be a real atomic number (`-1`, as every other adapter
+does). Note the `ASE/thermo.py` path is *not* affected — `Atoms(['*', ...])` raises
+`KeyError: '*'` — so this is specific to the optimization and single-point paths.
+
+Repro: `pad_from_mols([Chem.AddHs(Chem.MolFromSmiles("*CCO"))], "AIMNET", cpu,
+coord_pad=0.0, species_pad=0)`, then compare `atom_mask.sum()` with `(species != 0).sum()`.
+
+---
+
+### C2. `src/Auto3D/ASE/thermo.py:338-339` — `set_charge` does not invalidate ASE's result cache — DEMONSTRATED
+
+```python
+def set_charge(self, charge:int):
+    self.charge = torch.tensor([charge], dtype=torch.float, device=self.device)
+```
+
+`ase.calculators.calculator.Calculator.check_state` compares only positions, numbers,
+cell and pbc. Charge is not among them, and `set_charge` never calls `self.reset()`.
+`calc_thermo` constructs **one** `Calculator` (`thermo.py:997`) and reuses it for every
+record in the SDF, calling `calculator.set_charge(charge)` per molecule
+(`thermo.py:1007`).
+
+Two records with the same geometry and the same elements but different formal charge
+— the standard input shape for a **vertical ionization potential / electron affinity**
+calculation — silently share results. Hermetic repro (stub model, `E = -100·|q|` eV,
+5 eV/Å force for the charged state):
+
+```
+neutral (q=0):  ASE fmax=0.000e+00 eV/A  BFGS converged=True  steps=0  E=-0.000 eV
+anion   (q=-1): ASE fmax=0.000e+00 eV/A  BFGS converged=True  steps=0  E=-0.000 eV
+truth:          anion E = -100.000 eV and fmax = 5.0 eV/A (should NOT converge)
+```
+
+It is worse than a stale energy. The forces are cached too, so:
+
+* `relax_to_stationary_point` reads the **previous molecule's** converged forces,
+  reports `converged=True` after 0 steps, and the stationary-point gate at
+  `thermo.py:1037` — the guard that exists precisely to stop non-stationary
+  geometries from getting a Gibbs energy — passes.
+* `do_mol_thermo` then combines the **first** molecule's electronic energy
+  (`e = atoms.get_potential_energy()`, `thermo.py:629`) with the **second** molecule's
+  Hessian, symmetry number, multiplicity and moments of inertia. `E_hartree`,
+  `H_hartree` and `G_hartree` are all written from that mixture.
+
+Note the fmax pre-check at `thermo.py:1018-1021` bypasses the ASE calculator and uses
+the adapter directly, so it *does* see the right charge — which means an unconverged
+anion is routed into `relax_to_stationary_point`, i.e. straight into the stale-force
+path, rather than being caught.
+
+Physical consequence: in a real EA/IP workflow the error is the entire electron
+affinity, 1–4 eV = **20–90 kcal/mol**, reported with no warning and passing every
+quality gate.
+
+Correct behavior: `set_charge` must call `self.reset()` (or the calculator must be
+rebuilt per molecule, or the charge must participate in `check_state`).
+
+---
+
+## Major
+
+### M1. `src/Auto3D/ASE/geometry.py:113-114` vs `src/Auto3D/batch_opt/batchopt.py:334` — one property name, two units — DEMONSTRATED
+
+Two Auto3D writers emit an SD property called `E_tot`:
+
+* `optimizing.run()` (`batchopt.py:334`) writes it in **eV**.
+* `opt_geometry`'s `_annotate_and_rewrite` (`geometry.py:113-114`) rewrites it to
+  **Hartree**, with no unit-labeled sibling (unlike `ranking.py:297`, which adds
+  `E_tot(Hartree)`).
+
+Every consumer hard-codes eV: `ConformerRanker.top_window` (`ranking.py:195`,
+`window/ev2kcalpermol`), `ranking.py:294` (`/hartree2ev` on write),
+`filtering._filter_within_cluster` (`filtering.py:87`, `DEFAULT_DUPLICATE_ENERGY_TOL
+= 0.01` eV), `filtering.filter_unique_optimized` (`filtering.py:67`, 0.1 eV cluster
+window), `utils/chemistry.filter_unique` (`chemistry.py:552`).
+
+Demonstration — identical three-conformer input, `E_tot` written once in eV and once
+in Hartree, `ConformerRanker(window=2.0 kcal/mol)`:
+
+```
+E_tot written in eV       -> window=2.0 kcal/mol selected 2/3 conformers, E_rel = [0.0, 1.0]
+                             E_tot in output file: [-45.367, -45.3654]      (Hartree, correct)
+E_tot written in Hartree  -> window=2.0 kcal/mol selected 3/3 conformers, E_rel = [0.0, 0.037, 0.11]
+                             E_tot in output file: [-1.6672, -1.6671, -1.667]  (Hartree/27.211)
+```
+
+The 2.0 kcal/mol window acts as **54.4 kcal/mol** (27.2× too wide), `E_rel(kcal/mol)`
+is reported 27.2× too small (0.037 where the truth is 1.000), and `E_tot` /
+`E_tot(Hartree)` are divided by 27.211 a second time. The duplicate-energy tolerance
+becomes 0.01 Ha = **6.3 kcal/mol**, so any pair within 6.3 kcal/mol and 0.3 Å
+collapses. The same happens when `main()`'s own (already-Hartree) output is re-fed to
+`ConformerRanker` to re-filter — a natural thing for a user to do.
+
+Correct behavior: one unit for `E_tot` across all writers (eV, with the Hartree
+conversion happening only at the final user-facing write), or a mandatory
+unit-labeled property that consumers read.
+
+### M2. `src/Auto3D/ASE/thermo.py:664-672` — `ignore_imag_modes=True` deletes an artifact mode instead of using |ν| — DEMONSTRATED (analytic)
+
+`IMAGINARY_MODE_CUTOFF_CM = 50` (`constants.py:122`) defines everything below 50 cm⁻¹
+as a tolerable numerical artifact; those modes are dropped by ASE's
+`_clean_vib_energies` and the log says only "they are dropped from the
+thermochemistry, so treat the result as approximate" (`thermo.py:643-648`).
+
+Deleting a mode is not the same as the Gaussian/ORCA convention of keeping it at |ν|,
+and the difference is not a rounding error. Analytic RRHO at 298.15 K:
+
+```
+|v| =  10 cm-1 -> G changes by -2.374 kcal/mol  (ZPE 0.014, -T*S_vib -2.388)
+|v| =  20 cm-1 -> G changes by -1.949 kcal/mol
+|v| =  30 cm-1 -> G changes by -1.695 kcal/mol
+|v| =  49 cm-1 -> G changes by -1.378 kcal/mol  (just under the cutoff)
+```
+
+The term that dominates is the lost **−T·S_vib**, not the ZPE. So every "tolerated
+artifact" costs 1.4–2.4 kcal/mol of G, and the bias does not cancel between two
+species with different artifact counts — which is exactly the comparison a user makes.
+
+Correct behavior: substitute |ν| for sub-cutoff imaginary modes (or apply a
+quasi-harmonic floor), and state the residual uncertainty in kcal/mol rather than as
+"approximate".
+
+### M3. `src/Auto3D/ASE/thermo.py:664-672` — raw RRHO S_vib on an fp32-NNP Hessian, no quasi-harmonic treatment — DEMONSTRATED (analytic)
+
+`IdealGasThermo` is pure rigid-rotor / harmonic-oscillator: no Grimme or Truhlar
+quasi-harmonic damping and no low-frequency floor is applied to **real** low modes
+either. `S_vib` diverges as 1/ν, and the Hessian comes from a float32 NNP relaxed to
+`DEFAULT_THERMO_CONVERGENCE_THRESHOLD = 2e-4` eV/Å. Sensitivity of −T·S_vib to a
+±10 cm⁻¹ Hessian error on **one** mode at 298.15 K:
+
+```
+v =  20 cm-1 -> -T*S_vib spans -1.738 .. -2.388 kcal/mol   (spread 0.650)
+v =  30 cm-1 -> -T*S_vib spans -1.568 .. -1.978 kcal/mol   (spread 0.410)
+v =  50 cm-1 -> -T*S_vib spans -1.329 .. -1.568 kcal/mol   (spread 0.239)
+v = 200 cm-1 -> -T*S_vib spans -0.609 .. -0.664 kcal/mol   (spread 0.055)
+```
+
+A drug-sized flexible molecule carries several sub-50 cm⁻¹ modes, so the reported G
+has multiple kcal/mol of frequency-sensitivity that nothing in the output records.
+
+Correct behavior: at minimum record the number of modes below ~100 cm⁻¹ alongside G;
+better, offer a quasi-harmonic option and say which convention produced the number.
+
+### M4. `src/Auto3D/utils/validation.py:447` — the SMILES path's unspecified-stereo warning is blind to C=C — DEMONSTRATED
+
+```python
+c = CalcNumUnspecifiedAtomStereoCenters(mol)
+if c > 0: ...warn...
+```
+
+This counts **atom** stereocenters only. The SDF path was explicitly fixed for exactly
+this gap — `RDKitSdfIsomer.count_unspecified_stereo` (`isomer_engine.py:434`) counts
+`Chem.StereoSpecified.Unknown` as well, with a comment naming the case: *"a flat
+fumaric/maleic-acid SDF mixing two geometries ~5 kcal/mol apart into one species with
+no warning."* The SMILES path never received the same fix.
+
+```
+CC=CC             check_smi_format sees 0 unspecified  |  SDF path sees 1
+OC(=O)C=CC(=O)O   check_smi_format sees 0 unspecified  |  SDF path sees 1
+```
+
+With `enumerate_isomer=False` the SMILES path embeds the unspecified molecule
+directly (`isomer_engine.py:249-274`). Measured output of `embed_conformer`:
+
+```
+OC(=O)C=CC(=O)O   2 conformers ->  1 STEREOE  +  1 STEREOZ    (fumaric AND maleic acid)
+CC=CC             1 conformer  ->  1 STEREOZ                  (cis-2-butene only)
+```
+
+Both land under one `species_id`, compete on energy, and with `k=1` the ranker returns
+whichever is lower — silently returning one geometric isomer for an input that named
+neither. For `CC=CC` the single returned conformer is the *cis* isomer, ~1.0 kcal/mol
+above *trans*, with no warning anywhere.
+
+Correct behavior: `check_smi_format` should use the same predicate the SDF path uses.
+
+### M5. `src/Auto3D/ASE/thermo.py:649-662`, `:880` — a transition state passes the documented success filter — REASONED
+
+`analyze_vibrations` correctly identifies a saddle point and records
+`Is_transition_state`. But the record still gets `G_hartree` written, is appended to
+`out_mols`, and `_write_thermo_output` stamps it with `Thermo_failed = ""` —
+the property that `CHANGELOG.md` and `docs/source/migration-4.0.rst` document as
+*the* success filter (`thermo.py:865-869`). A saddle point's Gibbs energy, computed
+from 3N−7 modes with the reaction coordinate deleted, is therefore indistinguishable
+from a minimum's under the filter users are told to use.
+
+Contrast the non-convergence gate 10 lines above (`thermo.py:1037-1042`), which
+correctly diverts to `mols_failed`. The harmonic approximation is no more valid at a
+saddle point than at a non-stationary point.
+
+Correct behavior: route a confirmed transition state to `mols_failed` with
+`Thermo_failed = "transition_state"`, or document that `Thermo_failed == ""` must be
+combined with `Is_transition_state == "False"`.
+
+### M6. `src/Auto3D/ASE/thermo.py:127-170` — sigma = 1 is the value every out-of-the-box run uses — REASONED
+
+The default is deliberate and warned about, but the magnitude belongs on the record
+because **no Auto3D-generated SDF carries a `symmetry_number` property** — nothing in
+the pipeline ever sets one — so sigma = 1 is what every `auto3d thermo` run on Auto3D's
+own output actually uses. G is biased low by RT·ln σ: 1.47 kcal/mol for benzene
+(σ=12), 1.06 for ethane (σ=6), 0.41 for water (σ=2), 0.65 for methane (σ=12 → 1.47).
+This cancels between conformers of one species but not between tautomers, isomers or
+reaction partners — i.e. not for any comparison a user runs `thermo` to make.
+
+Correct behavior: derive σ from the point group of the optimized geometry (a 3D
+symmetry perception, not a graph-automorphism count — the docstring is right to reject
+the latter), or refuse to report G when σ is unknown for a molecule with any 3D
+symmetry element.
+
+---
+
+## Minor
+
+### m1. `src/Auto3D/filtering.py:60-81` — duplicates escape across an energy-cluster boundary — DEMONSTRATED
+
+`filter_unique_optimized` clusters by energy first and only RMSD-compares *within* a
+cluster, so a duplicate pair straddling a boundary is never compared. Three
+bit-identical geometries (heavy-atom RMSD 0.000 Å):
+
+```
+E - (-100) = [0.0, 0.001, 0.002]        -> filter kept 1/3   (correct)
+E - (-100) = [0.0, 0.099999, 0.100001]  -> filter kept 3/3   <-- duplicates survived
+```
+
+The last two differ by 2×10⁻⁶ eV. Consequence: a `k=5` request can return 5 slots
+filled by 2 distinct structures. The legacy O(n²) `filter_unique` is unaffected.
+
+### m2. `src/Auto3D/batch_opt/optimization_engine.py:212, 234-235, 277-284` — `Converged` and `fmax` in the output SDF are mutually inconsistent — DEMONSTRATED
+
+Convergence is decided from the **pre-step** force (`not_converged_post1 = fmax >
+opttol`, line 212), one more FIRE step is then taken (line 209), and `fmax` is
+recomputed at the **post-step** geometry (lines 277-284) — but `converged_mask` is
+never re-derived from it. Hermetic harmonic model, no NNP:
+
+```
+k=100 start=1.5: Converged=True  reported fmax=0.06237   <-- 6.2x the 0.01 eV/A tolerance
+k=100 start=2.0: Converged=True  reported fmax=0.02694
+k=100 start=3.0: Converged=True  reported fmax=0.02486
+```
+
+Energy consequence is small (<0.05 kcal/mol for realistic stiffness), but a consumer
+filtering on `fmax <= 0.01` gets a different set than one filtering on
+`Converged == "True"`, and the SDF asserts both.
+
+### m3. `src/Auto3D/ranking.py:50, 163, 203` — RMSD dedup runs *between diastereomers* — MEASURED
+
+`species_id` strips `<isomer>_<conformer>`, so all enumerated stereoisomers of one
+input share a group, and `_filter_mols` then runs heavy-atom `GetBestRMS` across
+chemically distinct compounds. Minimum heavy-atom RMSD over embedded conformer sets:
+
+```
+4-tBu-cyclohexanol   cis vs trans   0.300 A   <-- exactly DEFAULT_RMSD_THRESHOLD
+cyclohexane-1,4-diol cis vs trans   0.335 A
+2,3-butanediol       (R,S) vs (R,R) 0.633 A
+threonine            2 diastereomers 0.575 A
+```
+
+Only the 0.01 eV (0.23 kcal/mol) energy guard prevents cis/trans-1,4-disubstituted
+rings from collapsing, and 1,4-ring diastereomer gaps below 0.23 kcal/mol are common
+for small substituents. When it fires, one of two distinct compounds vanishes from
+the output with no record.
+
+### m4. `src/Auto3D/ASE/thermo.py:420-436` — natural-abundance masses where the reference programs use most-abundant-isotope masses — REASONED
+
+`mol2atoms` leaves ASE's default masses in place for unlabeled atoms (IUPAC standard
+atomic weights: C = 12.011, Cl = 35.453). Gaussian and ORCA default to the most
+abundant isotope (12.000, 34.9689). `thermo.py:678-680` explicitly claims to match
+ORCA/Gaussian on standard state; the mass convention is an undeclared difference.
+Magnitude: ~1% on M and on halogen-bearing frequencies, T·ΔS ≈ 0.01 kcal/mol for
+CH₃Cl and growing with heavy-halogen content. The `if any(a.GetIsotope() ...)` branch
+does not help — RDKit's `GetMass()` also returns the average mass for unlabeled atoms.
+
+### m5. `src/Auto3D/constants.py:38` — `STANDARD_PRESSURE` is dead; `101325` is hardcoded twice — REASONED
+
+`STANDARD_PRESSURE = 101325  # Pa` has no reader anywhere in `src/` or `tests/`.
+`thermo.py:681` and `:682` each hardcode the literal. A change to the constant would
+silently not propagate. (The values are correct: verified against ASE that
+S(1 atm) − S(1 bar) = −R ln 1.01325, T·ΔS = 0.0078 kcal/mol.)
+
+### m6. `src/Auto3D/ASE/thermo.py:214-311` — the bounds/parity validation never applies to the *derived* multiplicity — REASONED
+
+The lower bound, upper bound (`n_electrons + 1`) and parity checks all sit inside the
+`if mol.HasProp("multiplicity")` branch. The value derived from the radical-electron
+count is returned unchecked. Empirically this is mostly safe — RDKit re-derives
+radical electrons on sanitization even with `M  RAD` stripped from the molblock
+(verified for NO, NO₂, CH₃•, all correct). The residual exposure is a valence-satisfied
+drawing that hides an open shell; `_OPEN_SHELL_DRAWN_CLOSED` (`thermo.py:177`) covers
+only O₂. A singlet-drawn carbene/nitrene gets multiplicity 1, and an
+antiferromagnetically coupled biradical gets multiplicity 3 where 1 is right — either
+way R·ln 3 → **0.65 kcal/mol** in T·S_elec.
+
+### m7. `src/Auto3D/config.py:245` — `max_confs` docstring contradicts the code — REASONED
+
+> `"""Maximum conformers per SMILES. None uses dynamic number (num_heavy_atoms - 1)."""`
+
+`calculate_conformer_count` (`utils/chemistry.py:90-97`) computes
+`min(max(1, n_heavy, 2·8.481·n_rot**1.642), 1000)`. Not `n_heavy − 1`, and the
+rotatable-bond term dominates for anything flexible (glycerol → 238, not 5). Users
+sizing a run off this docstring will underestimate the conformer budget by 1–2 orders
+of magnitude.
+
+### m8. `src/Auto3D/ASE/thermo.py:778, 787` — two small boundary defects in `aimnet_hessian_helper` — REASONED
+
+* Line 778: `numbers.squeeze()` on a 1-atom molecule yields a 0-d tensor whose
+  `.tolist()` is a scalar `int`, so `to_model_species` iterates an int and raises
+  `TypeError`. A monatomic species on the ANI2xt thermo path fails inside the
+  catch-all handler and is reported as `Thermo_failed` rather than as monatomic.
+* Line 787: the custom-model branch passes `charge` as an int64 tensor
+  (`torch.tensor([charge])`, `thermo.py:477`) where every other site — `pad_from_mols`,
+  `mol2aimnet_input`, `Calculator.__init__`, `CustomModelAdapter.forward` — passes
+  float. A custom NNP that does arithmetic on the charge without casting sees a
+  different dtype from the Hessian path than from the optimization path.
+
+---
+
+## Areas examined and found sound
+
+Stating these explicitly, because a clean result here is itself information.
+
+**Unit constants.** `HARTREE_TO_EV`, `EV_TO_KCAL_PER_MOL`, `HARTREE_TO_KCAL_PER_MOL`
+and `EV_PER_WAVENUMBER` all match CODATA-2018 to ≤ 1.1×10⁻⁹ relative, and the three
+energy constants are internally consistent
+(`HARTREE_TO_EV × EV_TO_KCAL_PER_MOL` vs `HARTREE_TO_KCAL_PER_MOL`: 1.1×10⁻⁹).
+
+**Thermochemistry bookkeeping (H / S / G).** Verified end to end against NIST-JANAF for
+gaseous water using ASE exactly as `do_mol_thermo` calls it: S(1 bar) = 45.164 vs
+JANAF 45.132 cal/mol/K (+0.032, consistent with average-mass and
+fundamental-vs-harmonic differences); `G = H − T·S` reconstructs from the written
+`H_hartree` / `S_hartree_per_K` / `T_K` to 2×10⁻¹⁸ Ha; ZPE equals Σhν/2 exactly;
+`S_hartree_per_K` is genuinely per-kelvin as its name says. The 1 atm standard state
+is correctly obtained by passing `pressure=101325` to ASE (`get_entropy` /
+`get_gibbs_energy`), giving the −R ln(1.01325) shift = 0.0078 kcal/mol in T·S versus
+1 bar. The code comment about "ASE's internal reference is 1 bar so this applies the
+correction" describes ASE's internals loosely, but the call itself is right.
+
+**Vibrational-mode accounting.** `analyze_vibrations` matches `IdealGasThermo`'s own
+slicing and `n_imag` exactly for a clean minimum, a −18i cm⁻¹ artifact and a −420i
+cm⁻¹ genuine TS. Checked against the *installed* ase 3.27.0 source, which does
+`vib_energies.sort(key=np.abs)` before slicing `[-(3N−6):]`, as the docstring claims.
+
+**Linearity classification.** The dual test (moment ratio + max perpendicular offset)
+does what its comment says on real geometries: CO₂, HCN, acetylene, N₂O, CS₂, carbon
+suboxide and diacetylene → linear; water, allene, 2-butyne, 2,4-hexadiyne,
+2,4,6-octatriyne (ratio 5.7×10⁻³, max-perp 1.023 Å) and all-anti n-C₁₈H₃₈ → nonlinear.
+The previously reported 1/N² size-cutoff failure is closed.
+
+**`check_connectivity` thresholds.** The formed-bond rule (`d < 1.1·(rᵢ+rⱼ)`) has
+≥0.5 Å of margin on every strained polycyclic tested — cubane, bicyclo[1.1.0]butane,
+bicyclo[1.1.1]pentane, norbornane, spiropentane, tetrahedrane, adamantane,
+bicyclo[2.1.0]pentane, bicyclo[2.2.0]hexane, azetidine, oxirane, benzene, cyclohexane.
+No false "bond formed" verdict was produced. Unknown elements are skipped rather than
+raising.
+
+**SDF stereochemistry round trip.** 8/8 cases (E/Z-2-butene, R/S-2-butanol,
+(2R,3R)-tartaric acid, (E)-cinnamic acid, (2E,4E)-hexadienal, (R)-glycidol) come back
+as exactly one stereoisomer with the input's canonical SMILES; `count_unspecified_stereo`
+reports 0 for all of them. RDKit's 3D perception on `SDMolSupplier` is doing its job
+and `RDKitSdfIsomer` preserves it.
+
+**SMILES stereoisomer enumeration.** The full `enumerate_func` →
+`amend_configuration_w` → `remove_enantiomers` → `hash_enumerated_smi_IDs` chain
+produces exactly the right set of distinct species in 12/12 cases: fully specified
+molecules pass through untouched (1 in, 1 out), meso tartaric acid is not confused
+with its (R,R)/(S,S) pair (3 enumerated → 2 emitted), mixed specified/unspecified
+centers are preserved, open-chain glucose (4 unspecified) gives 16 → 8, and no
+unparseable SMILES is produced by the `create_enantiomer` string surgery. The
+`enantiomer_key` mirror-image test correctly leaves E/Z pairs alone.
+
+**Species/index conversion at model boundaries.** `to_model_species` / `ANI2XT_INDEX`
+is the single owner and is called at every boundary: `pad_from_mols` (padding.py:82),
+`Calculator.calculate` (thermo.py:352), `mol2aimnet_input` (thermo.py:379),
+`aimnet_hessian_helper` (thermo.py:778). ANI2xt, ANI2x and custom models all pad with
+`species_pad = -1`, which cannot collide with an atomic number or a 0-based index.
+The `optimizing` → `pad_from_mols` → `ensemble_opt` → `n_steps` chain carries the
+explicit `atom_mask` correctly, and the final force reduction masks it
+(optimization_engine.py:283). The only sentinel-derived mask left is C1 above.
+
+**Charge propagation.** `pad_from_mols` reads `rdmolops.GetFormalCharge` per molecule;
+the batch subsetting in `n_steps` (`state['charges'][not_converged]`) and in
+`EnForce_ANI.forward_batched` (`charges[sub]`) keeps charges index-aligned with coords
+and species; the OOM-retry recursion preserves output ordering. `vib_hessian` reads the
+per-molecule formal charge independently.
+
+**Multiplicity derivation.** Correct for every open-shell species tested — triplet O₂
+drawn as a diradical (3), NO (2), NO₂ (2), CH₃• (2), and still correct with the
+`M  RAD` line stripped from the molblock, since RDKit re-derives radical electrons on
+sanitization. `spin = (multiplicity − 1)/2` matches ASE's `R·ln(2·spin + 1)`. The
+2⁻³²-wraparound and unbounded-multiplicity defects are closed.
+
+**Energy ranking footing.** Within one pipeline run, everything compared is in eV and
+comes from the same model and the same final-geometry recompute
+(optimization_engine.py:277-284, which correctly re-evaluates energy *and* fmax at the
+reported coordinates rather than at the pre-step geometry). `top_window`'s early
+`break` is safe because `filter_unique_optimized` returns globally ascending energies
+(clusters are ordered and non-overlapping by construction). Tautomers are grouped on
+`@taut`, conformers on `_`, so the two grouping rules do not interfere.
+`select_tautomers` reads `E_tot` in Hartree, which is what `main()` writes, and
+documents the missing ZPE/thermal terms.
+
+**Chunking.** Round-robin over input rows, so every stereoisomer and conformer of one
+species stays in one chunk and therefore in one ranking group — top-k and window
+selection are not silently per-chunk for a given molecule.
+
+**TF32 / precision defaults.** `allow_tf32` defaults to False on every entry point,
+including `calc_thermo`, `calc_spe` and `opt_geometry`. Energies are accumulated in
+float64 where a float64 constant is involved (`ANI2xt_no_rep.py:181-204`).
+
+---
+
+## Method notes
+
+* No NNP was loaded and no model download was triggered. C1, C2 and m2 were
+  demonstrated with hermetic stub models (a 1-parameter `nn.Linear` to satisfy the
+  device/dtype probe, plus an analytic harmonic potential); M2 and M3 are closed-form
+  RRHO evaluations; everything else uses RDKit + ASE only.
+* `src/Auto3D/ASE/thermo.py` is the highest-risk file in the package by a wide margin:
+  2 of 2 Criticals, 4 of 6 Majors and 4 of 8 Minors live there or are reached from it.
+* Docstrings were treated as claims to test, not as documentation. Three were found
+  inaccurate: `config.py:245` (m7), `thermo.py:678-680`'s description of ASE's pressure
+  handling (correct code, misleading explanation), and `padding.py:40-47`'s assertion
+  that callers "must use this mask rather than comparing species against
+  `species_pad`" — which `AIMNet2Adapter.forward` does not (C1).

--- a/.claude/review-manifests/review-2026-08-02-hunt-silent-fallbacks.md
+++ b/.claude/review-manifests/review-2026-08-02-hunt-silent-fallbacks.md
@@ -1,0 +1,310 @@
+# Silent fallbacks and swallowed failures in Auto3D
+
+Analysis only — no source file was modified. Branch `main`, HEAD `db4a113`.
+
+**Note on the working tree:** `git diff` was already dirty when this sweep started:
+`src/Auto3D/cli/console.py` (`print_warning`/`print_error` short-circuited) and
+`src/Auto3D/utils/chemistry.py` (`amend_mol` short-circuited) carry `# MUTATION`
+markers from another agent's in-flight mutation run. They are not mine and were
+deliberately left in place. They did not affect any conclusion below (no
+demonstration calls `amend_mol` or the CLI print helpers).
+
+## The line that sorts this report
+
+A fallback that makes Auto3D **slower** is a performance note. A fallback that makes
+the **output different from what the user asked for, without telling them**, is a
+defect. Findings are ordered by how invisible the wrong answer is.
+
+## Counts
+
+| Severity | Meaning | Count |
+|---|---|---|
+| **High** | Output differs from the request; the user has no way to find out | **4** |
+| **Medium** | Output differs; a log line exists, but neither the return value nor the exit code reflects it | **4** |
+| **Low** | Bounded, documented, or surfaces as a crash rather than a wrong number | **7** |
+| *Not findings* | Constructs examined that cannot change the output | 9 |
+
+Every "DEMONSTRATED" item was reproduced with a hermetic script (RDKit / torch / ase
+only — no NNP loaded, no model downloaded, no GPU touched).
+
+---
+
+# HIGH — the user cannot find out
+
+## H1. `src/Auto3D/ASE/thermo.py:331-336` — the ASE calculator picks CUDA and float64 on its own, ignoring `use_gpu` and `gpu_idx` — DEMONSTRATED
+
+```python
+params = list(self.model.parameters())
+...
+if params:
+    self.device = params[0].device
+    self.dtype  = params[0].dtype
+else:
+    # Param-less custom model ...
+    self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    self.dtype  = torch.double
+```
+
+**What input reaches this path.** `calc_thermo(path, "/path/to/model.pt", use_gpu=False)`
+— or `auto3d thermo -e /path/to/model.pt --no-gpu` — where the user's custom NNP holds
+no `nn.Parameter` (a buffer-only model, a lazily-constructed backend, or a closed-form
+potential). `Calculator.__init__` is never handed `use_gpu` or `gpu_idx`; it infers
+everything from the model object.
+
+**What the user gets instead.** Two different devices *and* two different dtypes inside a
+single `calc_thermo` call:
+
+| stage | device | dtype |
+|---|---|---|
+| `relax_to_stationary_point` → BFGS, and `atoms.get_potential_energy()` in `do_mol_thermo` (via this `Calculator`) | **cuda:0** | **float64** |
+| the fmax pre-check (`mol2aimnet_input`) and `_load_hessian_model` | `get_device(gpu_idx, use_gpu=False)` = **cpu** | float32 |
+
+So `--no-gpu` is violated (the run seizes cuda:0 on a shared box), `gpu_idx` is ignored
+entirely (always device 0, never the requested index), and the relaxed geometry the
+Hessian is built on was produced at a different precision from the Hessian itself.
+
+**How they would find out.** They would not. `check_gpu_requested(False)` is a no-op by
+design, so the M23 guard cannot fire; nothing is logged; no property records the device.
+
+Reproduced (CUDA availability stubbed to `True` and `torch.tensor` patched to allocate on
+CPU so no CUDA context was created on this shared box — the *device-selection* logic is
+untouched and the recorded request is reported verbatim):
+
+```
+model WITH parameters, built on CPU     -> calculator.device = cpu   dtype = torch.float32
+model WITHOUT parameters, CUDA present  -> calculator.device = cuda  dtype = torch.float64
+   (charge tensor was requested on device: cuda)
+```
+
+---
+
+## H2. `src/Auto3D/ranking.py:50` — `species_id` merges two distinct input molecules when `enumerate_isomer=False` — DEMONSTRATED
+
+```python
+return name.strip().rsplit("_", 2)[0].strip()
+```
+
+**What input reaches this path.** `smiles2mols([...], Auto3DOptions(k=1, enumerate_isomer=False))`
+with two inputs that share a standard InChIKey — a tautomer pair the standard key
+conflates, or the same molecule written two ways. `smiles2smi`
+(`utils/file_ops.py:129-139`) renames the second one `<KEY>_2` *specifically so it is not
+dropped*. With `enumerate_isomer=False` the SMILES path appends only one trailing
+component (the conformer index), but `species_id` always strips two.
+
+```
+species_id('KEY_0'    ) = 'KEY'      <- input #1, conformer 0
+species_id('KEY_2_0'  ) = 'KEY'      <- input #2 ("KEY_2"), conformer 0   *** collision
+species_id('KEY_0_0'  ) = 'KEY'      <- enumerate_isomer=True: correct
+species_id('KEY_2_0_0') = 'KEY_2'    <- enumerate_isomer=True: correct
+```
+
+**What the user gets instead.** Both molecules land in one ranking group. `k=1` returns a
+single conformer for the pair, written out with `_Name = "KEY"`. The disambiguated input
+is absent from the result **and** — since selection is by energy across the merged group —
+the surviving record may be `KEY_2`'s conformer reported under `KEY`'s name. The exact
+failure the disambiguation was added to prevent, reintroduced one layer down.
+
+**How they would find out.** `find_smiles_not_in_sdf` logs a WARNING naming the missing id
+(reaches stderr via `logging.lastResort`), but `smiles2mols` returns a plain
+`list[Chem.Mol]`: no exception, no count, no `failures` carrier. The mis-attributed
+survivor is reported by nothing at all.
+
+The gap is acknowledged in `species_id`'s own docstring ("Known residual gap ... this
+combination has no test pinning it"), which makes it documented, not visible.
+
+---
+
+## H3. `src/Auto3D/torch_config.py:90-96, 113-114` — every Auto3D entry point silently resets the process's determinism and precision settings — DEMONSTRATED
+
+```python
+torch.backends.cuda.matmul.allow_tf32 = config.allow_tf32
+torch.backends.cudnn.allow_tf32       = config.allow_tf32
+torch.backends.cudnn.benchmark        = config.cudnn_benchmark
+...
+torch.use_deterministic_algorithms(config.deterministic, warn_only=True)
+torch.backends.cudnn.deterministic = config.deterministic
+```
+
+**What input reaches this path.** Any script that configures torch for reproducibility and
+then calls Auto3D. `main`, `smiles2mols`, `calc_spe`, `opt_geometry` and `calc_thermo` all
+call `configure_torch(TorchConfig(allow_tf32=<user flag>))` at entry — and `TorchConfig`'s
+other three fields default to `deterministic=False`, `cudnn_benchmark=False`,
+`random_seed=None`, which are then **written unconditionally**.
+
+**What the user gets instead.** Determinism turned off for the rest of the process,
+including their own code after the Auto3D call. Auto3D exposes no way to ask for it back:
+`deterministic` and `random_seed` exist on `TorchConfig` but nothing threads them from
+`Auto3DOptions`, the CLI, or any API function. And even a caller who reached
+`configure_torch` directly gets `warn_only=True` forced on, so a missing deterministic
+kernel warns instead of raising — the request is downgraded rather than honored.
+
+```
+before Auto3D call:                     after configure_torch(TorchConfig(allow_tf32=False)):
+  deterministic_algorithms  = True        deterministic_algorithms  = False
+  deterministic warn_only   = False       deterministic warn_only   = True
+  cudnn.benchmark           = True        cudnn.benchmark           = False
+  matmul.allow_tf32         = True        matmul.allow_tf32         = False
+```
+
+**How they would find out.** They would not. Nothing is logged. The next nondeterministic
+op silently produces nondeterministic results instead of raising, which is precisely the
+signal `use_deterministic_algorithms(True)` was set to obtain.
+
+The unconditional write is deliberate (the comment explains it makes the flags
+un-sticky), but the side effect on *state the caller owns* is not acknowledged anywhere.
+
+---
+
+## H4. `src/Auto3D/ranking.py:267-270`, `filtering.py:47-51`, `utils/chemistry.py:510-513` — a record with no `Converged` property is silently deleted — DEMONSTRATED
+
+```python
+try:
+    converged = mol.GetProp('Converged').lower() == 'true'
+except KeyError:
+    converged = False
+if converged:
+    ...   # else: the record simply never enters the DataFrame
+```
+
+**What input reaches this path.** `ConformerRanker` is a documented public class (aliased
+`Auto3D.ranking.ranking`) with a full constructor docstring and its own `check_output_not_input`
+/ `check_output_overwrite` guards — i.e. it is built to be called directly. Any SDF not
+produced by `batchopt.optimizing.run()` carries no `Converged` property: `opt_geometry`
+output (it writes `E_tot` but the rewrite drops nothing else), an ORCA/Gaussian export, a
+hand-built conformer set.
+
+**What the user gets instead.** A **0-byte output SDF** and `[]`. No exception, exit 0.
+
+```
+input records : 3
+returned mols : 0
+output bytes  : 0
+```
+
+**How they would find out.** Only by noticing the file is empty. The single message is
+`logger.info("No structure converged for {name}")` on the `Auto3D.*` tree, which has no
+handler unless `configure_logging` ran — and `configure_logging` is called only by
+`auto3D.main`, `cli/commands/run.py` and the legacy YAML runner, never by
+`auto3d energy/optimize/thermo` or by a direct API call. `filter_unique` and
+`filter_unique_optimized` do the same thing without even the INFO line.
+
+The docstring calls this "the lenient pattern"; the lenient outcome here is total data loss.
+
+---
+
+# MEDIUM — output differs, but only a log line says so
+
+## M1. `src/Auto3D/batch_opt/batchopt.py:276` — unparseable records dropped with no per-record message — DEMONSTRATED (mechanism) / REASONED (reachability)
+
+```python
+mols = [m for m in mols if m is not None]
+```
+
+**Input:** an input SDF containing a record RDKit cannot sanitize.
+**User gets:** for `opt_geometry`, an output SDF with fewer records than the input, the
+path returned, exit 0. Only the *all*-dropped case logs anything
+(`"No valid molecules in input file"`); individual drops are never named or counted.
+**How they'd find out:** by counting records. RDKit's own C++ parse error on stderr is
+the only trace, and it names a file offset, not a molecule.
+`SPE.calc_spe` and `ASE/thermo.iter_thermo_records` both log a per-record warning for the
+identical situation — this is the one path that does not.
+In `main()` the loss is caught downstream by `_reconcile_output` (exit 6), so the visible
+gap is `opt_geometry` / `smiles2mols`.
+
+## M2. `src/Auto3D/isomers/parallel_embed.py:48-50` + `isomer_engine.py:359-377` — the parallel embedding path is quieter than the serial one — REASONED
+
+`_embed_single` returns `[]` for an unparseable SMILES with **no** log line; the serial
+path logs `"Skipping molecule {name!r}: failed to parse {smi!r}"` (`isomer_engine.py:333`).
+`_run_parallel_embedding` also has **no** counterpart to the serial path's `n_written == 0`
+warning (`isomer_engine.py:347-357`, `"this species is absent from the output"`).
+**User gets:** the same molecules dropped, with strictly fewer diagnostics, decided by a
+switch (`use_parallel_embedding`) documented as a performance option.
+**How they'd find out:** only via `main()`'s end-of-run reconciliation.
+
+## M3. `src/Auto3D/utils/file_ops.py:649-652` + `workflow.py:604-617` — reconciliation is structurally blind to unparseable input records — REASONED
+
+`encode_ids` skips a record RDKit cannot parse (warning) so it never enters the run.
+`find_ids_not_in_sdf` then builds its expected-id list by reading **the same source SDF**
+and skipping the same record — so it is not in `source_ids`, cannot be in `failures`, and
+`_exit_if_incomplete` sees `failed_count == 0`.
+**User gets:** `auto3d run` prints a success summary and exits **0** for a run that
+processed fewer molecules than the file contains. The same blindness applies to
+`find_smiles_not_in_sdf` for `.smi` input via `iter_smi_records(on_malformed="skip")`.
+**How they'd find out:** only the "Skipping molecule at index N" warnings. The summary's
+molecule count and the exit code both assert completeness. The C7 reconciliation is
+explicitly the mechanism that is supposed to make a lost molecule visible.
+
+## M4. `src/Auto3D/workflow_workers.py:269-274` — `except Exception: … continue` drops an entire chunk — REASONED
+
+```python
+except Exception:
+    logger.exception(f"job{job} failed during optimization/ranking; "
+                     "skipping this chunk and continuing with the rest.")
+    continue
+```
+
+**Input:** any failure inside one chunk — CUDA OOM, a species-conversion bug, an
+`os.mkdir` collision on the housekeeping folder, a malformed enumerated SDF.
+**User gets:** that chunk's molecules missing from the output. Mitigated by
+`_reconcile_output` (they are named, exit 6) and by `preflight_model` (model-acquisition
+failures are moved to the parent), so the *loss* is visible.
+What is not visible is the **cause**: `logger.exception` goes to `logging.getLogger("auto3d")`,
+whose only handler in a worker is the `QueueHandler` writing `<job_dir>/Auto3D.log`. It
+never reaches stderr. A systematic bug that fails every chunk identically is therefore
+presented to the user as "N molecules produced no conformer" — the shape this sweep was
+asked to look for. (`job_directory_hint` does point at the directory.)
+
+---
+
+# LOW — bounded, documented, or a crash rather than a wrong number
+
+**L1. `ASE/thermo.py:149` — `max(1, int(...))` silently clamps a bad symmetry number, and has no upper bound.** DEMONSTRATED: `symmetry_number="0"` → sigma 1 and `"-3"` → sigma 1, both with **no warning**, while every other invalid value in this file warns; `"1000000"` → sigma 1000000 accepted unchecked, shifting Gibbs energy by RT·ln(1e6) = 8.2 kcal/mol at 298 K. `_resolve_multiplicity` two functions below bounds *and* parity-checks its property; this one does neither.
+
+**L2. `ASE/thermo.py:743` and `:772-788` — engine dispatch is case-SENSITIVE where the rest of Auto3D is case-INsensitive.** REASONED. `_load_hessian_model` tests `model_name in ("ANI2xt", "ANI2x")` and `aimnet_hessian_helper` tests `model_name == 'AIMNET'`, while `ModelFactory.create`, `resolve_engine_name`, `to_model_species` and `check_engine_supports_molecules` all fold case (verified). `calc_thermo(path, "ani2x")` / `auto3d thermo -e ani2x` passes every gate — `resolve_engine_name`'s canonicalized return value is discarded at `thermo.py:922` — then dies with `AttributeError: 'ANI2xAdapter' object has no attribute 'calculator'` at exit 1 "Unexpected Error", after model construction. `auto3d run -e ani2x` works, because `CLIConfig.to_auto3d_options`'s `engine_map` normalizes it. A crash, not a wrong number — listed because the divergence is exactly the kind that becomes a wrong number after one refactor.
+
+**L3. `ASE/thermo.py:786-788` — the custom-NNP Hessian branch bypasses `CustomModelAdapter.forward`.** REASONED. It calls `model.forward(numbers, coord, charge)` with `charge` as int64 (`torch.tensor([charge])`, `thermo.py:477`) and `coord` as float64, where the optimization half of the *same* `calc_thermo` call feeds the same model float32 coords and a float32 charge through the adapter. A custom NNP that does arithmetic on `charge`, or that is dtype-sensitive, gets two different answers in one run.
+
+**L4. `utils/chemistry.py:363-364` — `check_connectivity` has "no opinion" on 17-element-table misses.** REASONED, documented in the docstring. A dissociated M–L bond in a salt or metal complex is never flagged, so `top_k` / `filter_unique` keep a structure that has fallen apart and report it as converged with valid connectivity.
+
+**L5. `config.py` FIELD_BOUNDS + `ranking.py:156` — `k=True` silently means `k=1`.** DEMONSTRATED. `Auto3DOptions(k=True)` passes `check_field_bounds` (`operator.ge(True, 1)`), then `top_k`'s `if k == 1` is True. Harmless in effect, but `k: int | bool = False` advertises a bool where only `False` was meant to be a sentinel.
+
+**L6. `chunk_manager.py:101` vs `ASE/geometry.py:134` — `batchsize_atoms` means two different things.** REASONED. `main()` multiplies it by detected memory (`batchsize_atoms * memory_gb`), `opt_geometry` uses it absolutely. On an 80 GB card the same value is 80x apart between the two entry points. Memory/performance only.
+
+**L7. `batch_opt/optimization_engine.py:277-284` — `Converged` and `fmax` describe different geometries.** REASONED. Energy and fmax are recomputed at the final geometry after the loop; `converged_mask` (which becomes the `Converged` SD property) is not re-evaluated, so `Converged=True` describes the force *before* the last FIRE step while the reported `fmax` and coordinates describe the one after. With `v = 0` on a just-converged structure the step is `dt²·f ≤ 1e-4 Å`, so the discrepancy is numerically negligible. Recorded for completeness, not as a defect.
+
+---
+
+# Examined and NOT findings
+
+Nine constructs matched the search patterns but cannot change the output.
+
+1. **`batch_opt/model_wrapper.py:211-223`, the CUDA-OOM batch-halving recursion.** Results are appended in split order and the recursion runs in place at the failing position, so `torch.cat(e_list)` / `torch.cat(f_list)` reassemble the exact input order. The `raise OptimizationError` at batch size 1 is a real error, not a degrade. Clean.
+2. **`ASE/geometry.py:111`, `_annotate_and_rewrite`'s `if mol is None or not mol.HasProp("E_tot"): continue`.** It does silently delete records — DEMONSTRATED, 4 records in, 2 out, nothing on stdout — but its only caller feeds it `optimizing.run()`'s own output, which sets `E_tot` on every molecule and whose graphs came from an already-sanitized read (only coordinates changed, and coordinates do not affect sanitization). Neither branch is reachable in production. The reachable sibling defect is M1, one layer up.
+3. **`chunk_manager.py:110-119`, `pd.read_csv(..., dtype=str)`.** `dtype=str` does not disable pandas' default NA detection, so a SMILES field equal to any of `NA`/`nan`/`None`/`null`/`<NA>`/… is blanked and the molecule is later skipped as "missing molecule ID" — DEMONSTRATED. But none of the 19 default NA tokens is a SMILES RDKit parses (checked all 19), so only an input that was already invalid is affected. The only cost is a misleading message.
+4. **`isomer_engine.py:209-212`, `RDKitIsomer.read()` returns a dict keyed by molecule id**, so duplicate ids collapse (DEMONSTRATED: 3 lines in, 2 entries out). Unreachable — `encode_ids` rejects duplicate ids and `smiles2smi` disambiguates them before this is ever called.
+5. **`filtering.py:143-152`, `_mol_energy`.** The docstring claims a NaN energy falls back to RMSD-only comparison; it does not — `float("nan")` parses fine, so `e_i is None` is False and the pair takes the `abs(e_i - e_j) < tol` branch, which is always False for NaN, i.e. "always distinct". DEMONSTRATED. The behavior is the conservative one (keep the conformer), so this is docstring drift, not a wrong answer.
+6. **`models/adapter.py:33-39`, `_try_compile`.** Falls back from `torch.compile` to eager on any exception, with `warnings.warn`. Slower, not different. (`self._compiled = True` is set even when compilation failed — cosmetic.)
+7. **`optimization_engine.py:259/268`, `workflow_workers.py:228`, `workflow.py:510` — `except Exception: pass` around progress callbacks.** Display-only; the guarded call computes nothing the optimization consumes.
+8. **`model_factory.py:233-251`, `get_device(..., use_gpu=True)` still returns CPU when CUDA is absent.** All four call sites run `check_gpu_requested` first — verified by grep: `SPE.py:71→142`, `ASE/geometry.py:196→233`, `ASE/thermo.py:933→994`, `cli/commands/models.py:250→251` — so the M23 fallback is unreachable through them. The one path that reaches a device decision without that guard is `ASE/thermo.Calculator`, which is H1. The `gpu_idx` bounds check added to `get_device` is correct and does raise.
+9. **`ASE/thermo.py:820`, `BFGS(atoms)` with ASE's default `logfile='-'`.** Confirmed against installed ase 3.27.0: the BFGS step table goes to `sys.stdout` (102 bytes for 1 step). Not a `--json` hazard: `cli/app._ReservedStdoutCommand` wraps every command body in `reserve_stdout`, which redirects `sys.stdout` to stderr before the body runs. Python-API callers of `calc_thermo` do get step tables on stdout — noise, not a wrong answer.
+
+---
+
+# What is genuinely well-defended
+
+Recorded so a future sweep does not re-litigate it:
+
+- **`species_pad`.** `BaseModelAdapter.__init__` defaults to `-1`, `CustomModelAdapter`
+  reads `model.species_pad` directly (no `getattr` default), `validate_custom_nnp` rejects
+  a model missing it, and `pad_from_mols` returns an explicit `atom_mask` so nothing
+  derives padding from a sentinel comparison. The two-layers-disagree defect is closed.
+- **`get_device(99)`** raises `GPUError` with an in-range hint instead of returning `cuda:99`.
+- **`check_gpu_requested`** is called first at all nine sites that decide GPU use.
+- **`to_model_species`** raises on an out-of-set element for ANI2xt and passes through
+  case-insensitively for everything else (verified for Z=35 across ANI2xt / AIMNET / custom).
+- **`check_engine_supports_molecules`** rejects a charged molecule for `ANI2x`, `ani2x`
+  and `ANI2XT` alike (verified) — the C11 guard is case-insensitive.
+- **`isomer_wrapper`'s `finally: queue.put("Done")`** cannot deadlock the optimizers, and
+  it re-raises rather than swallowing.
+- **`_exit_if_incomplete` / exit code 6** makes a partial run distinguishable from a crash
+  on both the modern and the legacy CLI entry points.

--- a/.claude/review-manifests/review-2026-08-02-hunt-vacuous-tests.md
+++ b/.claude/review-manifests/review-2026-08-02-hunt-vacuous-tests.md
@@ -1,0 +1,768 @@
+# Tests that name a guarantee they do not provide
+
+Systematic sweep of the whole Auto3D test suite for tests whose name or docstring
+promises a property the assertions cannot observe.
+
+**Analysis only — no production or test file was left modified.** Every mutation below
+was either executed and reverted with a precise inverse edit, or reasoned structurally;
+each finding is labelled **VERIFIED** (mutation run, test observed green) or
+**SUSPECTED** (reasoned only).
+
+- Working tree at start: clean. At end: clean (`git diff` empty, `git status --porcelain` empty).
+- Branch: `phase9/cli-api-parity` (the task named `main`; `main` is the merge base).
+- Scope: 69 test files, 1121 collected tests, **66 slow-marked**. All 69 files were read.
+- All 69 files received an exhaustive pass. Mutations against the optimizer/model-loading
+  group were executed on an `rsync` scratch copy rather than in-tree; the repository was
+  never modified for that group.
+- Box rules honoured: `pytest -m slow` was never run; no NNP was loaded; no model download
+  was triggered. Slow tests were analysed by reading, by `pytest -m slow --collect-only`,
+  and by replaying their exact assertions against synthesised inputs.
+
+**Concurrency note.** Mutations to `src/Auto3D/cli/console.py` and
+`src/Auto3D/utils/chemistry.py` were live for about a minute during this sweep. A
+concurrent session's report (`.superpowers/analysis/hunt-silent-fallbacks.md`) records
+seeing exactly those two `# MUTATION` markers and attributes them to "another agent's
+in-flight mutation run". They were mine, they are fully reverted, and that report states
+they did not affect its conclusions.
+
+---
+
+## Counts
+
+| Tier | Meaning | Count |
+|---|---|---|
+| **1 — Load-bearing** | A real guarantee named by the test is entirely unpinned, and nothing else pins it | **45** |
+| **2 — Real but narrower** | Vacuous as written; partly compensated by a sibling test | **49** |
+| **3 — Weak/degenerate** | Assertion is unfalsifiable or the input cannot exercise the feature | **24** |
+| **Total findings** | | **118** |
+| *Modules examined and cleared* | | **21** |
+
+Plus **3 non-test defects** surfaced while checking these (§ Adjacent defects).
+
+**Headline:** of the 66 slow-marked tests, **24 (36%) contain no assertion at all** — 19
+in `test_auto3D.py`, 5 in `test_thermo.py`. They are the most expensive tests in the
+project (full NNP pipelines on CPU in CI) and can only ever catch an exception.
+
+---
+
+# Tier 1 — load-bearing
+
+## Pipeline and chemistry correctness
+
+### 1. `tests/test_pipeline_e2e.py:147` — the precondition added to make the test non-vacuous is itself vacuous — **VERIFIED**
+
+`test_one_bad_molecule_does_not_remove_the_others` asserts `assert "sodium_acetate" not in produced`.
+`produced` is built at line 128 as `m.GetProp("_Name").split("_")[0]`. The pipeline's final
+`_Name` is the **original input id** (`decode_ids`, `workflow.py:569`, runs after ranking's
+`species_id` strip) — literally `sodium_acetate` — and `split("_")[0]` yields `"sodium"`.
+**The string `"sodium_acetate"` can never appear in `produced`.**
+
+The docstring (lines 133-146) presents this exact line as what rescues the test from
+vacuity: *"A test for 'one failure does not cascade' has to establish that a failure
+happened."* It does not. This is the same `split("_")[0]` bug already fixed **in
+production** — `ranking.species_id` was deliberately changed to `rsplit("_", 2)[0]`
+(`ranking.py:20-50`; see also the comment at `tests/test_config_parity.py:505`). The test
+file still uses the buggy idiom at lines 71, 128, 212, 235.
+
+**Mutation:** none needed — the very defect the assertion's message describes ("the model
+returned a number for an element it does not implement") leaves it green. Reproduced:
+
+```
+output SDF _Name values : ['ethanol', 'propanol', 'sodium_acetate', 'benzene']
+test's `produced` set   : ['benzene', 'ethanol', 'propanol', 'sodium']
+line 147 assertion: PASSES  <-- VACUOUS
+=> whole test stays GREEN under the mutation.
+```
+
+### 2. `tests/test_thermo.py:259, 267, 275, 303, 317` — five slow tests with zero assertions — **VERIFIED**
+
+`test_opt_geometry1`…`5` call `opt_geometry(..., opt_steps=5000)` against a real NNP, then
+`try: os.remove(out) except OSError: pass`. No assertion of any kind, and
+`FileNotFoundError` ⊂ `OSError`, so a **missing output file** is swallowed too.
+
+**Mutation:** make `opt_geometry` a no-op returning a path it never wrote. Replaying the
+verbatim bodies: `test_opt_geometry1/2/3: PASSES`. The sibling
+`test_opt_geometry_with_patience_and_batchsize` asserts only `os.path.exists(out)`.
+Optimisation returning the input geometry unchanged is invisible to all six.
+
+### 3. `tests/test_auto3D.py:136-372` — nineteen slow tests with zero assertions — **VERIFIED**
+
+Every test is `main(args)` followed by directory cleanup. 19 of the module's 20 slow tests
+assert nothing. The docstrings are honest (*"Check that the program runs"*) but the
+**names** claim engine-combination coverage (`test_auto3D_rdkit_ani2xt`,
+`test_auto3D_sdf_omega_aimnet`, `test_auto3D_userNNP2`, …).
+
+**Mutation:** emit the unoptimized embedded geometry with an arbitrary `E_tot` — all
+nineteen stay green. Only `_finalize_output`'s zero-output guard stands between these
+tests and total silence.
+
+### 4. `tests/test_thermo_helpers.py:164` — isotope-mass guard tested only where it cannot matter — **VERIFIED**
+
+`test_unlabeled_species_uses_ordinary_masses` probes `Chem.AddHs(MolFromSmiles("C#N"))`.
+
+**Mutation:** delete the guard in `mol2atoms` (`src/Auto3D/ASE/thermo.py:426`) so the
+RDKit-mass path always runs. C, N and H are exactly the elements where RDKit and ASE masses
+are byte-identical:
+
+```
+C  ase=12.011000  rdkit=12.011000        S   ase=32.060000  rdkit=32.067000  <-- DIFFERS
+N  ase=14.007000  rdkit=14.007000        Cl  ase=35.450000  rdkit=35.453000  <-- DIFFERS
+H  ase=1.008000   rdkit=1.008000         P/F/Se/Si/I                          <-- DIFFER
+```
+
+Masses feed moments of inertia and the rotational partition function, so the guard is
+load-bearing for most of AIMNet2's element set.
+
+### 5. `tests/test_isomer_engine.py:51` — conformer-diversity check passes on empty output — **VERIFIED**
+
+`test_rd_isomer_class` asserts `rmsd_greater(mols, threshold) == True` with no
+non-emptiness check. `rmsd_greater` is a nested loop returning `True` when it never runs:
+`rmsd_greater([]) -> True`, `rmsd_greater([one]) -> True`.
+
+**Mutation:** make `rd_isomer.run()` write an empty SDF, or emit one conformer per species.
+Green, with RMSD pruning entirely absent.
+
+### 6. `tests/test_ranking.py:172` — top-k can ignore k — **VERIFIED (agent)**
+
+`test_top_k_with_optimized_filtering` (k=2) asserts only `len(results) <= 2`.
+
+**Mutation:** `ranking.py:165` `out_mols = out_mols_[:k]` → `out_mols_[:1]`. **The entire
+`test_ranking.py` stays green (18/18)** while top-k silently returns one conformer for
+every request.
+
+### 7. `tests/test_ranking.py:341` — the energy window is never applied — **VERIFIED (agent)**
+
+`test_top_window_with_optimized_filtering` builds mol3 explicitly "outside the window" and
+asserts only `len(results) >= 1`.
+
+**Mutation:** delete the `if rel_energy <= window: … else: break` filter in `top_window`
+(`ranking.py:216-220`) and append everything. Green — including the conformer 5 kcal/mol
+outside a 1 kcal/mol window. The entire purpose of `top_window` is unpinned.
+
+### 8. `tests/test_ranking.py:530` — the unit label is a tautology — **VERIFIED (agent, confirmed by inspection)**
+
+`test_output_has_labeled_energy_unit` asserts
+`mol.GetProp("E_tot(Hartree)") == mol.GetProp("E_tot")`. But `ranking.py:297` sets
+`E_tot(Hartree)` by **copying** `E_tot`, so the assertion holds in whatever unit `E_tot`
+happens to be.
+
+**Mutation:** delete the eV→Hartree conversion at `ranking.py:294`. Green, with the output
+labelled "Hartree" while carrying eV — exactly the misread the comment says the label
+exists to prevent.
+
+### 9. `tests/test_ranking.py:202` — "skips RMSD filtering" is unobserved — **VERIFIED (agent)**
+
+`test_top_k_equals_1_skips_rmsd_filtering`. **Mutation:** delete the whole `if k == 1:`
+fast path (`ranking.py:156-161`). The whole file stays green — no spy or counter observes
+whether `_filter_mols` ran.
+
+### 10. `tests/test_ranking.py:40, 97, 140` — optimized-vs-legacy filtering — **VERIFIED (agent)**
+
+`test_ranker_with_optimized_filtering_default` asserts only that the constructor stored the
+flag; `test_ranker_optimized_vs_legacy_produce_same_results` compares two paths that a
+one-line mutation makes literally the same code; `test_energy_cluster_window_parameter`
+asserts `len(results) >= 1`.
+
+**Mutation:** delete the `if self.use_optimized_filtering:` branch in `_filter_mols`
+(`ranking.py:126-133`). All three green.
+
+### 11. `tests/test_config_parity.py:597` — the parity test compares half the fields — **VERIFIED (agent)**
+
+`test_valid_config_agrees_across_entry_points` compares 12 of 24 fields. `use_gpu`,
+`gpu_idx`, `path`, `enumerate_tautomer`, `tauto_engine`, `pKaNorm`, `isomer_engine`,
+`enumerate_isomer`, `mode_oe`, `allow_tf32`, `verbose`, `job_name` are never compared.
+
+**Mutation:** delete `use_gpu=self.use_gpu,` and `gpu_idx=self.gpu_idx,` from
+`CLIConfig.to_auto3d_options` (`cli/config_schema.py:238-239`). Green (and all of
+`test_cli_config_schema.py` too) while a config saying CPU silently runs on GPU — precisely
+the entry-point divergence the class exists to forbid.
+
+### 12. `tests/test_ase_torch_config.py:7, 24` — asserts a value the test just set — **VERIFIED (agent)**
+
+The test sets both TF32 flags to `True`, reloads the module, and asserts they are `True`.
+Only an override *to False* is detectable.
+
+**Mutation:** add `configure_torch(TorchConfig(allow_tf32=True))` at module scope in
+`ASE/thermo.py` / `geometry.py`. Both green, while importing the module hard-enables TF32
+process-wide — dropping FP32 matmul to a 10-bit mantissa for every importer.
+
+### 13. `tests/test_isomer_engine_hardening.py:108` — read-back goes through the test's own stub — **VERIFIED (agent)**
+
+`test_sdf_run_skips_none_record`'s readback at line 131 runs while
+`monkeypatch.setattr(Chem, "SDMolSupplier", FakeSupplier)` is still active, so it returns
+the fake's `[valid, None]`, never the file. (The sibling
+`test_calc_spe_skips_none_and_aligns_indices` calls `monkeypatch.undo()` first; this one
+does not.)
+
+**Mutation:** delete `writer.write(mol2, confId=conf.GetId())` in `RDKitSdfIsomer.run`
+(`isomer_engine.py:532`). Verified: `out.sdf` is 0 bytes, `len(written) == 2`, test green.
+
+### 14. `tests/test_utils_file_ops.py:888` — same shape, in `decode_ids` — **VERIFIED (agent)**
+
+`test_decode_ids_skips_none_records` monkeypatches `file_ops.Chem.SDMolSupplier`; `Chem` is
+the shared module object, so `count_sdf(out)` at line 908 also hits the stub.
+
+**Mutation:** delete `w.write(mol)` in `decode_ids` (`utils/file_ops.py:716`). With the
+output truncated to 0 bytes, `count_sdf(out)` still returns `1`. (The "does not raise
+`AttributeError`" half *is* genuinely exercised.)
+
+### 15. `tests/test_cli_security.py:144` — the parametrized expected message is never used — **VERIFIED**
+
+```python
+@pytest.mark.parametrize("content,expected", [("", "empty"), ("- a\n- b\n", "mapping"), ("k: [1, 2\n", "not valid YAML")])
+def test_bad_config_exits_2_with_a_message(self, tmp_path, content, expected):
+    assert result.exit_code == 2
+    assert "Unexpected Error" not in result.output
+    assert "AttributeError" not in result.output
+```
+
+`expected` is declared and **never referenced**. The name promises "with a message"; none is
+checked. **Mutation:** collapse all three raise sites in `load_yaml_config`
+(`cli/config_schema.py:316-335`) to a single `raise ConfigurationError("bad config")`.
+
+### 16. `tests/test_cli_commands_config.py:15` — the preset guard checks the wrong dict — **VERIFIED (agent)**
+
+`test_no_preset_sets_both_k_and_window` inspects the raw `PRESETS` entries, never the
+`DEFAULT_CONFIG | preset` merge that `execute_config_init` actually writes.
+
+**Mutation:** change `PRESETS["thorough"]` (`cli/commands/config.py:54-64`) to
+`{"window": 5.0, "opt_steps": 5000}`. This test and `test_config_init_preset_enum_valid`
+both stay green, but `auto3d config init -p thorough` then writes `k: 5` **and**
+`window: 5.0`, and loading that generated file raises
+`ConfigurationError: Only one of k or window may be specified`.
+
+### 17. `tests/test_isomer_engine_hardening.py:205` — the test calls neither path it compares — **VERIFIED (agent)**
+
+`test_smiles_and_sdf_paths_agree` reduces to
+`calculate_conformer_count(AddHs(g)) == calculate_conformer_count(AddHs(AddHs(g)))`;
+`AddHs` is idempotent, so this is `f(m) == f(m)`.
+
+**Mutation:** `isomer_engine.py:509` `calculate_conformer_count(mol2)` →
+`calculate_conformer_count(mol)`, reinstating exactly the SMILES-vs-SDF divergence the test
+names. Green.
+
+### 18. `tests/test_parallel_embed.py:157, 166` — the error boundary is never entered — **VERIFIED (agent)**
+
+Both tests use SMILES that `Chem.MolFromSmiles` rejects, so `_embed_single` returns `[]` via
+its own early guard and never raises; the parent's `except Exception` is never reached.
+
+**Mutation:** delete the whole `except Exception` block
+(`isomers/parallel_embed.py:132-138`). Both green — the per-molecule error boundary,
+including the `Boost.Python.ArgumentError` case its comment calls out, is unpinned.
+
+### 19. `tests/test_parallel_embed.py:53` — clash filtering never fires — **VERIFIED (agent)**
+
+`test_embed_single_filters_invalid_conformers` asserts only `positions.shape[0] > 0`. Butane
+embeds 3 conformers and all 3 survive `relieve_clash`, so the branch is never taken.
+
+**Mutation:** make the append at `isomers/parallel_embed.py:72` unconditional. Green.
+
+### 20. `tests/test_utils_chemistry.py:353` — "returns None for invalid" asserts nothing — **VERIFIED (mutation run)**
+
+The body ends on the comment *"The function should handle this appropriately"*. No assertion.
+
+**Mutation:** `return mol` as the first statement of `amend_mol`
+(`utils/chemistry.py:381`) — `check_valid` ignored, `None` never returned. Ran it: the
+target test passes **and all 48 tests in the file pass**. No other test references
+`amend_mol`, and it has no production callers.
+
+### 21. `tests/test_utils_chemistry.py:167, 184, 506` — RMSD and dedup unfalsifiable — **VERIFIED (agent)**
+
+- `:167 test_different_conformers` ("RMSD > 0") asserts `rmsd >= 0`; `get_rmsd` returns a
+  non-negative float or `inf`. **Mutation:** `chemistry.py:285` → `rmsd = 0.0`. Green.
+  (The real RMSD is 0.9532.)
+- `:184 test_remove_hs_option` compares a molecule to its exact copy, so both branches return
+  0.0. **Mutation:** delete the `if remove_hs:` branch (`chemistry.py:278-283`). Every test
+  in `TestGetRmsd` stays green.
+- `:506 test_filter_different_conformers` asserts `len(unique_mols) >= 1`; the property it
+  names is **already false** (`filter_unique` returns 1 for that input) and it is green anyway.
+
+### 22. `tests/test_utils_stereochemistry.py:233, 288, 304` — stereo transforms can be no-ops — **VERIFIED (agent)**
+
+- `:233 test_remove_enantiomers_basic` asserts `"mol" in result` and `len(lines) >= 1`.
+  **Mutation:** `stereochemistry.py:235` `new_values = enantiomer_helper(values)` →
+  `new_values = values`. Green with both enantiomers written.
+- `:288 test_amend_configuration_complete` asserts only `"mol" in result`, which the grouping
+  loop produces before any amendment. **Mutation:** delete the whole amendment block
+  (`stereochemistry.py:484-508`). Green.
+- `:304 test_amend_configuration_w_writes_file` asserts `len(lines) >= 1` on a file that
+  already had one line. **Mutation:** `return` as the first statement of
+  `amend_configuration_w` (`stereochemistry.py:528`). Green.
+
+### 23. `tests/test_chemistry.py:62` — heavy-atom filter removable — **VERIFIED (agent)**
+
+`test_calculate_conformer_count_molecule_with_hydrogens`'s comment says "should count only
+heavy atoms (C, C, O = 3)"; the assertion is `count >= 3`.
+
+**Mutation:** delete the heavy-atom filter at `utils/chemistry.py:88`. **All 7 tests in the
+file stay green** while this molecule's count silently goes 3 → 16.
+
+### 24. `tests/test_thermo_helpers.py:243` — asserts the signature default, not the value used — **SUSPECTED (agent)**
+
+`test_do_mol_thermo_default_temperature_is_298_15` asserts only
+`inspect.signature(do_mol_thermo).parameters["T"].default == 298.15`.
+
+**Mutation:** insert `T = 500.0` as the first statement of `do_mol_thermo`'s body
+(`ASE/thermo.py:618`). Green, while every enthalpy/entropy/Gibbs number in the package is
+computed at 500 K. The only test that drives `do_mol_thermo` asserts `G_hartree` *exists*,
+never its value or `T_K`. Nothing else in `tests/` pins the effective temperature.
+
+---
+
+# Tier 2 — real but narrower
+
+### Pipeline / thermo
+25. **`tests/test_pipeline_e2e.py:222`** — `test_top_k_returns_distinct_conformers` never checks distinctness. Both assertions (`len<=3`, `energies[0]==min`) are structurally guaranteed by the sort at `ranking.py:150` and the slice at `:165`. **Mutation:** `out_mols_ = list(df2["mols"])` (no RMSD dedup). *SUSPECTED.*
+26. **`tests/test_thermo_reference.py:35`** — `any(m.HasProp("G_hartree") …)` cannot tell "skipped" from "aborted". **Mutation:** `ASE/thermo.py:847` `continue` → `break`; ethanol still has `G`, propanol and everything after it silently vanish. `all(...)` would pin it. *SUSPECTED.*
+27. **`tests/test_thermo_reference.py:72`** — backstop `all(HasProp("G_hartree") or HasProp("Thermo_failed"))` is satisfied by total failure. **Mutation:** make `do_mol_thermo` always set `Thermo_failed` and never compute `G`. *SUSPECTED.*
+28. **`tests/test_workflow.py:265`** — `assert "empty" in caplog.text`, but the fixture file is named `empty.sdf` and the warning echoes the path. **Mutation:** collapse the two guards at `batch_opt/batchopt.py:266-271` so an empty file is misdiagnosed as missing. *VERIFIED (agent, live capture).*
+29. **`tests/test_workflow.py:740`** — asserts module-attribute identity, not the call site. **Mutation:** add a private reimplementation and call it instead. *SUSPECTED, low.*
+
+### Isomer / tautomer
+30. **`tests/test_isomer_engine.py:96`** — `test_SDF2chunks` asserts only the chunk **count**. **Mutation:** `file_ops.py:547` `chunks.append(chunk)` → `chunks.append([])`; reproduced: `len(chunks)=2 == count_sdf=2` with *0 lines per chunk*. *VERIFIED.*
+31. **`tests/test_isomer_engine.py:176`** — `test_rd_isomer_parallel_embedding_threshold` asserts back the two constructor kwargs and never calls `run()`, where the threshold is read (`isomer_engine.py:313-316`). **Mutation:** `use_parallel = bool(self.use_parallel_embedding)`. Ran the verbatim body: PASSES. *VERIFIED.*
+32. **`tests/test_isomer_engine.py:99, 143`** — neither observes which embedding branch ran. **Mutation:** always call `_run_serial_embedding`. *SUSPECTED.*
+33. **`tests/test_isomers.py:235`** — constructor-kwarg echo; `run()` never called. **Mutation:** drop the three parallel kwargs from the `RDKitIsomer(...)` construction in `isomers/rdkit_adapters.py:82-84`, so parallel embedding can never be enabled through the factory. *SUSPECTED (agent).*
+34. **`tests/test_isomers.py:172, 273`** — both `test_engine_type_case_insensitive` tests pass `"UNKNOWN"` and assert the constant error prefix, which is emitted whether or not the input was lowercased. **Mutation:** delete `engine_type = engine_type.lower()` (`isomers/factory.py:109` and `:270`). Green everywhere — every other caller passes lowercase. *VERIFIED (agent).*
+35. **`tests/test_isomer_engine_hardening.py:141`** — the warning assertion sits inside `if len(isomers) == 1024:`; the probe returns 4096, so it is dead code. **Mutation:** delete the `MAX_STEREOISOMERS` warning block (`isomer_engine.py:231-235`). *VERIFIED (agent).*
+36. **`tests/test_isomer_engine_hardening.py:221`** — the "…and paths agree" half of the name is untested (no embed path invoked). *SUSPECTED (agent).*
+37. **`tests/test_parallel_embed.py:41`** — `test_embed_single_with_dynamic_conformers` asserts `len(results) >= 1`. **Mutation:** `parallel_embed.py:58` → `n_conformers = 1`. Green. *VERIFIED (agent).*
+38. **`tests/test_tautomer_select.py:9`** — docstring says "keep **top**-k per id", but the fixture is already in ascending-energy order and `_Name` is overwritten with the group name. **Mutation:** delete `group = group.sort_values(by="energy")` (`tautomer.py:77`). Green. This is the only *fast* test of `select_tautomers`. *VERIFIED (agent).*
+39. **`tests/test_stereo_identity.py:99`** — `assert not mixed` is structurally unfalsifiable for a single-stereocenter input, and the `except ValueError: return` has no `match=`, so any unrelated `ValueError` reads as "explicit refusal". **Mutation:** truncate `RDKitSdfIsomer.stereoisomers()` to its first element — byte-identical output here, 3 of 4 diastereomers silently dropped for any two-centre molecule. *VERIFIED (agent).* (Not fully vacuous: disabling enumeration entirely does turn it red.)
+
+### CLI
+40. **`tests/test_cli_console.py:37, 44`** — `test_print_error` ("should output to **stderr**") and `test_print_warning` assert nothing. **Mutation:** `return` as the first statement of both (`cli/console.py:241, 250`). Ran it: **all 5 tests in the file pass, and `tests/test_cli.py` (23 tests) passes** with both helpers emitting nothing. *VERIFIED.*
+41. **`tests/test_cli_console.py:25`** — `test_print_success` ("green checkmark") asserts only the message substring; dropping `[green]✓[/green]` stays green. It also permanently sets `console._force_terminal = False` on the module singleton, leaking into every later test. *VERIFIED (agent).*
+42. **`tests/test_cli_console.py:15`** — `test_console_auto_detects_tty`: the `monkeypatch` of `sys.stdout.isatty` is inert under pytest capture, and the assertion is a disjunction that survives deleting the detection block. Passes here, would go **red on CI** where `FORCE_COLOR` makes Rich report `is_terminal=True`. *VERIFIED (agent).*
+43. **`tests/test_cli_results.py:66`** — `test_print_failures_empty` asserts nothing. **Mutation:** delete the `if not failures: return` guard (`cli/results.py:87-88`). Ran it: **all 9 tests in the file pass**, while every clean run now prints `Warning: 0 molecules failed`. *VERIFIED.*
+44. **`tests/test_cli_results.py:74, 83, 49`** — three more "does not crash" tests. Deleting the whole `if verbose:` table branch, replacing `output_json`'s body with `emit_json({})`, and replacing `print_results_summary`'s body with `pass` each stay green. *VERIFIED (agent).* (Partly compensated by `test_cli_exit_codes.py` and `test_cli_app.py::test_json_output_is_pure_json`.)
+45. **`tests/test_cli_app.py:32`** — `test_version_works` asserts only `exit_code == 0`, which comes from `raise typer.Exit()` independently of the print. **Mutation:** delete the `console.print` in `version_callback` (`cli/app.py:186-190`). *VERIFIED.*
+46. **`tests/test_cli_app.py:40` and `tests/test_cli.py:103`** — both assert `"--config" in out or "-c" in out`. Reproduced: the tokens containing `-c` are `['--config', '--max-confs', '-c']`. **Mutation:** delete the `-c/--config` option — `--max-confs` still supplies the substring. *VERIFIED.*
+47. **`tests/test_cli.py:137`** — `test_models_subcommand_help` asserts `"info" in out`. **Mutation:** delete `@models_app.command("info")`; the group's own help line "Neural network model **info**rmation." keeps it green. *VERIFIED (agent).*
+48. **`tests/test_cli.py:75`** — `test_new_cli_help` asserts `"run" in out`. **Mutation:** delete the entire `run` command; `validate`'s description "…without **run**ning optimization." keeps it green. *VERIFIED (agent).*
+49. **`tests/test_cli.py:150`** — `test_validate_subcommand_help` ("should show options") asserts only `exit_code == 0`. **Mutation:** delete every option from `validate`. *VERIFIED (agent).*
+50. **`tests/test_cli_app.py:295`** — `test_config_init_invalid_preset` asserts `exit_code == 2` and `"quick" in output`. Changing the `Preset` enum annotation to plain `str` routes to the fallback guard (`cli/commands/config.py:134-138`), which also exits 2 with a hint containing "quick". The two-paths-same-integer trap. *SUSPECTED (agent).*
+51. **`tests/test_cli_property_commands.py:206`** — `test_run_rejects_when_gpu_requested_without_cuda`'s docstring claims the refusal comes from `check_valid_configuration` "before any worker is forked". **Mutation:** delete `check_gpu_requested(use_gpu)` from `check_valid_configuration` (`utils/validation.py:581`) — still exit 4, still the same message, because `check_input` (`validation.py:315`) raises the identical `GPUError`. The three sibling GPU tests add `m.assert_not_called()`; this one does not. *VERIFIED (agent).*
+52. **`tests/test_cli_app.py:982, 118`** — `"Pd" in stdout` is satisfied by three other lines of the panel; `"B"` is satisfied by "**B**est for organic molecules". **Mutation:** remove `Pd` from the element set / replace the AIMNET element list. *VERIFIED (agent).*
+53. **`tests/test_cli_security.py:109, 115`** — `match="must contain a YAML mapping"` is also contained in the **empty-file** message (`cli/config_schema.py:327-330`), so `match=` cannot distinguish the two guards. **Mutation:** delete the `if not isinstance(data, dict)` branch and widen the empty-file guard. *SUSPECTED (agent).*
+54. **`tests/test_progress.py:78`** — `test_display_empty_jobs_is_noop` constructs `OptimizationDisplay(0)`, whose constructor already zeroes every field, then asserts zeros. **Mutation:** delete the `if not jobs: return` guard (`cli/progress.py:62-63`). Green. The no-op property is only observable from a non-zero start. *VERIFIED (agent).*
+55. **`tests/test_public_api.py:10`** — `test_all_public_names_resolve` iterates the very `__all__` it claims to lock. **Mutation:** delete 8 names from `__all__` (`Auto3D/__init__.py:35-54`) — the whole file stays green. Nothing anywhere pins the *contents* of `Auto3D.__all__`. *VERIFIED (agent).*
+56. **`tests/test_cli.py:90`** — `test_new_cli_version` compares the CLI's output against the same attribute the CLI printed. **Mutation:** hardcode any `__version__`. Green. *See adjacent defect 3 — this is live right now.* *VERIFIED (agent).*
+
+### Config / validation / model
+57. **`tests/test_model_factory.py:33`** — `test_create_unknown_model_raises_error`'s docstring states the contract exactly ("no longer raise a `ValueError` up front"); the assertion is bare `pytest.raises(Exception)`. **Mutation:** restore the pre-fix guard at `model_factory.py:159`. Ran it: **all 21 selected tests in the file pass** with the regression back in place. *VERIFIED.*
+58. **`tests/test_config.py:142`** — `test_chunk_meta_structure`: `TypedDict` is not enforced at runtime; the test builds a plain dict (already missing 6 of 11 declared keys) and asserts values it just set. **Mutation:** `class ChunkMeta(TypedDict): pass`. *VERIFIED (agent).*
+59. **`tests/test_config.py:128`** — `test_immutable_default_list` never touches a list; it is a verbatim duplicate of `test_default_values`. **Mutation:** give `gpu_idx` a genuinely shared mutable default. Green (caught only by a differently-named test). *VERIFIED (agent, by inspection).*
+60. **`tests/test_utils_validation.py:196`** — `test_filter_unique_custom_threshold` asserts `len(strict) >= len(lenient)`, trivially true when equal. **Mutation:** make `filter_unique` ignore `crit`. *VERIFIED (agent).*
+61. **`tests/test_utils_chemistry.py:561`** — same shape: `unique_mols_small` is computed and discarded. *VERIFIED (agent).*
+62. **`tests/test_validation_errors.py:175`** — `test_multiple_valid_molecules` asserts only `isinstance(..., bool/list)`, guaranteed by the return type. **Mutation:** `break` after the first record in `check_sdf_format` (`utils/validation.py:493-508`) — records 2..n are never validated. *SUSPECTED (agent).*
+
+---
+
+# Tier 3 — weak / degenerate inputs
+
+63-82. Assertions that cannot fail, or inputs that cannot exercise the named feature.
+Ranked lower because each is either compensated by a sibling test or names only what it
+delivers:
+
+- `tests/test_utils_chemistry.py:372` `test_amend_mol_with_sanitize` — input is already sanitized; only `is not None`. **Mutation:** delete `if sanitize: Chem.SanitizeMol(mol)`.
+- `tests/test_utils_chemistry.py:427` `test_include_bond_order` — the bond-order assertion is inside `if len(bond_info) == 3:`, false exactly when the feature is broken.
+- `tests/test_utils_chemistry.py:386` — `assert (0,1) in c or (1,0) in c` explicitly accepts either ordering, so the documented `atom1_idx < atom2_idx` sort is pinned nowhere.
+- `tests/test_utils_stereochemistry.py:262` — the two achiral molecules have different IDs, so they land in separate groups and are never compared.
+- `tests/test_utils_stereochemistry.py:338` — `MolFromSmiles(result) is not None`; a `create_enantiomer` that creates nothing passes (caught by a sibling).
+- `tests/test_chemistry.py:37` — methane has exactly 1 heavy atom, so `count >= 1` is satisfied by the `max(1, …)` floor alone.
+- `tests/test_isomer_engine_hardening.py:199` — `[C]` has `num_heavy=1`; the literal `1` in `max(1, num_heavy, …)` is redundant here.
+- `tests/test_isomer_engine_hardening.py:180` — imports nothing from Auto3D; passes with the package deleted. Docstring is honest ("Sanity:"), so it is a documented premise-check.
+- `tests/test_cli_config_schema.py:8` — `assert CLIConfig is not None` cannot fail once the import succeeds. **Mutation:** `class CLIConfig: pass`.
+- `tests/test_padding_invariance.py:37` — `atol=1e-3` for ANI2xt while the same comment states float32 ULP is ~4e-3 eV. Not vacuity — the opposite — but a latent CI flake.
+- `tests/test_species_conversion.py:19` — module-level `importorskip("torchani")` gates `test_pad_from_mols_emits_indices_for_ani2xt`, which needs no torchani at all (`batch_opt/padding.py` imports only torch/rdkit). It also carries `@pytest.mark.slow`, so the one fast, model-free assertion in the file never runs in the fast gate.
+- Plus the remaining low-severity items in `test_ranking.py`, `test_cli_app.py` and `test_parallel_embed.py` already enumerated above.
+
+---
+
+# Tier 1 (continued) — filtering, chunking, processors, custom-NNP contract
+
+Every mutation in this block was executed against the real tests.
+
+### 25. `tests/test_filtering.py:134, 157, 176` — energy clustering is entirely unpinned — **VERIFIED**
+
+`test_energy_clustering_groups_similar_energies`,
+`test_single_cluster_energy_guard_keeps_distinct_energies` and
+`test_small_energy_window_creates_separate_clusters` claim that clustering groups/separates
+conformers and that `energy_cluster_window` controls it — the whole reason
+`filter_unique_optimized` exists (O(n·k) instead of O(n²)).
+
+**Mutation:** delete the entire clustering block (`src/Auto3D/filtering.py:61-73`) and
+replace with `clusters = [valid_mols]`, so `energy_cluster_window` is never read.
+**All 18 tests in the file still pass** — the per-pair `energy_tol` guard reproduces every
+expected count on its own, so no test distinguishes "clustered" from "one big cluster".
+
+### 26. `tests/test_filtering.py:272` — the incomparable-pair fallback is not what keeps them — **VERIFIED**
+
+`test_rmsd_failure_keeps_both` claims to pin the `except RuntimeError → rmsd = inf` fallback.
+
+**Mutation:** `filtering.py:123` `rmsd = float("inf")` → `rmsd = 0.0` — treating an
+incomparable pair as a *perfect duplicate*, the exact pre-fix bug named in the sibling
+docstring at `tests/test_utils_chemistry.py:625`. **All 18 tests still pass**: the test's two
+mols have energies −1.0 / −0.9, so `abs(dE)=0.1 ≫ DEFAULT_DUPLICATE_ENERGY_TOL (0.01)` and
+the *energy* guard keeps both. Giving them equal `E_tot` would make the test bite.
+
+### 27. `tests/test_filtering.py:71` — RMSD dedup is pinned by exactly one test, and not the one named for it — **VERIFIED**
+
+`test_different_conformers_returns_both` asserts `len(result) >= 1`, satisfied by 1 *or* 2.
+Neither mol carries `E_tot`, so `energy_close` is unconditionally True.
+
+**Mutation:** `filtering.py:131` `if rmsd < rmsd_threshold and energy_close:` →
+`if energy_close:`. This test passes and **17 of 18 tests in the file pass** — only
+`test_filter_within_cluster_removehs_is_linear_and_nondestructive` (line 225) catches it,
+incidentally. The module's headline behaviour is pinned by one unrelated test.
+
+### 28. `tests/test_chunk_manager.py:127, 149, 174, 194, 215, 240, 327` — chunk **content** is never read — **VERIFIED**
+
+Every assertion in `TestCreateChunkFiles` / `TestPrepareChunks` is a count, a suffix, or an
+`exists()`. Even `test_prepare_chunks_reads_ragged_smi` only counts non-blank lines.
+
+**Mutation:** `chunk_manager.py:170`
+`df_chunk = df.iloc[chunk_idxes[i], :]` → `df.iloc[[chunk_idxes[i][0]] * len(chunk_idxes[i]), :]`
+(write the first row repeated, discarding every other molecule) **and** line 176 →
+`chunk_path.write_text("")` (SDF chunks emptied). **All 17 tests still pass.**
+`tests/test_workflow.py:119, 164` repeat the same count-only shape, so it is not covered
+there either. This is the same shape as finding 30 (`SDF2chunks`), one layer up.
+
+### 29. `tests/test_processors.py` — the tautomer-ID hashing step has zero coverage — **VERIFIED**
+
+`TautomerProcessor.process` creates and runs the engine, **hashes the tautomer IDs**, and
+returns the output path. Line 96 monkeypatches `hash_taut_smi` to a no-op and never asserts
+it was called.
+
+**Mutation:** delete `hash_taut_smi(output_path, output_path)` (`src/Auto3D/processors.py:53`).
+**All 6 tests still pass.** `hash_taut_smi` itself is tested in `test_utils_file_ops.py`, but
+nothing pins that the processor calls it — and `TautomerProcessor` appears only in this file.
+
+### 30. `tests/test_custom_nnp_contract.py:411` — deleting a guard turns rejection into silent acceptance — **VERIFIED**
+
+`test_validate_custom_nnp_is_callable_directly` claims the validator is "the single owner of
+the contract" for duck-typed objects. Both its stubs define `forward`, so the "no forward at
+all" branch is never exercised on a non-Module.
+
+**Mutation:** delete the `if forward is None: raise ModelLoadError(...)` guard
+(`src/Auto3D/models/contract.py:157-162`). `inspect.signature(None)` then raises `TypeError`,
+which the `except (ValueError, TypeError): return` at line 166 **swallows → silent accept**.
+All 23 tests still pass. A deleted guard becoming an accept is the worst direction.
+
+### 31. `tests/test_custom_nnp_contract.py:364` — the test names the regression and cannot detect it — **VERIFIED**
+
+`test_adapter_keeps_no_padding_fallback_of_its_own`'s docstring states explicitly that the
+`getattr(model, 'species_pad', -1)` fallback must not re-grow. The test only ever observes
+`coord_pad`, which is read *first* and raises first.
+
+**Mutation:** `src/Auto3D/models/adapter.py:443` `model.species_pad` →
+`getattr(model, "species_pad", -1)` — the exact regression the docstring says it is pinning.
+All 23 tests pass: `match="coord_pad"` is satisfied by the earlier access, and both
+acceptance stubs happen to have `species_pad == -1`.
+
+### 32. `tests/test_custom_nnp_eager.py:68` — the `double=False` side is never checked — **VERIFIED**
+
+`test_load_custom_nnp_eager_and_double` claims "the shared loader returns an eager
+`nn.Module`; **`double=True`** casts to fp64". `assert isinstance(m, torch.nn.Module)` is
+unfalsifiable (the function returns an `nn.Module` or raises).
+
+**Mutation:** `src/Auto3D/models/loading.py:72`
+`return model.double() if double else model` → `return model.double()` — every custom NNP
+silently forced to fp64. All 23 tests still pass.
+
+### 33. `tests/test_fire_optimizer.py:265` — the FIRE velocity reset can be deleted outright — **VERIFIED**
+
+`test_fire_resets_on_force_reversal`'s docstring: *"FIRE should reset velocity when forces
+reverse direction."* Its only assertion is:
+
+```python
+assert optimizer.v.norm().item() >= 0  # Sanity check
+```
+
+A vector norm is non-negative by definition — the assertion is **mathematically incapable of
+failing**. The preceding comment already hedges ("or been reset depending on dot product").
+
+**Mutation:** `src/Auto3D/batch_opt/fire_optimizer.py:130`
+`self.v = torch.where(prog3, v_mixed, torch.zeros_like(self.v))` → `self.v = v_mixed`,
+deleting the reset-when-not-progressing branch — the defining feature of FIRE, and the
+mechanism the module docstring describes at line 36. Ran it:
+**all 23 tests in `tests/test_fire_optimizer.py` pass.**
+
+This sits in the optimizer every Auto3D geometry optimization runs through; losing the reset
+turns FIRE into plain momentum descent, which overshoots minima rather than converging.
+
+## Tier 2 (continued)
+
+- **`tests/test_filtering.py:31`** `test_single_mol_returns_itself` ("returned as-is") asserts only `len(result) == 1`. **Mutation:** `filtering.py:103-104` `return list(mols)` → `return [Chem.RemoveHs(m) for m in mols]` — every single-conformer cluster silently loses explicit hydrogens. All 18 pass. *VERIFIED.*
+- **`tests/test_filtering.py:99`** `test_filters_unconverged_structures` asserts `len(result) == 1`, never *which* mol survived. **Mutation:** `filtering.py:48` `== 'true'` → `!= 'true'` (keep only the unconverged one) — this test passes; 6 others in the file do catch it. *VERIFIED.*
+- **`tests/test_chunk_manager.py:56, 73`** both build a `MagicMock(total_memory=8*1024**3)` and assert only `num_jobs`. **Mutation:** `chunk_manager.py:76-80` → `memory_gb = 1` (never query the device). All 17 pass. The CPU branch *is* pinned (line 90). *VERIFIED.*
+- **`tests/test_processors.py:85`** `test_tautomer_processor_uses_facade` records all four forwarded arguments but asserts only `calls["args"][0] == "rdkit"`. **Mutation:** `processors.py:50` `pka_norm=self.config.pKaNorm` → `pka_norm=True` — the config option is silently ignored; the test sets `pKaNorm=False` and never checks it took effect. *VERIFIED.*
+- **`tests/test_custom_nnp_contract.py:243`** `test_wrong_arity_is_rejected_at_load` claims "always three positional arguments" but only exercises the `< 3` half. **Mutation:** delete `or len(required) > 3` (`contract.py:184`) — a `forward(self, species, coords, charges, cutoff)` model now loads clean and fails mid-run. All 23 pass. *VERIFIED.*
+- **`tests/test_custom_nnp_contract.py:216, 285`** exercise only `numbers`/`positions`/`charge`; 9 of the 15 synonym-vocabulary entries and the case-folding are dead. **Mutations:** (a) `contract.py:112` `lowered = name.lower()` → `lowered = name` (a `forward(Positions, Numbers, Charge)` transposed model slips through); (b) shrink `_SPECIES_NAMES`/`_COORDS_NAMES`/`_CHARGES_NAMES` (`contract.py:43-49`), dropping `z`, `elements`, `atomic_numbers`, `coord`, `coordinates`, `pos`, `xyz`, `q` — each turns a *detected transposition* into a silent accept. All 23 pass under each. *VERIFIED.*
+- **`tests/test_SPE.py:136, 151, 177`** each iterate `for mol in Chem.SDMolSupplier(out)` with a 2-entry reference dict and never assert the record count. **Mutation:** `SPE.py:162` `enumerate(mols)` → `enumerate(mols[:1])` — half the reference energies are never checked, all three green. (A fully empty output is *not* green: RDKit raises `OSError` on a 0-byte SDF.) A one-line `assert len(list(mols)) == 2` closes it. *SUSPECTED (mechanism verified).*
+- **`tests/test_auto3D.py`** — beyond the zero-assertion problem (finding 3), a concrete mutation: `ranking.py:216` `if rel_energy <= window:` → `if True:` silently ignores the `window` option, and every `window=`-using test here (lines 209, 245, 283, 294, 305, 316) stays green. *VERIFIED.*
+
+## Tier 3 (continued)
+
+- **`tests/test_processors.py:66`** `test_rdkit_engine` — `assert Path(result).exists()` is satisfied by the *input* path. **Mutation:** `processors.py:55` `return output_path` → `return input_path` (caught by line 38's test).
+- **`tests/test_custom_nnp_contract.py:176, 185`** — bare `pytest.raises(ModelLoadError)` with no `match=`, unlike their siblings at lines 165 and 216. The "must reject *the transposed order*" guarantee is not distinguished from any other load failure.
+- **`tests/test_auto3D.py:351`** `test_auto3D_userNNP2` instantiates **`userNNP1`** (TorchANI, `torch.jit.script`), not the module's `userNNP2` (eager AIMNet2). `userNNP2` is reached only by `test_auto3D_userNNP3`, which is GPU-gated and skipped on CI. **Mutation:** delete the eager `torch.load` fallback (`models/loading.py:56-70`) — both userNNP tests stay green. Severity limited by `test_custom_nnp_eager.py`, but the name is wrong.
+
+**Coverage-placement note (not a vacuous test):** `test_SPE.py::test_calc_spe_uses_model_factory`
+(line 218) is strong *and* fully hermetic — no model, no network — yet the module-level
+`pytestmark = pytest.mark.slow` gates it behind the slow job, so the only model-free test in
+the file never runs in the fast suite. Same shape as
+`test_species_conversion.py::test_pad_from_mols_emits_indices_for_ani2xt`.
+
+---
+
+# Tier 1 (continued) — optimizer, batching, model preflight
+
+Baseline for this group: 111 passed / 3 skipped across the 8 files. Every mutation below was
+executed on a scratch copy and confirmed to leave the named test green.
+
+### 34. `tests/test_fire_optimizer.py:353` — the golden trajectory never enters the branches it exists to guard — **VERIFIED**
+
+`test_fire_trajectory_golden`'s docstring says it "guards the branchless rewrite". Instrumentation
+shows `progressing` is `[False,False,False]` only at step 0 (where `v=0` makes `v_mixed == zeros`
+identically), then **all-True for all 19 remaining steps**, so `all_progressing` is always True and
+`speedup` is **never** True at any step. The checksum therefore never exercises the reset branch or
+the dt/`a` speed-up branch — precisely the branches the rewrite restructured.
+
+Confirmed green under **seven** separate mutations: deleting `@torch.jit.script`, the dt speed-up,
+the velocity reset, the `a` reset, the `Nsteps` increment, the per-molecule `dt` selection, **and
+the `maxstep` clamp**. This is the file's designated safety net and it holds nothing.
+
+### 35. `tests/test_optimization_engine.py:412` — the padding mask can be deleted outright — **VERIFIED**
+
+`test_fmax_ignores_padded_atoms` claims forces on padded slots are excluded from `fmax`.
+
+**Mutation:** delete *both* padding masks — `optimization_engine.py:203-204`
+(`pad_mask = ~atom_mask_subset…; f = f.masked_fill(pad_mask, 0.0)`) and line 283
+(`f_final = …masked_fill(~state['atom_mask']…)`). All 8 files stay green (36/36 across the
+opt-engine/padding/batchopt trio).
+
+The stub puts the **same force `100.0`** on the real atom (index 0) *and* on the padded slot
+(index 2), so `max()` over atoms is `100·√3 ≈ 173` whether or not padding is zeroed — this is
+exactly the "one value used for both subjects" shape the brief names as known history, and the
+assertion `fmax > 50.0` cannot discriminate. (It *does* catch the narrower C13 regression to a
+value-derived `numbers == 0` mask; only the "padding is ignored" half — the half it is named
+after — is unpinned.)
+
+**Second gap, same test:** batch size 1 and `n=1`, so the per-step
+`state['atom_mask'][not_converged]` gather (line 187) never runs on a partial subset. The
+stale-gather mutation `atom_mask_subset = state['atom_mask'][:coord.shape[0]]` — the exact bug
+class the test's own docstring at lines 392-401 warns about — is also green across all 8 files.
+
+### 36. `tests/test_optimization_engine.py:451` — the lag it detects vanishes at the minimum — **VERIFIED**
+
+`test_stored_energy_matches_stored_coord` claims the reported energy is evaluated at the reported
+final geometry. **Mutation:** delete `state['energy'] = e_final.detach()…`
+(`optimization_engine.py:279`), leaving the stale in-loop pre-step energy. All 8 files green.
+
+It runs `n=50, opttol=0.01` and converges to the harmonic minimum: measured stale energy
+`3.911e-5` vs true `7.718e-7`, a difference of `3.83e-5` — **26× under** its own `1e-3` tolerance.
+Its hardened sibling `test_stored_fmax_matches_stored_coord` (line 477) uses `n=3, opttol=1e-9`
+so the lag stays large, and *does* fail when the fmax recompute is deleted. Same fix applies here.
+
+### 37-40. `tests/test_model_preflight.py:73, 263, 93, 171` — the asserted substring is supplied by the test's own input — **VERIFIED**
+
+- **:73 `test_unknown_registry_name_is_rejected_up_front`** and **:263 `test_a_typo_names_the_alternatives`**
+  assert `"aimnet2" in message` / `"aimnet2-2025" in message` with the comment *"the error must list
+  valid options"*. The bad value the test supplies is `"aimnet2-2025x"`, which **contains both
+  strings**; the first test also lowercases the message, so `AIMNET` matches too.
+  **Mutation:** delete the `Registry aliases: {', '.join(aliases)}.` clause and its
+  `load_model_registry()` call (`models/preflight.py:100-107`), leaving only
+  `f"Unknown optimizing_engine {name!r}."`. Both tests green — the "lists valid options"
+  assertion is satisfied purely by the echoed typo. This is the confirmed `match=`-collision
+  shape, sourced from the input rather than from `tmp_path`.
+- **:93 `test_network_failure_names_the_network`** — `any(word in message for word in
+  ("network","download","cache","model"))`; the bare word `"model"` appears in essentially any
+  model-related message. **Mutation:** replace the whole `ConnectionError`/`RequestException`
+  handler (`preflight.py:199-205`) with `raise ModelLoadError("model")`. Green. Nothing pins
+  "network", the cache directory, or the `AIMNET_CACHE_DIR` hint.
+- **:171 `test_checksum_mismatch_says_to_delete_the_file`** — the filename is never asserted (it
+  only rides in via `{exc}`), and the recovery disjunction `("delete","remove","aimnet_cache_dir")`
+  is satisfied by the incidental `AIMNET_CACHE_DIR` mention alone. **Mutation:** replace the
+  handler message (`preflight.py:189-197`) with `"A checksum check failed. Override with
+  AIMNET_CACHE_DIR."` — no filename, no instruction to delete anything. Green.
+  (Contrast `TestUnwritableCacheDirectory` at line 463, which *is* live.)
+
+### 41. `tests/test_batchopt.py:209` — "buckets must be size-homogeneous" is checked on one bucket — **VERIFIED**
+
+`test_make_buckets_groups_by_size` names the ≤25% padding-waste contract. **Mutation:**
+`optimizing.BUCKET_SIZE_FACTOR = 1.25` → `11.0` (`batchopt.py:192`); any value < 12 works.
+The fixture is 5/8/11/60 atoms and the assertion only inspects the bucket containing the 60-atom
+outlier, so 5 and 11 atoms sharing a bucket (≈55% padding waste) passes. `BUCKET_MAX_COUNT` is
+likewise unpinned (only 4 molecules in the fixture).
+
+### 42-45. `tests/test_fire_optimizer.py:245, 287, 230, 328+338` — four more FIRE branches deletable — **VERIFIED**
+
+| Line | Test | Named guarantee | Mutation confirmed green |
+|---|---|---|---|
+| 245 | `test_fire_time_step_increases_with_progress` | "increase time step when making consistent progress" | `dt_prog = torch.where(speedup, dt_speedup, self.dt)` → `dt_prog = self.dt` (line 137). Asserts only `0 < dt <= dt_max`, both guaranteed by the `clamp`. |
+| 287 | `test_fire_handles_mixed_convergence` | "batches where some molecules need reset" | velocity-reset deletion (line 130). Sole assertion `coord.shape == (4,5,3)` is guaranteed by `return coord + dr`. |
+| 230 | `test_fire_multiple_steps_convergence` | "converge toward lower force configuration" | `nsteps_prog = …self.Nsteps+1…` → `self.Nsteps` (line 150). Assertion `Nsteps[0] > 0 or dt[0] < 0.1` — the second disjunct is near-guaranteed because step 1 always has `v=0 → vf=0 → not progressing → dt = 0.1*0.7`. Nothing about convergence is asserted. |
+| 328, 338 | `test_fire_is_torchscript_class`, `test_fire_works_in_jit_context` | docstring: "verifies the `@torch.jit.script` decorator worked" | **delete `@torch.jit.script`** (line 25). Whole file green — `callable(obj)` and `hasattr(obj,'clean')` hold for any plain Python class, and `torch.jit.optimized_execution(False)` is a no-op in eager mode. |
+
+Together with findings 33 and 34, **every branch of the FIRE optimizer can be individually
+deleted with `tests/test_fire_optimizer.py` fully green.**
+
+## Tier 2 (continued)
+
+- **`tests/test_fire_optimizer.py:306`** `test_fire_independent_molecule_tracking` ("track each molecule's state independently"). **Mutation:** `self.dt = torch.where(progressing, …)` → `torch.where(progressing.all(), …)` (line 138), making dt batch-coupled. The test's own force pattern makes `progressing` all-False at every step, so every per-molecule branch is taken uniformly, and the asserted `v_norms` inequality is produced entirely by the test's `forces[i] = …` pattern. *VERIFIED.*
+- **`tests/test_batchopt.py:116`** `test_ensemble_opt_returns_convergence_info` asserts key presence, `isinstance(…, list)` and `len(…) == 2` — never the contents. **Mutation:** `converged_mask=state['converged_mask'].tolist()` → `[False] * len(state['ids'])` (`batchopt.py:139`). The stub returns zero forces so the correct answer is `[True, True]`. The count-only shape again; the field-presence half of the name *is* pinned. *VERIFIED.*
+- **`tests/test_batchopt.py:88`** `test_enforce_ani_forward_batched` ("should batch calls correctly") asserts `call_count >= 1`. **Mutation:** `batch_size = max(1, self.batchsize_atoms // N)` → `max(1, B)` (`model_wrapper.py:204`), i.e. never split. Green here — but `tests/test_model_wrapper.py` catches it three times over (`>= 2`, `== 2`, `== 3`), so this copy is redundant as well as vacuous. *VERIFIED.*
+
+## Tier 3 (continued)
+
+- **`tests/test_optimization_engine_validation.py:99-158`** (`TestNStepsValidation`) — **Mutation:** swap `optimization_engine.py:143-145` so `optimizer = FIRE(coord)` runs *before* `_validate_state(state)`. Green — the shape-3 "guard movable below construction" pattern. Low impact: `FIRE.__init__` is allocation-only and the guard cannot move further down (`state['nn']` is `None`, so anything past the NN call raises `AttributeError`, not `ValueError`). Note `test_n_steps_error_is_not_assertion_error:144` uses `pytest.raises(ValueError)` with no `match=`, though its siblings cover the messages. *VERIFIED.*
+
+---
+
+# Adjacent defects (not test findings)
+
+### A. `tests/test_config_parity.py` fails when the file is run alone — **VERIFIED**
+
+```
+python -m pytest -p no:randomly tests/test_config_parity.py   =>  1 failed, 39 passed
+python -m pytest -p no:randomly tests/test_cli.py tests/test_config_parity.py  =>  63 passed
+```
+
+`TestSelectorRequiredEverywhere::test_cli_run_refuses_when_neither_selector_is_given` fails
+with `assert 1 == 2` /
+`TypeError: _run_legacy_and_capture.<locals>.<lambda>() got an unexpected keyword argument 'json_output'`.
+
+Mechanism: `_run_legacy_and_capture` (line 587) monkeypatches `Auto3D.cli.errors.handle_error`
+by string path. `auto3Dcli._run_legacy_yaml` then does
+`from Auto3D.cli.commands.run import _exit_if_incomplete` (`auto3Dcli.py:100`) — if that
+module has not been imported yet, its module-level
+`from Auto3D.cli.errors import handle_error` (`cli/commands/run.py:16`) executes **while the
+patch is live** and permanently binds the test's 2-arg lambda. monkeypatch's undo restores
+the original in `cli.errors` but not `run.py`'s copy. The test is green in CI only because
+alphabetical collection imports `test_cli.py` first. Fix: also patch
+`Auto3D.cli.commands.run.handle_error`, or give the lambda `**kwargs`.
+
+### B. `no_enantiomer_helper([], [])` returns `True` — **VERIFIED**
+
+```
+no_enantiomer_helper([], [])                  -> True
+no_enantiomer("CCO", ["CCO", "CCCO"])         -> False
+=> two unrelated ACHIRAL molecules are reported as an enantiomeric pair.
+```
+
+This is the same vacuous-empty-loop defect that *was* fixed in `enantiomer()`
+(`utils/stereochemistry.py:63-64`, with the comment explaining exactly why an empty loop
+leaves `indicator` at `True`). The helper never got the same guard, and
+`tests/test_stereochemistry_validation.py:176`
+(`test_no_enantiomer_helper_empty_lists_returns_true`) currently pins the unfixed behaviour.
+
+### C. Shipped version is 3.0.0 while `pyproject.toml` declares 3.5.0 — **VERIFIED**
+
+```
+importlib.metadata.version("Auto3D") = 3.0.0
+Auto3D.__version__                   = 3.0.0
+pyproject.toml: version = "3.5.0"
+$ auto3d --version  ->  Auto3D version 3.0.0
+```
+
+`test_new_cli_version` compares the CLI's output to the same attribute the CLI printed
+(tautology); `test_packaging_metadata.py::test_version_is_3_5` reads `pyproject.toml`, not
+the installed distribution. Both are green. On this box the cause is most likely stale
+editable-install metadata rather than a repo defect — but the *test* conclusion stands:
+the two tests together look like they pin the shipped version and demonstrably cannot.
+
+---
+
+# Examined and cleared
+
+No green-surviving mutation was found in: **`test_durability.py`** (the three bare
+`pytest.raises(Exception)` calls are each backstopped by a byte-comparison or leftover
+scan; `match="same file"`/`"already exists"` are narrow and `use_gpu=False` keeps the
+earlier `GPUError` from satisfying them) · **`test_cli_exit_codes.py`** (every exit-code
+assertion is paired with a discriminator a second same-integer path cannot satisfy) ·
+**`test_cli_errors.py`** (verbosity tests pin the traceback; the FORCE_COLOR hazard was
+checked against the negative assertions and Rich injects no escapes there) ·
+**`test_validation.py`** · **`test_ase_geometry.py`** · **`test_stereochemistry_validation.py`**
+· **`test_stereo_postopt.py`** · **`test_utils.py`** · **`test_sdf_isomer_enumeration.py`** ·
+**`test_tautomer_stereo.py`** · **`test_species_module.py`** · **`test_torch_config.py`** ·
+**`test_logging_config.py`** · **`test_mp_start_method.py`** · **`test_lazy_torchani_import.py`**
+· **`test_validate_run_parity.py`** · **`test_results.py`** · **`test_packaging_metadata.py`**
+· **`test_padding_invariance.py`** · **`test_padding.py`** (dropping the ANI2xt species remap
+fails 3 tests; the `species_pad`-collision test asserts a real hydrogen count as its own
+non-vacuity check) · **`test_model_wrapper.py`** (batching, min-one-per-batch, exact-boundary,
+legacy deprecation and the OOM retry are all live) · **`test_model_caching.py`** (dropping
+`compile_model` from the cache key fails `test_cache_key_includes_compile_model`; 3 of 6 tests
+skip without `torchani`, a gating cost rather than vacuity) · most of **`test_thermo_helpers.py`**
+(`TestLinearity`, `TestVibrationAnalysis`, `TestHessianGeometrySourcing`,
+`TestStationaryPointGate`, `TestRecordFiltering`, `TestThermoFailedMarker`,
+`TestSymmetryNumber`, `TestMultiplicity` all pin real mutations) · most of
+**`test_config_parity.py`**.
+
+Two suspicions explicitly **cleared**:
+- `tests/test_padding.py:92` — *not* a finding; it uses `np.testing.assert_array_almost_equal`.
+- `tests/test_tauto.py` — *not* a finding; the `if name == "smi0"` branch does fire, because
+  `select_tautomers` resets `_Name` to the bare id (`tautomer.py:90`).
+- **ASE API surface** — no test reads a nonexistent third-party attribute.
+  `Atoms.set_calculator`, `VibrationsData.get_atoms` and every `monkeypatch.setattr` target
+  resolve against ase 3.27.0. The `vib.atoms` defect noted in the brief is genuinely fixed at
+  `tests/test_thermo_reference.py:203`.
+
+---
+
+# Systemic observations
+
+1. **The `split("_")[0]` idiom is still live in the test suite** at
+   `tests/test_pipeline_e2e.py:71, 128, 212, 235`, after being removed from production for
+   being wrong. Finding 1 is its direct consequence.
+
+2. **Zero-assertion slow tests dominate the slow tier** — 24 of 66 (36%). They consume most
+   of the slow job's wall time (CI records 6-18 minutes against a 45-minute ceiling) and can
+   only catch an exception.
+
+3. **Console and reporting helpers are almost entirely unpinned.** `print_error`,
+   `print_warning`, `print_failures`, `print_results_summary` and `output_json` can all be
+   reduced to no-ops with `test_cli_console.py`, `test_cli_results.py` and `test_cli.py`
+   still fully green.
+
+4. **`--help` substring assertions are systematically unreliable.** `"-c"` matches
+   `--max-confs`; `"info"` matches "information"; `"run"` matches "running"; `"B"` matches
+   "Best"; `"Pd"` matches three prose lines. Five separate tests rely on them.
+
+5. **The monkeypatch-still-active read-back is a recurring bug** (findings 13, 14). One
+   sibling gets it right by calling `monkeypatch.undo()` before reading back; the others do
+   not.
+
+6. **"Assert the count, never the content" is the single most common shape in this suite.**
+   It recurs independently at four layers of the same data path — `SDF2chunks`
+   (finding 30), `ChunkManager._create_chunk_files` (finding 28, re-verified here: **all 17
+   tests pass with every molecule but the first discarded and all SDF chunks emptied**),
+   `filter_unique_optimized` (findings 25-27), and `ConformerRanker.top_k` /
+   `top_window` (findings 6, 7). Molecules can be silently dropped, duplicated or emptied
+   at every stage between input parsing and output ranking without a single test going red.
+
+7. **Deleting a guard sometimes turns rejection into silent acceptance** rather than a
+   crash — `models/contract.py:157-162` (finding 30) is swallowed by a downstream
+   `except (ValueError, TypeError): return`. That is the worst failure direction for a
+   validation layer and no test covers it.
+
+8. **The FIRE optimizer is effectively untested.** Every branch — velocity reset, `a` reset,
+   dt speed-up, per-molecule dt selection, `Nsteps` increment, the `maxstep` clamp, and the
+   `@torch.jit.script` decorator itself — can be individually deleted with
+   `tests/test_fire_optimizer.py` fully green (findings 33, 34, 42-45). The designated safety
+   net, `test_fire_trajectory_golden`, never enters the branches it was written to guard:
+   `speedup` is never True at any of its 20 steps. This is the numerical core of every Auto3D
+   geometry optimization.
+
+9. **`match=`-style collisions are sourced from the test's own input, not only from `tmp_path`.**
+   `tests/test_model_preflight.py:73, 263` assert that an error "lists valid options" by
+   checking for `"aimnet2"` / `"aimnet2-2025"` — both **substrings of the bad value the test
+   itself passed in** (`"aimnet2-2025x"`). Deleting the entire alias listing leaves them green.
+   Worth grepping the suite for asserted substrings that are prefixes of the fixture value.
+
+10. **Two CI-only environment hazards.** `tests/test_workflow.py:387` and `:600` leave
+   `optimizing_engine` at its default `AIMNET`, so `_validate_input` reaches
+   `preflight_model` → `get_registry_model_path`, which **downloads on a cold cache**. They
+   pass here only because `~/.cache/aimnet` is warm. `test_two_runs_do_not_reuse_job_name`
+   (line 482) already pins `optimizing_engine="ANI2xt"` for exactly this reason.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -546,6 +546,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `__constants__` for TorchScript). The failure is now a clear
   `ModelLoadError` at load rather than a wrong padding value applied silently.
 
+- **`E_tot` is written in Hartree by every entry point.** The SDF property
+  name meant two different units depending on which code wrote the file:
+  `batch_opt.optimizing.run` wrote **eV**, while `opt_geometry` and
+  `ConformerRanker` wrote **Hartree** under the same name -- and the five
+  in-package consumers (`ranking`, `filtering`, `utils.chemistry.filter_unique`)
+  all hard-coded eV, so they misread the very files Auto3D itself produced.
+  Feeding an `opt_geometry` output to `ConformerRanker(window=2.0)` opened a
+  window **27.211x too wide** (3 conformers kept where 2 belong), reported
+  `E_rel` 0.037 kcal/mol where the truth is 1.000, and wrote an
+  `E_tot(Hartree)` that had been divided by 27.211 **twice**.
+
+  | Producer | `E_tot` in 3.x / 4.0-pre | `E_tot` now |
+  | --- | --- | --- |
+  | `optimizing.run()` (`*_3d.sdf` in the job dir, `--verbose` output) | eV | **Hartree** |
+  | `opt_geometry` / `auto3d optimize` | Hartree | Hartree (unchanged) |
+  | `ConformerRanker` / `main()` / `smiles2mols` (final output) | Hartree | Hartree (unchanged) |
+  | `calc_spe` / `auto3d energy` (writes `E_hartree`) | Hartree | Hartree (unchanged) |
+
+  **Which unit is my file in?** Only the intermediate optimizer output
+  changed. If a file has both `E_tot` and `E_tot(Hartree)` it is Hartree by
+  construction. If it has `E_tot` alone and came from a 3.x/4.0-pre
+  `optimizing.run()` (an unranked, un-annotated SDF straight out of the
+  optimization step), it is in eV -- divide by 27.211386245988 to migrate it,
+  or simply re-run. Every finished Auto3D output (`main()`, `smiles2mols`,
+  `opt_geometry`, `auto3d run/optimize`) was already Hartree and is
+  bit-identical.
+
+  `opt_geometry` output now also carries the unit-labeled `E_tot(Hartree)`
+  sibling, which previously only the ranked output had. `fmax` is unchanged
+  and remains eV/Angstrom. `Auto3D.utils.energy` is the single owner of this
+  conversion: writers call `set_e_tot_from_ev`, readers call `e_tot_ev` /
+  `try_e_tot_ev`, so `energy_cluster_window` and the duplicate-energy
+  tolerance keep their documented eV meaning and no public parameter changed
+  units.
+
 ### Added
 
 - **`auto3d validate` accepts `--json`**, the one result-producing command
@@ -567,6 +602,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The Rich error panel is unchanged and still goes to stderr.
 
 ### Fixed
+
+- **A charge change no longer reuses the previous molecule's energy and
+  forces.** `ASE/thermo.py`'s `Calculator.set_charge` reassigned the charge
+  without discarding the cached result. ASE decides cache validity with
+  `Calculator.check_state` -> `compare_atoms`, which compares positions,
+  atomic numbers, cell and pbc -- the charge is invisible to it. In
+  `calc_thermo`'s shared-calculator loop, two records with the **same geometry
+  and different formal charge** therefore shared one energy *and* one gradient:
+  `BFGS` "converged" in zero steps on the previous molecule's forces, the
+  stationary-point gate passed, and the reported `E_hartree`/`H_hartree`/
+  `G_hartree` combined molecule 1's electronic energy with molecule 2's
+  Hessian. A vertical IP/EA input -- one geometry at two charges -- is an
+  ordinary use, and the error is the whole ionization energy or electron
+  affinity (20-90 kcal/mol) with no warning. The charge now lives in the ASE
+  calculator's own `parameters`, and both `set_charge(q)` and a direct
+  `calc.charge = q` invalidate the cache.
+
+- **An R-group (`*`) atom is no longer deleted as padding.**
+  `AIMNet2Adapter.forward` derived its real-atom mask as
+  `species != self.species_pad`, and that adapter's `species_pad` is `0` --
+  which is also the atomic number of a dummy atom. `padding.pad_from_mols`
+  documents exactly this hazard (audit C13) and returns an explicit
+  `atom_mask` so callers need not guess; this consumer was the last one still
+  guessing. For `*CCO` the padder reported 9 real atoms and the adapter scored
+  8: the energy belonged to a different species, the dummy atom received
+  exactly zero force and stayed frozen for the whole optimization, and
+  `utils.validation._requires_aimnet` routes precisely these molecules to this
+  engine. The explicit mask is now threaded from `pad_from_mols` through
+  `EnForce_ANI.forward`/`forward_batched` (new optional `atom_mask=`
+  parameter, sliced per sub-batch) to the adapters, and `calc_spe` forwards it
+  too. Recompute any run containing dummy/R-group atoms.
 
 - **`auto3d <config.yaml>` no longer reports success on a run that lost
   molecules.** The deprecated single-argument form printed a green

--- a/docs/source/migration-4.0.rst
+++ b/docs/source/migration-4.0.rst
@@ -7,6 +7,100 @@ This release corrects defects that produced silently wrong results. Read the
 Results that change
 --------------------
 
+``E_tot`` is Hartree in every file Auto3D writes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``E_tot`` SD property meant two different units depending on which piece
+of Auto3D wrote the file. ``batch_opt.optimizing.run`` wrote **eV**, while
+``opt_geometry`` and ``ConformerRanker`` wrote **Hartree** under the same
+name, and the in-package consumers (``ranking``, ``filtering``,
+``utils.chemistry.filter_unique``) all hard-coded eV -- so they misread files
+Auto3D itself produced. Feeding an ``opt_geometry`` output straight to
+``ConformerRanker(window=2.0)`` opened a window 27.211x too wide, kept 3
+conformers where 2 belong, reported ``E_rel`` 0.037 kcal/mol where the truth
+is 1.000, and wrote an ``E_tot(Hartree)`` that had been divided by 27.211
+twice.
+
+``E_tot`` is now Hartree at every writer, converted once on the way to disk.
+
+**Which unit is my file in?**
+
+.. list-table::
+   :widths: 45 20 20
+   :header-rows: 1
+
+   * - Producer
+     - 3.x / 4.0-pre
+     - 4.0
+   * - ``optimizing.run()`` -- the unranked SDF from the optimization step
+       (kept in the job directory, and in the ``--verbose`` housekeeping
+       archive)
+     - eV
+     - **Hartree**
+   * - ``opt_geometry`` / ``auto3d optimize``
+     - Hartree
+     - Hartree
+   * - ``main()`` / ``smiles2mols`` / ``auto3d run`` final output
+     - Hartree
+     - Hartree
+   * - ``calc_spe`` / ``auto3d energy`` (writes ``E_hartree``)
+     - Hartree
+     - Hartree
+
+Only the intermediate optimizer output changed unit. A file carrying both
+``E_tot`` and ``E_tot(Hartree)`` is Hartree by construction. A file carrying
+``E_tot`` alone, produced by a 3.x/4.0-pre ``optimizing.run()``, is in eV:
+divide by 27.211386245988 to migrate it, or re-run. Every finished Auto3D
+output was already Hartree and is unchanged.
+
+``opt_geometry`` output now also carries the unit-labeled ``E_tot(Hartree)``
+sibling that previously only the ranked output had. ``fmax`` is unchanged and
+remains eV/Angstrom.
+
+If you wrote code against the old intermediate file, note that no public
+parameter changed units: ``ConformerRanker``'s ``energy_cluster_window`` and
+the duplicate-energy tolerance are still eV.
+``Auto3D.utils.energy`` is now the single owner of the conversion --
+``set_e_tot_from_ev`` on write, ``e_tot_ev`` / ``try_e_tot_ev`` on read.
+
+Molecules with R-group (``*``) atoms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``AIMNet2Adapter`` identified padded slots as ``species != species_pad`` with
+``species_pad = 0``, which is also the atomic number of a dummy atom. A
+molecule containing ``*`` therefore had that atom deleted before the energy
+call: for ``*CCO`` the padder reported 9 real atoms and the adapter scored 8.
+The energy belonged to a different species, and the dummy atom received
+exactly zero force, so it stayed frozen at its input coordinate for the whole
+optimization while everything else relaxed around it -- the geometry is wrong,
+not just the energy. Because element 0 is outside the ANI set, Auto3D routes
+exactly these molecules to this engine. Recompute any run containing dummy or
+R-group atoms.
+
+The adapter now uses the explicit ``atom_mask`` that
+``batch_opt.padding.pad_from_mols`` returns. If you maintain a **custom NNP**,
+the same collision class applies to you: your model identifies its own padding
+from the ``species_pad`` value it declares, so choose one that cannot collide
+with a real species index -- ``-1`` is always safe, ``0`` is not.
+
+``calc_thermo`` on inputs that share a geometry at different charges
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``calc_thermo`` reuses one ASE calculator across every record and called
+``set_charge`` per molecule. ASE's cache-validity test compares positions,
+atomic numbers, cell and pbc -- never the charge -- so two records with the
+same geometry and different formal charge shared one cached energy *and* one
+cached gradient. ``BFGS`` then "converged" in zero steps on the previous
+molecule's forces, the stationary-point gate passed, and the reported
+``E_hartree``/``H_hartree``/``G_hartree`` combined the first molecule's
+electronic energy with the second's Hessian.
+
+A vertical IP/EA input -- the same geometry submitted at two charges -- is the
+ordinary case that hits this, and the error is the entire ionization energy or
+electron affinity, 20-90 kcal/mol, with nothing in the output to indicate it.
+Recompute any ``calc_thermo`` batch in which two records shared a geometry and
+differed in charge.
+
 ``calc_thermo`` with ANI2xt
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/example/stereochemistry.ipynb
+++ b/example/stereochemistry.ipynb
@@ -319,7 +319,7 @@
     "        if mol.HasProp(\"E_hartree\"):\n",
     "            e = float(mol.GetProp(\"E_hartree\"))\n",
     "        elif mol.HasProp(\"E_tot\"):\n",
-    "            e = float(mol.GetProp(\"E_tot\")) / 27.2114\n",
+    "            e = float(mol.GetProp(\"E_tot\"))  # already Hartree\n",
     "        else:\n",
     "            continue\n",
     "        \n",

--- a/example/strain_energy.ipynb
+++ b/example/strain_energy.ipynb
@@ -149,7 +149,7 @@
     "        if mol.HasProp(\"E_hartree\"):\n",
     "            e = float(mol.GetProp(\"E_hartree\"))\n",
     "        elif mol.HasProp(\"E_tot\"):\n",
-    "            e = float(mol.GetProp(\"E_tot\")) / 27.2114  # eV to Hartree\n",
+    "            e = float(mol.GetProp(\"E_tot\"))  # E_tot is Hartree\n",
     "        else:\n",
     "            continue\n",
     "        \n",

--- a/example/tautomer_protomer_analysis.ipynb
+++ b/example/tautomer_protomer_analysis.ipynb
@@ -213,7 +213,7 @@
     "        if mol.HasProp(\"E_hartree\"):\n",
     "            e_hartree = float(mol.GetProp(\"E_hartree\"))\n",
     "        elif mol.HasProp(\"E_tot\"):\n",
-    "            e_hartree = float(mol.GetProp(\"E_tot\")) / 27.2114  # eV to Hartree\n",
+    "            e_hartree = float(mol.GetProp(\"E_tot\"))  # E_tot is Hartree\n",
     "        else:\n",
     "            continue\n",
     "            \n",

--- a/src/Auto3D/ASE/geometry.py
+++ b/src/Auto3D/ASE/geometry.py
@@ -20,7 +20,7 @@ from Auto3D.constants import (
 from Auto3D.model_factory import get_device
 from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.torch_config import TorchConfig, configure_torch
-from Auto3D.utils import hartree2ev
+from Auto3D.utils.energy import E_TOT_HARTREE_PROP, E_TOT_PROP
 from Auto3D.utils.validation import (
     check_engine_supports_molecules,
     check_gpu_requested,
@@ -70,7 +70,20 @@ def _stage_beside(target: str) -> str:
 
 
 def _annotate_and_rewrite(outpath: str) -> None:
-    """Convert E_tot from eV to hartree in-place, atomically.
+    """Add the unit-labeled ``E_tot(Hartree)`` sibling in-place, atomically.
+
+    This function used to CONVERT ``E_tot`` from eV to Hartree, because
+    ``optimizing.run()`` wrote eV. It no longer does: ``optimizing.run()``
+    writes ``E_tot`` in Hartree like every other Auto3D writer (see
+    ``Auto3D.utils.energy``), so converting again here would divide by 27.211
+    a second time. Two jobs remain, and neither is a no-op: this pass DROPS
+    records that failed to re-parse or carry no ``E_tot`` (so ``opt_geometry``
+    output contains only usable energies), and it guarantees the unit-labeled
+    ``E_tot(Hartree)`` sibling regardless of what the optimizer wrote -- the
+    same guarantee ``ConformerRanker`` makes for the ranked output. Setting
+    the label is idempotent: ``optimizing.run()`` already writes it, and
+    re-asserting the identical string here keeps the guarantee attached to
+    ``opt_geometry`` itself rather than to whichever writer ran upstream.
 
     ``optimizing.run()`` has already written its only copy of the optimized
     geometries to ``outpath``. Opening ``Chem.SDWriter(outpath)`` directly
@@ -88,10 +101,6 @@ def _annotate_and_rewrite(outpath: str) -> None:
     handle is held. This function reads ``outpath`` and then replaces it, so it
     has the same exposure -- see the explicit release below.
     """
-    # `ev2hatree` is a LOCAL in opt_geometry, so a module-level helper cannot
-    # see it -- recompute from the module-level `hartree2ev` import rather than
-    # adding a parameter for a constant.
-    ev2hatree = 1 / hartree2ev
     supp = Chem.SDMolSupplier(outpath, removeHs=False)
     mols = list(supp)
     # Release the handle on `outpath` BEFORE os.replace targets it, exactly as
@@ -108,10 +117,11 @@ def _annotate_and_rewrite(outpath: str) -> None:
                 # Skip records that failed to re-parse or lack E_tot rather
                 # than crashing, which would discard the entire (already
                 # completed) optimization run on a single bad record.
-                if mol is None or not mol.HasProp("E_tot"):
+                if mol is None or not mol.HasProp(E_TOT_PROP):
                     continue
-                e = float(mol.GetProp("E_tot")) * ev2hatree
-                mol.SetProp("E_tot", str(e))
+                # Same number, stated in a name that carries its unit. No
+                # arithmetic: E_tot is already Hartree when it gets here.
+                mol.SetProp(E_TOT_HARTREE_PROP, mol.GetProp(E_TOT_PROP))
                 f.write(mol)
         os.replace(tmp_path, outpath)
     except BaseException:
@@ -248,8 +258,9 @@ def opt_geometry(
     opt_engine = optimizing(path, outpath, model_name, device, opt_config)
     opt_engine.run()
 
-    # change the energy unit from eV to hartree, staged through a temp file so
-    # a failed rewrite cannot destroy the completed optimization (C14)
+    # `optimizing.run()` already wrote E_tot in Hartree; this pass only adds
+    # the unit-labeled sibling, staged through a temp file so a failed rewrite
+    # cannot destroy the completed optimization (C14)
     _annotate_and_rewrite(outpath)
     return outpath
 

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -312,8 +312,36 @@ def _resolve_multiplicity(mol: Chem.Mol) -> int:
 
 
 class Calculator(ase.calculators.calculator.Calculator):
-    """ASE calculator interface for AIMNET and ANI2xt"""
+    """ASE calculator interface for AIMNET and ANI2xt.
+
+    The molecular charge is part of the calculator's own ASE state
+    (``self.parameters['charge']``), not a bare attribute the caller mutates.
+    ASE decides whether a cached ``energy``/``forces`` may be reused by calling
+    ``check_state``, which delegates to ``compare_atoms`` and compares only
+    positions, atomic numbers, cell and pbc -- the charge is invisible to it.
+    Reassigning the charge without discarding the cache therefore let two
+    records with the SAME geometry and DIFFERENT formal charge share one
+    result: a vertical IP/EA input (one geometry, two charges) is the ordinary
+    case, and it silently reported the neutral energy for the ion. Downstream
+    that is the entire electron affinity, tens of kcal/mol, with no warning --
+    and because the cached FORCES were reused too, ``BFGS`` "converged" in zero
+    steps on the previous molecule's gradient and the stationary-point gate
+    passed.
+
+    ``discard_results_on_any_change`` makes ASE's own ``Calculator.set`` call
+    ``reset()`` whenever a parameter actually changes, so routing the charge
+    through ``set(charge=...)`` (see the ``charge`` setter below) is what
+    invalidates the cache. Both ``calc.set_charge(q)`` and a direct
+    ``calc.charge = q`` go through that one path.
+    """
     implemented_properties = ['energy', 'forces']
+    #: A change to any parameter (there is exactly one, ``charge``) makes every
+    #: cached result stale, so let ASE's ``Calculator.set`` call ``reset()``.
+    discard_results_on_any_change = True
+    #: Declared so ``self.parameters`` always carries a charge entry, even
+    #: before the first assignment in ``__init__``.
+    default_parameters = {'charge': 0}
+
     def __init__(self, model, charge=0, *, model_name):
         super().__init__()
         self.model = model
@@ -333,10 +361,43 @@ class Calculator(ase.calculators.calculator.Calculator):
             # so fall back to a sensible default for the ASE-facing tensors.
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
             self.dtype = torch.double
-        self.charge = torch.tensor([charge], dtype=torch.float, device=self.device)
+        # Goes through the `charge` setter below, so `self.parameters['charge']`
+        # and the tensor `calculate()` reads are populated from one place.
+        self.charge = charge
 
-    def set_charge(self, charge:int):
-        self.charge = torch.tensor([charge], dtype=torch.float, device=self.device)
+    @property
+    def charge(self) -> torch.Tensor:
+        """Molecular charge as a ``(1,)`` float tensor on ``self.device``.
+
+        Kept as a tensor (rather than an int) because ``calculate`` hands it
+        straight to the model, and aimnet's AIMNet2 requires a 1-D per-molecule
+        charge tensor.
+        """
+        return self._charge
+
+    @charge.setter
+    def charge(self, value) -> None:
+        # Accept an int/float or a tensor: `Calculator(model, charge=1)` and a
+        # caller-supplied `calc.charge = torch.tensor([1])` must both land in
+        # `self.parameters`, or the assignment that skipped it would keep the
+        # stale cache alive again.
+        if isinstance(value, torch.Tensor):
+            scalar = int(value.reshape(-1)[0].item())
+        else:
+            scalar = int(value)
+        self._charge = torch.tensor([scalar], dtype=torch.float, device=self.device)
+        # ASE's own parameter bookkeeping: with
+        # discard_results_on_any_change=True this calls reset() -- dropping the
+        # cached energy AND forces -- exactly when the value actually changes.
+        self.set(charge=scalar)
+
+    def set_charge(self, charge: int) -> None:
+        """Set the molecular charge, discarding any result cached at the old one.
+
+        See the class docstring: ASE's cache-validity test never looks at the
+        charge, so this must invalidate the cache itself.
+        """
+        self.charge = charge
 
     def calculate(self, atoms=None, properties=None,
                   system_changes=ase.calculators.calculator.all_changes):

--- a/src/Auto3D/SPE.py
+++ b/src/Auto3D/SPE.py
@@ -147,15 +147,19 @@ def calc_spe(
     # Create EnForce_ANI wrapper for batched forward support (new API without name)
     model = EnForce_ANI(model_adapter)
 
-    # Use new vectorized padding that returns tensors directly. calc_spe only
-    # needs energies (not forces), so the atom mask pad_from_mols also returns
-    # is unused here.
-    coord_padded, numbers_padded, charges, _atom_mask = pad_from_mols(
+    # Use new vectorized padding that returns tensors directly. The explicit
+    # atom mask is forwarded to the model: an adapter that flattens a padded
+    # batch (AIMNet2) must be told which slots are real rather than inferring
+    # it from `species == species_pad`, which deletes a legitimate atomic
+    # number 0 (an R-group `*` atom) along with the padding (audit C13).
+    coord_padded, numbers_padded, charges, atom_mask = pad_from_mols(
         mols, model_name, device,
         coord_pad=model_adapter.coord_pad, species_pad=model_adapter.species_pad
     )
 
-    es, fs = model.forward_batched(coord_padded, numbers_padded, charges)
+    es, fs = model.forward_batched(
+        coord_padded, numbers_padded, charges, atom_mask=atom_mask
+    )
     es = es.to('cpu').detach().numpy()
 
     with Chem.SDWriter(str(outpath)) as f:

--- a/src/Auto3D/batch_opt/batchopt.py
+++ b/src/Auto3D/batch_opt/batchopt.py
@@ -40,6 +40,7 @@ from Auto3D.batch_opt.model_wrapper import EnForce_ANI
 from Auto3D.batch_opt.optimization_engine import n_steps, print_stats  # noqa: F401
 from Auto3D.constants import INITIAL_ENERGY_SENTINEL, INITIAL_FMAX_SENTINEL
 from Auto3D.model_factory import create_model
+from Auto3D.utils.energy import set_e_tot_from_ev
 from Auto3D.utils.stereo_check import apply_optimized_coords
 
 from .padding import pad_from_mols
@@ -331,7 +332,15 @@ class optimizing:
                 converged_i = converged_flags[i]
                 osc_count_i = osc_counts[i]
                 convergence_i = converged_i and osc_count_i < patience
-                mol.SetProp('E_tot', str(energies[i]))
+                # The model returns eV; `E_tot` is a Hartree property at
+                # every Auto3D writer, so the conversion happens HERE, on the
+                # way to disk, and the unit-labeled sibling is written next to
+                # it. Writing eV under this name is what made the same tag mean
+                # two different things depending on entry point (see
+                # Auto3D.utils.energy).
+                set_e_tot_from_ev(mol, energies[i])
+                # fmax stays in eV/Angstrom (opt_tol's unit); it is a force, not
+                # an energy, and no consumer converts it.
                 mol.SetProp('fmax', str(fmaxs[i]))
                 mol.SetProp('Converged', str(convergence_i))
                 # Mark structures dropped due to oscillation for diagnostics

--- a/src/Auto3D/batch_opt/model_wrapper.py
+++ b/src/Auto3D/batch_opt/model_wrapper.py
@@ -89,6 +89,7 @@ class EnForce_ANI(nn.Module):
         coord: torch.Tensor,
         numbers: torch.Tensor,
         charges: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Calculate the energies and forces for input molecules.
 
@@ -108,6 +109,12 @@ class EnForce_ANI(nn.Module):
                   each structure, 3 represents xyz dimensions.
             numbers: The periodic numbers for all atoms. Shape (B, N).
             charges: Molecular charges. Shape (B,).
+            atom_mask: Boolean (B, N), True for real atoms and False for padded
+                slots, as returned by
+                :func:`Auto3D.batch_opt.padding.pad_from_mols`. Forwarded to
+                the adapter so it never has to re-derive padding from a
+                species sentinel (audit C13). ``None`` means the batch is
+                unpadded.
 
         Returns:
             Tuple of (energies, forces) where energies has shape (B,) and
@@ -115,7 +122,7 @@ class EnForce_ANI(nn.Module):
         """
         if self._use_legacy_forward:
             return self._legacy_forward(coord, numbers, charges)
-        return self.model.forward(coord, numbers, charges)
+        return self.model.forward(coord, numbers, charges, atom_mask=atom_mask)
 
     def _legacy_forward(
         self,
@@ -178,6 +185,7 @@ class EnForce_ANI(nn.Module):
         coord: torch.Tensor,
         numbers: torch.Tensor,
         charges: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Calculate the energies and forces for input molecules in batches.
 
@@ -190,6 +198,10 @@ class EnForce_ANI(nn.Module):
                   each structure, 3 represents xyz dimensions.
             numbers: The periodic numbers for all atoms. Shape (B, N).
             charges: Molecular charges. Shape (B,).
+            atom_mask: Boolean (B, N), True for real atoms. Sliced with the
+                same molecule indices as ``coord``/``numbers``/``charges`` so
+                each sub-batch's adapter call receives the mask for exactly
+                its own molecules. ``None`` means the batch is unpadded.
 
         Returns:
             Tuple of (energies, forces) concatenated across batches.
@@ -210,7 +222,10 @@ class EnForce_ANI(nn.Module):
             # raise a clear, actionable error instead of crashing opaquely.
             for sub in batch_idx.split(bsize):
                 try:
-                    _e, _f = self(coord[sub], numbers[sub], charges[sub])
+                    _e, _f = self(
+                        coord[sub], numbers[sub], charges[sub],
+                        atom_mask=None if atom_mask is None else atom_mask[sub],
+                    )
                 except torch.cuda.OutOfMemoryError:
                     if torch.cuda.is_available():
                         torch.cuda.empty_cache()

--- a/src/Auto3D/batch_opt/optimization_engine.py
+++ b/src/Auto3D/batch_opt/optimization_engine.py
@@ -189,8 +189,14 @@ def n_steps(
         oscillating_count = state["oscillating_count"][not_converged]
 
         coord.requires_grad_(True)
-        e, f = state['nn'].forward_batched(coord, numbers,
-                                           charges)  # Key step to calculate all energies and forces.
+        # atom_mask goes to the model too, not just to the force reduction
+        # below: an adapter that has to flatten a padded batch (AIMNet2) needs
+        # to know which slots are real, and deriving that from a species
+        # sentinel is what audit C13 forbids.
+        e, f = state['nn'].forward_batched(
+            coord, numbers, charges,
+            atom_mask=atom_mask_subset,
+        )  # Key step to calculate all energies and forces.
         coord.requires_grad_(False)
 
         # Zero forces on padded atom slots so convergence is independent of how
@@ -275,7 +281,10 @@ def n_steps(
     # state['coord']. The adapters differentiate internally for forces, so grad
     # must be enabled; the forces were previously discarded.
     final_coord = state['coord'].detach().clone().requires_grad_(True)
-    e_final, f_final = state['nn'].forward_batched(final_coord, state['numbers'], state['charges'])
+    e_final, f_final = state['nn'].forward_batched(
+        final_coord, state['numbers'], state['charges'],
+        atom_mask=state['atom_mask'],
+    )
     state['energy'] = e_final.detach().to(state['energy'].dtype)
     # Zero padded-atom force slots before the reduction, matching the in-loop
     # convergence check, so reported fmax is independent of how the model treats

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -11,6 +11,7 @@ from Auto3D.constants import (
     DEFAULT_RMSD_THRESHOLD,
 )
 from Auto3D.utils import check_connectivity
+from Auto3D.utils.energy import e_tot_ev, try_e_tot_ev
 from Auto3D.utils.stereo_check import stereo_preserved
 
 
@@ -31,10 +32,13 @@ def filter_unique_optimized(
     much smaller than n for molecules with diverse energies.
 
     Args:
-        mols: List of RDKit Mol objects with 'E_tot' and 'Converged' properties.
-            Records marked 'Stereo_changed' are excluded.
+        mols: List of RDKit Mol objects with 'E_tot' (Hartree) and 'Converged'
+            properties. Records marked 'Stereo_changed' are excluded.
         rmsd_threshold: RMSD threshold for considering structures similar (Angstrom).
-        energy_cluster_window: Energy window for clustering (eV).
+        energy_cluster_window: Energy window for clustering (eV). Unchanged:
+            the stored Hartree energies are converted to eV on read
+            (``Auto3D.utils.energy.e_tot_ev``), so this parameter keeps its
+            documented unit.
 
     Returns:
         List of unique molecules, sorted by energy (lowest first).
@@ -54,16 +58,17 @@ def filter_unique_optimized(
     if not valid_mols:
         return []
 
-    # Sort by energy
-    valid_mols.sort(key=lambda m: float(m.GetProp('E_tot')))
+    # Sort by energy. E_tot is stored in Hartree; energy_cluster_window and
+    # the duplicate tolerance below are both in eV, so convert on read.
+    valid_mols.sort(key=e_tot_ev)
 
     # Cluster by energy
     clusters: list[list[Chem.Mol]] = []
     current_cluster: list[Chem.Mol] = [valid_mols[0]]
-    current_min_e = float(valid_mols[0].GetProp('E_tot'))
+    current_min_e = e_tot_ev(valid_mols[0])
 
     for mol in valid_mols[1:]:
-        e = float(mol.GetProp('E_tot'))
+        e = e_tot_ev(mol)
         if e - current_min_e <= energy_cluster_window:
             current_cluster.append(mol)
         else:
@@ -141,12 +146,11 @@ def _filter_within_cluster(
 
 
 def _mol_energy(mol: Chem.Mol) -> float | None:
-    """Return a mol's optimized energy (eV) from the ``E_tot`` property, or None.
+    """Return a mol's optimized energy in eV, or None.
 
-    Used by the duplicate-conformer test as an energy guard; ``None`` signals
-    "no usable energy" so callers fall back to RMSD-only comparison.
+    ``E_tot`` is stored in Hartree; the conversion lives in
+    ``Auto3D.utils.energy`` so this module and ``ranking``/``utils.chemistry``
+    cannot drift apart on it. ``None`` signals "no usable energy" so callers
+    fall back to RMSD-only comparison.
     """
-    try:
-        return float(mol.GetProp("E_tot"))
-    except (KeyError, ValueError):
-        return None
+    return try_e_tot_ev(mol)

--- a/src/Auto3D/models/adapter.py
+++ b/src/Auto3D/models/adapter.py
@@ -105,6 +105,7 @@ class ModelAdapter(Protocol):
         coords: torch.Tensor,
         species: torch.Tensor,
         charges: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute energies and forces.
 
@@ -112,6 +113,12 @@ class ModelAdapter(Protocol):
             coords: Atomic coordinates (batch, n_atoms, 3).
             species: Atomic numbers (batch, n_atoms).
             charges: Molecular charges (batch,).
+            atom_mask: Boolean (batch, n_atoms), True for real atoms and False
+                for padded slots, as returned by
+                :func:`Auto3D.batch_opt.padding.pad_from_mols`. Required from
+                any caller that passes a PADDED batch; ``None`` means every
+                slot holds a real atom. An adapter must never re-derive this by
+                comparing ``species`` against ``species_pad`` (audit C13).
 
         Returns:
             Tuple of (energies, forces) where energies has shape (batch,)
@@ -186,6 +193,7 @@ class BaseModelAdapter(ABC, nn.Module):
         coords: torch.Tensor,
         species: torch.Tensor,
         charges: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute energies and forces.
 
@@ -193,6 +201,13 @@ class BaseModelAdapter(ABC, nn.Module):
             coords: Atomic coordinates (batch, n_atoms, 3).
             species: Atomic numbers (batch, n_atoms).
             charges: Molecular charges (batch,).
+            atom_mask: Boolean (batch, n_atoms), True for real atoms and False
+                for padded slots, threaded through from
+                :func:`Auto3D.batch_opt.padding.pad_from_mols`. ``None`` means
+                "every slot is a real atom" and is correct only for an
+                unpadded batch. Subclasses that need to know which slots are
+                padding must use THIS mask, never a comparison against
+                ``self.species_pad`` (audit C13).
 
         Returns:
             Tuple of (energies, forces) where energies has shape (batch,)
@@ -256,20 +271,41 @@ class AIMNet2Adapter(BaseModelAdapter):
         coords: torch.Tensor,
         species: torch.Tensor,
         charges: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute energies (eV) and forces (eV/A) for a padded batch.
 
         Args:
             coords: (batch, n_atoms, 3); padded slots at coord_pad.
-            species: atomic numbers (batch, n_atoms); padded slots == species_pad (0).
+            species: atomic numbers (batch, n_atoms); padded slots at
+                species_pad. The VALUE is never inspected here -- see below.
             charges: molecular charges (batch,).
+            atom_mask: Boolean (batch, n_atoms), True for real atoms, as
+                returned by :func:`Auto3D.batch_opt.padding.pad_from_mols`.
+                Required for a padded batch. ``None`` means every slot is a
+                real atom, which is what the unpadded single-molecule callers
+                (``ASE/thermo.py``'s ASE Calculator, ``auto3d models test``)
+                want.
 
         Returns:
             (energy[batch], forces[batch, n_atoms, 3]) in eV and eV/A. Padded
             atom slots have zero force.
+
+        The real-atom mask is the caller's explicit ``atom_mask``, NEVER
+        ``species != self.species_pad``. This adapter's ``species_pad`` is 0
+        and it consumes raw atomic numbers, so the sentinel comparison deleted
+        atomic number 0 -- an R-group/dummy ``*`` atom, which
+        ``utils.validation._requires_aimnet`` routes to precisely this engine.
+        For ``*CCO`` the padder reported 9 real atoms and this adapter scored
+        8: the energy belonged to a different species, and the dummy atom got
+        exactly zero force and stayed frozen for the whole optimization. That
+        is the collision class ``padding.pad_from_mols`` documents (audit C13).
         """
         b, n = species.shape[0], species.shape[1]
-        mask = species != self.species_pad                     # (B, N) real-atom mask
+        if atom_mask is None:
+            mask = torch.ones((b, n), dtype=torch.bool, device=species.device)
+        else:
+            mask = atom_mask.to(device=species.device, dtype=torch.bool)
         coord_flat = coords[mask]                              # (M, 3)
         numbers_flat = species[mask]                           # (M,)
         mol_idx = torch.arange(b, device=species.device).unsqueeze(1).expand(b, n)[mask]  # (M,)
@@ -317,6 +353,7 @@ class ANI2xtAdapter(BaseModelAdapter):
         coords: torch.Tensor,
         species: torch.Tensor,
         charges: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute energies and forces using ANI2xt.
 
@@ -324,6 +361,11 @@ class ANI2xtAdapter(BaseModelAdapter):
             coords: Atomic coordinates (batch, n_atoms, 3).
             species: Indexed atomic species (batch, n_atoms).
             charges: Molecular charges (batch,) - not used by ANI2xt.
+            atom_mask: Accepted for interface uniformity and deliberately
+                unused: ANI consumes ``species_pad = -1`` as its own dummy-atom
+                index, so the model itself skips padded slots. -1 is not a
+                sentinel this adapter compares against, and it can never
+                collide with a real 0-based species index.
 
         Returns:
             Tuple of (energies, forces) in eV units.
@@ -362,6 +404,7 @@ class ANI2xAdapter(BaseModelAdapter):
         coords: torch.Tensor,
         species: torch.Tensor,
         charges: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute energies and forces using ANI2x.
 
@@ -369,6 +412,10 @@ class ANI2xAdapter(BaseModelAdapter):
             coords: Atomic coordinates (batch, n_atoms, 3).
             species: Atomic numbers (batch, n_atoms).
             charges: Molecular charges (batch,) - not used by ANI2x.
+            atom_mask: Accepted for interface uniformity and deliberately
+                unused: torchani consumes ``species_pad = -1`` as its own
+                dummy-atom index, which can never collide with a real atomic
+                number.
 
         Returns:
             Tuple of (energies, forces) in eV units.
@@ -448,6 +495,7 @@ class CustomModelAdapter(BaseModelAdapter):
         coords: torch.Tensor,
         species: torch.Tensor,
         charges: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute energies and forces using custom model.
 
@@ -455,6 +503,14 @@ class CustomModelAdapter(BaseModelAdapter):
             coords: Atomic coordinates (batch, n_atoms, 3).
             species: Atomic numbers or indexed species (batch, n_atoms).
             charges: Molecular charges (batch,).
+            atom_mask: Accepted for interface uniformity and NOT forwarded:
+                the published custom-NNP contract
+                (:class:`Auto3D.models.contract.CustomNNP`) is
+                ``forward(species, coords, charges)``, so a user model
+                identifies its own padding from the ``species_pad`` value it
+                declared. Choose a ``species_pad`` that cannot collide with a
+                real species index (-1 is always safe); see the class
+                docstring.
 
         Returns:
             Tuple of (energies, forces) in eV units.

--- a/src/Auto3D/ranking.py
+++ b/src/Auto3D/ranking.py
@@ -8,8 +8,9 @@ from rdkit import Chem
 from Auto3D.config import SELECTOR_FIELDS, check_selectors_mutually_exclusive
 from Auto3D.exceptions import ConfigurationError
 from Auto3D.filtering import filter_unique_optimized
-from Auto3D.utils import ev2kcalpermol, filter_unique, hartree2ev
+from Auto3D.utils import ev2kcalpermol, filter_unique
 from Auto3D.utils.chemistry import check_connectivity
+from Auto3D.utils.energy import E_TOT_HARTREE_PROP, E_TOT_PROP, e_tot_ev
 from Auto3D.utils.logging_config import get_logger
 from Auto3D.utils.stereo_check import stereo_preserved
 from Auto3D.utils.validation import check_output_not_input, check_output_overwrite
@@ -174,9 +175,10 @@ class ConformerRanker:
             logger.info(f"No structure converged for {name}.")
         else:
             #Adding relative energies
-            ref_energy = float(out_mols[0].GetProp('E_tot'))
+            # E_tot is stored in Hartree; E_rel(eV) is, as its name says, eV.
+            ref_energy = e_tot_ev(out_mols[0])
             for mol in out_mols:
-                my_energy = float(mol.GetProp('E_tot'))
+                my_energy = e_tot_ev(mol)
                 rel_energy = my_energy - ref_energy
                 mol.SetProp('E_rel(eV)', str(rel_energy))
         return out_mols
@@ -209,9 +211,13 @@ class ConformerRanker:
             name = names[0].strip()
             logger.info(f"No structure converged for {name}.")
         else:
-            ref_energy = float(out_mols_[0].GetProp('E_tot'))
+            # `window` was converted from kcal/mol to eV above, and E_tot is
+            # stored in Hartree, so both sides of the comparison are eV here.
+            # Reading the Hartree number as if it were eV is what made the
+            # window 27.2x too wide for an opt_geometry-produced input.
+            ref_energy = e_tot_ev(out_mols_[0])
             for mol in out_mols_:
-                my_energy = float(mol.GetProp('E_tot'))
+                my_energy = e_tot_ev(mol)
                 rel_energy = my_energy - ref_energy
                 if rel_energy <= window:
                     mol.SetProp('E_rel(eV)', str(rel_energy))
@@ -271,7 +277,7 @@ class ConformerRanker:
                 if converged:
                     mols.append(mol)
                     names.append(species_id(mol.GetProp('_Name')))
-                    energies.append(float(mol.GetProp('E_tot')))
+                    energies.append(e_tot_ev(mol))
 
         df = pd.DataFrame({"names": names, "energies": energies, "mols": mols})
         groups = df.groupby("names")
@@ -290,11 +296,14 @@ class ConformerRanker:
 
         with Chem.SDWriter(self.out_path) as f:
             for mol in results:
-                # Change the energy unit from eV back to Hartree
-                mol.SetProp('E_tot', str(float(mol.GetProp('E_tot'))/hartree2ev))
+                # E_tot arrives in Hartree and leaves in Hartree: every Auto3D
+                # writer stores this property in Hartree now (see
+                # Auto3D.utils.energy). This used to divide by hartree2ev here,
+                # which was correct only because batch_opt wrote eV -- so the
+                # same division was applied twice to an opt_geometry output.
                 # Unit-labeled sibling so consumers can't misread E_tot's units
                 # (E_tot is kept unlabeled for backward compatibility).
-                mol.SetProp('E_tot(Hartree)', mol.GetProp('E_tot'))
+                mol.SetProp(E_TOT_HARTREE_PROP, mol.GetProp(E_TOT_PROP))
                 mol.SetProp('E_rel(kcal/mol)', str(float(mol.GetProp('E_rel(eV)')) * ev2kcalpermol))
                 mol.ClearProp('E_rel(eV)')
                 # Strip the trailing <isomer>_<conformer> suffix, keeping the

--- a/src/Auto3D/tautomer.py
+++ b/src/Auto3D/tautomer.py
@@ -9,6 +9,7 @@ from Auto3D.auto3D import main
 from Auto3D.config import Auto3DOptions
 from Auto3D.exceptions import ConfigurationError
 from Auto3D.utils import hartree2kcalpermol
+from Auto3D.utils.energy import e_tot_hartree
 from Auto3D.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -71,12 +72,12 @@ def select_tautomers(sdf: str, k: int | None = None, window: float | None = None
     # the part before '@' -- this is the real tautomer-grouping separator (see
     # test_select_tautomers_groups_by_id), distinct from the '_' conformer index.
     ids = [title.split("@")[0].strip() for title in titles]
-    energies = [float(mol.GetProp("E_tot")) * hartree2kcalpermol for mol in mols]
+    energies = [e_tot_hartree(mol) * hartree2kcalpermol for mol in mols]
     df = pd.DataFrame({"id": ids, "energy": energies, "mol": mols})
     for group_name, group in df.groupby("id"):
         group = group.sort_values(by="energy")
         out_mols0 = list(group["mol"])
-        ref_energy = float(out_mols0[0].GetProp("E_tot")) * hartree2kcalpermol
+        ref_energy = e_tot_hartree(out_mols0[0]) * hartree2kcalpermol
         #select top k
         if k is not None:
             if k >= len(out_mols0):
@@ -84,7 +85,7 @@ def select_tautomers(sdf: str, k: int | None = None, window: float | None = None
             else:
                 out_mols = out_mols0[:k]
             for mol in out_mols:
-                mol_energy = float(mol.GetProp("E_tot")) * hartree2kcalpermol
+                mol_energy = e_tot_hartree(mol) * hartree2kcalpermol
                 e_rel = mol_energy - ref_energy
                 mol.SetProp("E_tautomer_relative(kcal/mol)", str(e_rel))
                 mol.SetProp("_Name", group_name)
@@ -92,7 +93,7 @@ def select_tautomers(sdf: str, k: int | None = None, window: float | None = None
         elif window is not None:
             out_mols = []
             for mol in out_mols0:
-                mol_energy = float(mol.GetProp("E_tot")) * hartree2kcalpermol
+                mol_energy = e_tot_hartree(mol) * hartree2kcalpermol
                 e_rel = mol_energy - ref_energy
                 if e_rel <= window:
                     mol.SetProp("E_tautomer_relative(kcal/mol)", str(e_rel))

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -28,6 +28,7 @@ from Auto3D.constants import (
     MAX_CONFORMERS_CAP,
     MIN_ATOM_DISTANCE,
 )
+from Auto3D.utils.energy import try_e_tot_ev
 from Auto3D.utils.stereo_check import stereo_descriptors_from_3d, stereo_preserved
 
 logger = logging.getLogger("auto3d")
@@ -524,17 +525,16 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
     # Heavy-atom RMSD alone collapses conformers that differ only in an O-H / N-H
     # rotor orientation. Guard with an energy check: a pair counts as duplicate
     # only when the RMSD is below ``crit`` AND the energies agree within
-    # DEFAULT_DUPLICATE_ENERGY_TOL. Mols without a usable 'E_tot' fall back to
-    # RMSD-only (energy guard cannot apply).
+    # DEFAULT_DUPLICATE_ENERGY_TOL (eV; 'E_tot' is stored in Hartree and is
+    # converted on read by Auto3D.utils.energy). Mols without a usable 'E_tot'
+    # fall back to RMSD-only (energy guard cannot apply).
     unique_mols: list[Chem.Mol] = []
     unique_noH: list[Chem.Mol] = []
     unique_energies: list[float | None] = []
     for mol_i in mols:
         mol_i_noH = Chem.RemoveHs(mol_i)
-        try:
-            e_i: float | None = float(mol_i.GetProp("E_tot"))
-        except (KeyError, ValueError):
-            e_i = None
+        # E_tot is stored in Hartree; DEFAULT_DUPLICATE_ENERGY_TOL is in eV.
+        e_i: float | None = try_e_tot_ev(mol_i)
         unique = True
         for mol_j_noH, e_j in zip(unique_noH, unique_energies, strict=True):
             try:

--- a/src/Auto3D/utils/energy.py
+++ b/src/Auto3D/utils/energy.py
@@ -1,0 +1,94 @@
+# src/Auto3D/utils/energy.py
+"""The one place that knows what unit the ``E_tot`` SDF property is in.
+
+``E_tot`` is written in **Hartree**, always, by every Auto3D writer. That is
+the unit README, ``docs/legacy-v2/source/usage.rst`` and ``main()``'s own
+"Energy unit: Hartree if implicit." log line have always claimed, and the unit
+``Auto3D.tautomer.select_tautomers`` has always read.
+
+Until 4.0.1 it was only *sometimes* true. ``batch_opt.optimizing.run`` wrote
+``E_tot`` in eV and ``ASE/geometry.opt_geometry`` converted the same tag to
+Hartree afterwards, so the identical property name carried two units depending
+on which entry point produced the file -- and the five in-package consumers
+(``ranking``, ``filtering``, ``utils.chemistry.filter_unique``) all hard-coded
+eV. Feeding an ``opt_geometry`` output straight to
+``ConformerRanker(window=2.0)`` therefore opened a window 27.2x too wide, kept
+3 conformers where 2 belong, reported ``E_rel`` 0.037 kcal/mol where the truth
+is 1.000, and wrote an ``E_tot(Hartree)`` that had been divided by 27.211
+twice.
+
+The fix is one unit for the property and one conversion boundary. Writers call
+:func:`set_e_tot_from_ev` (models produce eV); readers call :func:`e_tot_ev` /
+:func:`try_e_tot_ev` and get eV back, so every in-package energy tolerance
+(``DEFAULT_DUPLICATE_ENERGY_TOL``, ``DEFAULT_ENERGY_CLUSTER_WINDOW``, the
+kcal/mol -> eV window conversion in ``ranking``) keeps its documented eV
+meaning. Writers additionally set :data:`E_TOT_HARTREE_PROP`, the unit-labeled
+sibling, so a file states its own unit.
+"""
+from __future__ import annotations
+
+from rdkit import Chem
+
+from Auto3D.constants import HARTREE_TO_EV
+
+__all__ = [
+    "E_TOT_PROP",
+    "E_TOT_HARTREE_PROP",
+    "set_e_tot_from_ev",
+    "e_tot_hartree",
+    "e_tot_ev",
+    "try_e_tot_ev",
+]
+
+#: Unlabeled property name, kept for backward compatibility. Hartree.
+E_TOT_PROP = "E_tot"
+#: Unit-labeled sibling carrying the identical value.
+E_TOT_HARTREE_PROP = "E_tot(Hartree)"
+
+
+def set_e_tot_from_ev(mol: Chem.Mol, energy_ev: float, *, labeled: bool = True) -> None:
+    """Write ``E_tot`` (Hartree) from an energy the model produced in eV.
+
+    Args:
+        mol: Molecule to annotate, in place.
+        energy_ev: Total energy in eV -- the unit every Auto3D model adapter
+            returns (see ``Auto3D.models.adapter.ModelAdapter.forward``).
+        labeled: Also write the unit-labeled :data:`E_TOT_HARTREE_PROP`
+            sibling. Left True for anything a user reads.
+    """
+    hartree = float(energy_ev) / HARTREE_TO_EV
+    mol.SetProp(E_TOT_PROP, str(hartree))
+    if labeled:
+        mol.SetProp(E_TOT_HARTREE_PROP, mol.GetProp(E_TOT_PROP))
+
+
+def e_tot_hartree(mol: Chem.Mol) -> float:
+    """Return ``E_tot`` in Hartree, the unit it is stored in.
+
+    Raises:
+        KeyError: The molecule has no ``E_tot`` property.
+        ValueError: The property is not a number.
+    """
+    return float(mol.GetProp(E_TOT_PROP))
+
+
+def e_tot_ev(mol: Chem.Mol) -> float:
+    """Return ``E_tot`` converted to eV, the unit the filters compare in.
+
+    Raises:
+        KeyError: The molecule has no ``E_tot`` property.
+        ValueError: The property is not a number.
+    """
+    return e_tot_hartree(mol) * HARTREE_TO_EV
+
+
+def try_e_tot_ev(mol: Chem.Mol) -> float | None:
+    """``e_tot_ev`` for callers that treat a missing/garbled energy as absent.
+
+    Returns None instead of raising, which the duplicate-conformer energy
+    guard uses to mean "no usable energy, fall back to RMSD only".
+    """
+    try:
+        return e_tot_ev(mol)
+    except (KeyError, ValueError):
+        return None

--- a/tests/test_SPE.py
+++ b/tests/test_SPE.py
@@ -274,7 +274,7 @@ def test_calc_spe_uses_model_factory(tmp_path, monkeypatch):
         def __init__(self, model_adapter):
             enforce_args.append(model_adapter)
 
-        def forward_batched(self, coords, numbers, charges):
+        def forward_batched(self, coords, numbers, charges, atom_mask=None):
             n = coords.shape[0]
             return torch.zeros(n, dtype=torch.float64), torch.zeros_like(coords)
 

--- a/tests/test_adapter_atom_mask.py
+++ b/tests/test_adapter_atom_mask.py
@@ -1,0 +1,199 @@
+"""AIMNet2Adapter must take its real-atom mask from pad_from_mols, not species.
+
+``batch_opt/padding.py`` states the rule (audit C13): a caller identifies
+padding from the explicit ``atom_mask`` ``pad_from_mols`` returns, never by
+comparing ``species`` against ``species_pad``, because a padding value can
+collide with a real species index. ``AIMNet2Adapter`` declares
+``species_pad = 0`` and consumes raw atomic numbers, so the comparison it used
+to make deleted atomic number 0 -- an R-group / dummy ``*`` atom.
+``utils.validation._requires_aimnet`` routes exactly those molecules here
+(element 0 is outside the ANI set), so the collision was reachable by the
+default engine on ordinary input.
+
+These tests assert the numbers the adapter produces, not that a branch ran:
+the stub calculator's energy counts the atoms it was actually handed, and the
+scattered force on the dummy atom must be nonzero. No neural network potential
+is loaded -- ``AIMNet2Calculator`` is replaced by a recording stub and the
+adapter is built without its ``__init__``.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from Auto3D.batch_opt.padding import pad_from_mols
+from Auto3D.models.adapter import AIMNet2Adapter
+
+rdkit = pytest.importorskip("rdkit")
+from rdkit import Chem  # noqa: E402
+from rdkit.Chem import AllChem  # noqa: E402
+
+
+class _RecordingCalculator:
+    """Stand-in for ``aimnet.calculators.AIMNet2Calculator``.
+
+    Records the ragged batch it was given and returns an energy that is a
+    function of HOW MANY atoms it received (-1 eV per atom, grouped by
+    ``mol_idx``) plus a uniform +1 eV/A force on every atom it was told about.
+    Both make a dropped atom visible as a number rather than as a branch.
+    """
+
+    def __init__(self) -> None:
+        self.numbers: torch.Tensor | None = None
+        self.mol_idx: torch.Tensor | None = None
+
+    def __call__(self, data: dict, forces: bool = False) -> dict:
+        coord = data["coord"]
+        numbers = data["numbers"]
+        mol_idx = data["mol_idx"]
+        self.numbers = numbers.clone()
+        self.mol_idx = mol_idx.clone()
+
+        n_mols = int(mol_idx.max().item()) + 1 if mol_idx.numel() else 0
+        per_atom = torch.full((numbers.shape[0],), -1.0, dtype=torch.float)
+        energy = torch.zeros(n_mols, dtype=torch.float).index_add_(0, mol_idx, per_atom)
+
+        f = torch.zeros_like(coord)
+        f[:, 0] = 1.0
+        return {"energy": energy, "forces": f}
+
+
+def _stub_adapter(calc: _RecordingCalculator) -> AIMNet2Adapter:
+    """An AIMNet2Adapter around ``calc``, built without loading any model.
+
+    ``AIMNet2Adapter.__init__`` constructs a real ``AIMNet2Calculator`` (model
+    download + load), so the instance is created directly and given exactly the
+    attributes ``forward`` reads.
+    """
+    adapter = AIMNet2Adapter.__new__(AIMNet2Adapter)
+    nn.Module.__init__(adapter)
+    adapter.device = torch.device("cpu")
+    adapter.coord_pad = 0.0
+    adapter.species_pad = 0
+    adapter.model_name = "stub"
+    adapter._compiled = False
+    adapter.model = nn.Identity()
+    adapter._calc = calc
+    return adapter
+
+
+def _embed(smiles: str, name: str) -> Chem.Mol:
+    mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    AllChem.EmbedMolecule(mol, randomSeed=42)
+    mol.SetProp("_Name", name)
+    return mol
+
+
+class TestDummyAtomIsNotTreatedAsPadding:
+    """``*CCO``: 9 real atoms, one of them atomic number 0."""
+
+    @staticmethod
+    def _pad(mols):
+        return pad_from_mols(
+            mols, "AIMNET", torch.device("cpu"), coord_pad=0.0, species_pad=0
+        )
+
+    def test_r_group_atom_is_counted(self):
+        mol = _embed("*CCO", "rgroup")
+        assert mol.GetNumAtoms() == 9
+        assert mol.GetAtomWithIdx(0).GetAtomicNum() == 0, "atom 0 is the dummy"
+
+        coords, species, charges, atom_mask = self._pad([mol])
+        assert int(atom_mask.sum()) == 9
+
+        calc = _RecordingCalculator()
+        adapter = _stub_adapter(calc)
+        energy, forces = adapter.forward(coords, species, charges, atom_mask=atom_mask)
+
+        # The calculator saw every atom, dummy included.
+        assert calc.numbers.numel() == 9
+        assert 0 in calc.numbers.tolist()
+        # -1 eV per atom: 9 atoms is -9, and the sentinel-derived mask gave -8.
+        assert float(energy[0]) == pytest.approx(-9.0)
+
+    def test_r_group_atom_receives_a_nonzero_force(self):
+        mol = _embed("*CCO", "rgroup")
+        coords, species, charges, atom_mask = self._pad([mol])
+
+        adapter = _stub_adapter(_RecordingCalculator())
+        _, forces = adapter.forward(coords, species, charges, atom_mask=atom_mask)
+
+        # A dummy atom excluded as padding keeps exactly zero force forever, so
+        # it is frozen for the entire optimization while the rest relaxes
+        # around it.
+        assert float(forces[0, 0, 0]) == pytest.approx(1.0)
+        assert forces[0, 0].abs().sum() > 0.0
+        # Every real atom got its force scattered back.
+        assert torch.all(forces[0, :, 0] == 1.0)
+
+
+class TestRealPaddingIsStillExcluded:
+    """The mask must still drop genuine padded slots (AIMNet2 NaNs on them)."""
+
+    def test_padded_slots_are_dropped_and_get_zero_force(self):
+        big = _embed("*CCO", "rgroup")   # 9 atoms
+        small = _embed("O", "water")     # 3 atoms
+        coords, species, charges, atom_mask = pad_from_mols(
+            [big, small], "AIMNET", torch.device("cpu"),
+            coord_pad=0.0, species_pad=0,
+        )
+        assert species.shape == (2, 9)
+        assert int(atom_mask.sum()) == 12
+
+        calc = _RecordingCalculator()
+        adapter = _stub_adapter(calc)
+        energy, forces = adapter.forward(coords, species, charges, atom_mask=atom_mask)
+
+        assert calc.numbers.numel() == 12
+        assert float(energy[0]) == pytest.approx(-9.0)
+        assert float(energy[1]) == pytest.approx(-3.0)
+        # Water's 6 padded slots keep zero force; its 3 real atoms do not.
+        assert torch.all(forces[1, 3:] == 0.0)
+        assert torch.all(forces[1, :3, 0] == 1.0)
+
+
+class TestUnpaddedCallersNeedNoMask:
+    """``atom_mask=None`` means "every slot is a real atom"."""
+
+    def test_no_mask_treats_every_slot_as_real(self):
+        mol = _embed("*CCO", "rgroup")
+        coords, species, charges, _ = pad_from_mols(
+            [mol], "AIMNET", torch.device("cpu"), coord_pad=0.0, species_pad=0
+        )
+        calc = _RecordingCalculator()
+        energy, _ = _stub_adapter(calc).forward(coords, species, charges)
+        assert calc.numbers.numel() == 9
+        assert float(energy[0]) == pytest.approx(-9.0)
+
+
+class TestMaskReachesTheAdapterThroughTheStack:
+    """EnForce_ANI must slice and forward the mask, not swallow it."""
+
+    def test_forward_batched_forwards_the_mask_per_sub_batch(self):
+        from Auto3D.batch_opt.model_wrapper import EnForce_ANI
+
+        seen: list[int] = []
+
+        class _CountingAdapter(nn.Module):
+            coord_pad = 0.0
+            species_pad = 0
+
+            def forward(self, coords, species, charges, atom_mask=None):
+                assert atom_mask is not None, "the mask must survive the split"
+                seen.append(int(atom_mask.sum()))
+                n = int(atom_mask.sum())
+                energy = torch.full((coords.shape[0],), float(-n), dtype=torch.double)
+                return energy, torch.zeros_like(coords)
+
+        big = _embed("*CCO", "rgroup")
+        small = _embed("O", "water")
+        coords, species, charges, atom_mask = pad_from_mols(
+            [big, small], "AIMNET", torch.device("cpu"),
+            coord_pad=0.0, species_pad=0,
+        )
+        # batchsize_atoms=9 with N=9 gives one molecule per sub-batch, so the
+        # mask has to be sliced with the same indices as coord/numbers.
+        wrapper = EnForce_ANI(_CountingAdapter(), 9)
+        wrapper.forward_batched(coords, species, charges, atom_mask=atom_mask)
+        assert seen == [9, 3]

--- a/tests/test_ase_geometry.py
+++ b/tests/test_ase_geometry.py
@@ -36,7 +36,7 @@ def test_opt_geometry_skips_none_and_missing_etot(monkeypatch, tmp_path):
     good = Chem.AddHs(Chem.MolFromSmiles("CCO"))
     AllChem.EmbedMolecule(good, randomSeed=1)
     good.SetProp("_Name", "good")
-    good.SetProp("E_tot", "-100.0")  # eV
+    good.SetProp("E_tot", "-100.0")  # Hartree, as optimizing.run() writes it
     no_etot = Chem.AddHs(Chem.MolFromSmiles("CCO"))
     AllChem.EmbedMolecule(no_etot, randomSeed=2)
     no_etot.SetProp("_Name", "no_etot")  # deliberately missing E_tot

--- a/tests/test_batchopt.py
+++ b/tests/test_batchopt.py
@@ -89,7 +89,7 @@ class TestEnForceANI:
         """EnForce_ANI.forward_batched should batch calls correctly."""
         mock_adapter = MagicMock()
         # Return consistent results for batching
-        def mock_forward(coords, species, charges):
+        def mock_forward(coords, species, charges, atom_mask=None):
             batch_size = coords.shape[0]
             return torch.ones(batch_size), torch.ones(batch_size, coords.shape[1], 3)
 

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -159,7 +159,7 @@ class TestAuxiliaryEntryPointGuards:
             def __init__(self, adapter):
                 pass
 
-            def forward_batched(self, coords, numbers, charges):
+            def forward_batched(self, coords, numbers, charges, atom_mask=None):
                 n = coords.shape[0]
                 return torch.ones(n, dtype=torch.float64), torch.zeros_like(coords)
 

--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -398,7 +398,7 @@ class TestSameFileGuard:
             def __init__(self, adapter):
                 pass
 
-            def forward_batched(self, coords, numbers, charges):
+            def forward_batched(self, coords, numbers, charges, atom_mask=None):
                 n = coords.shape[0]
                 return torch.ones(n, dtype=torch.float64), torch.zeros_like(coords)
 
@@ -861,7 +861,7 @@ class TestOutputOverwriteGuard:
             def __init__(self, adapter):
                 pass
 
-            def forward_batched(self, coords, numbers, charges):
+            def forward_batched(self, coords, numbers, charges, atom_mask=None):
                 n = coords.shape[0]
                 return torch.ones(n, dtype=torch.float64), torch.zeros_like(coords)
 

--- a/tests/test_e_tot_units.py
+++ b/tests/test_e_tot_units.py
@@ -1,0 +1,194 @@
+"""``E_tot`` is Hartree at every writer, and every reader agrees.
+
+Before this, ``batch_opt.optimizing.run`` wrote ``E_tot`` in **eV** and
+``ASE/geometry.opt_geometry`` rewrote the same tag in **Hartree**, while the
+in-package consumers (``ranking``, ``filtering``, ``utils.chemistry``) all
+hard-coded eV. The property name meant two different things depending on which
+entry point produced the file, and nothing in the file said which.
+
+The consequence these tests pin is the one a user hits without doing anything
+unusual: feed an ``opt_geometry`` output to ``ConformerRanker(window=2.0)``.
+Reading a Hartree number as eV makes the window 27.211x too wide, so a
+3-conformer set that should yield 2 yields 3, ``E_rel`` reads 0.037 kcal/mol
+where the truth is 1.000, and the ranker's own eV->Hartree conversion runs on
+an already-Hartree number, dividing by 27.211 twice.
+
+No neural network potential is loaded: ``ensemble_opt`` and ``create_model``
+are stubbed at the model boundary, exactly as ``tests/test_batchopt.py`` does,
+so the real padder, the real ``optimizing.run`` writer, the real
+``_annotate_and_rewrite`` and the real ranker all execute.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from Auto3D.constants import EV_TO_KCAL_PER_MOL, HARTREE_TO_EV
+from Auto3D.utils.energy import E_TOT_HARTREE_PROP, E_TOT_PROP, e_tot_ev
+
+#: Three conformers of one species, 0 / 1 / 3 kcal/mol apart. A 2 kcal/mol
+#: window must admit the first two and refuse the third.
+BASE_EV = -10.0
+ENERGIES_EV = [
+    BASE_EV,
+    BASE_EV + 1.0 / EV_TO_KCAL_PER_MOL,
+    BASE_EV + 3.0 / EV_TO_KCAL_PER_MOL,
+]
+
+
+def _write_input(path, names) -> None:
+    """Three embedded conformers of ethanol, named <species>_<isomer>_<conf>."""
+    with Chem.SDWriter(str(path)) as w:
+        for i, name in enumerate(names):
+            mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+            AllChem.EmbedMolecule(mol, randomSeed=i + 1)
+            mol.SetProp("_Name", name)
+            w.write(mol)
+
+
+def _stub_model_boundary(monkeypatch, energies_ev):
+    """Replace the NNP with a table of energies; everything else stays real."""
+    import Auto3D.batch_opt.batchopt as bo
+
+    def fake_ensemble_opt(net, coord, numbers, charges, param, device,
+                          atom_mask=None, progress_cb=None):
+        n = len(coord)
+        return dict(
+            coord=coord.tolist(), ids=list(range(n)),
+            energy=list(energies_ev[:n]), fmax=[0.0] * n, he=[], close=[],
+            timing={}, numbers=numbers.tolist(),
+            converged_mask=[True] * n, oscillating_count=[0] * n,
+        )
+
+    monkeypatch.setattr(bo, "ensemble_opt", fake_ensemble_opt)
+    monkeypatch.setattr(
+        bo, "create_model",
+        lambda *a, **k: SimpleNamespace(coord_pad=0.0, species_pad=-1),
+    )
+
+
+class TestOptimizerWritesHartree:
+    """``optimizing.run`` is the first writer; it owns the conversion."""
+
+    def test_e_tot_is_the_model_energy_in_hartree(self, tmp_path, monkeypatch):
+        import Auto3D.batch_opt.batchopt as bo
+
+        _stub_model_boundary(monkeypatch, ENERGIES_EV)
+        inp = tmp_path / "in.sdf"
+        out = tmp_path / "out.sdf"
+        _write_input(inp, ["spec_0_0", "spec_0_1", "spec_0_2"])
+
+        bo.optimizing(
+            str(inp), str(out), "AIMNET", torch.device("cpu"),
+            {"opt_steps": 1, "opttol": 0.01, "patience": 1, "batchsize_atoms": 1024},
+        ).run()
+
+        mols = [m for m in Chem.SDMolSupplier(str(out), removeHs=False) if m]
+        assert len(mols) == 3
+        for mol, energy_ev in zip(mols, ENERGIES_EV, strict=True):
+            stored = float(mol.GetProp(E_TOT_PROP))
+            # Hartree, not eV: the eV value is 27.211x larger in magnitude.
+            assert stored == pytest.approx(energy_ev / HARTREE_TO_EV, rel=1e-9)
+            assert e_tot_ev(mol) == pytest.approx(energy_ev, rel=1e-9)
+
+
+class TestOptGeometryDoesNotConvertTwice:
+    """``opt_geometry`` annotates the unit; it must not re-divide."""
+
+    def test_output_energy_is_the_model_energy_in_hartree(self, tmp_path, monkeypatch):
+        import Auto3D.ASE.geometry as geo
+
+        _stub_model_boundary(monkeypatch, ENERGIES_EV)
+        inp = tmp_path / "mols.sdf"
+        _write_input(inp, ["spec_0_0", "spec_0_1", "spec_0_2"])
+
+        out = geo.opt_geometry(str(inp), "AIMNET", use_gpu=False)
+
+        mols = [m for m in Chem.SDMolSupplier(out, removeHs=False) if m]
+        assert len(mols) == 3
+        for mol, energy_ev in zip(mols, ENERGIES_EV, strict=True):
+            assert float(mol.GetProp(E_TOT_PROP)) == pytest.approx(
+                energy_ev / HARTREE_TO_EV, rel=1e-9
+            )
+            # The property name states its unit, and states it truthfully.
+            assert mol.GetProp(E_TOT_HARTREE_PROP) == mol.GetProp(E_TOT_PROP)
+
+
+class TestOptGeometryOutputRanksCorrectly:
+    """The chain the brief demonstrates: opt_geometry -> ConformerRanker."""
+
+    def test_a_2_kcal_window_admits_two_of_three(self, tmp_path, monkeypatch):
+        import Auto3D.ASE.geometry as geo
+        from Auto3D.ranking import ConformerRanker
+
+        _stub_model_boundary(monkeypatch, ENERGIES_EV)
+        inp = tmp_path / "mols.sdf"
+        _write_input(inp, ["spec_0_0", "spec_0_1", "spec_0_2"])
+        optimized = geo.opt_geometry(str(inp), "AIMNET", use_gpu=False)
+
+        ranked = tmp_path / "ranked.sdf"
+        results = ConformerRanker(
+            input_path=optimized, out_path=str(ranked), threshold=0.3, window=2.0,
+        ).run()
+
+        # 2, not 3: the third conformer is 3 kcal/mol up, outside a 2 kcal/mol
+        # window. Reading Hartree as eV widens the window 27.211x and keeps it.
+        assert len(results) == 2
+
+        rel = [float(m.GetProp("E_rel(kcal/mol)")) for m in results]
+        assert rel[0] == pytest.approx(0.0, abs=1e-9)
+        # 1.000, not 0.037.
+        assert rel[1] == pytest.approx(1.0, abs=1e-6)
+
+    def test_ranked_energy_is_not_divided_twice(self, tmp_path, monkeypatch):
+        import Auto3D.ASE.geometry as geo
+        from Auto3D.ranking import ConformerRanker
+
+        _stub_model_boundary(monkeypatch, ENERGIES_EV)
+        inp = tmp_path / "mols.sdf"
+        _write_input(inp, ["spec_0_0", "spec_0_1", "spec_0_2"])
+        optimized = geo.opt_geometry(str(inp), "AIMNET", use_gpu=False)
+
+        ranked = tmp_path / "ranked.sdf"
+        ConformerRanker(
+            input_path=optimized, out_path=str(ranked), threshold=0.3, k=1,
+        ).run()
+
+        out = [m for m in Chem.SDMolSupplier(str(ranked), removeHs=False) if m]
+        assert len(out) == 1
+        expected_hartree = min(ENERGIES_EV) / HARTREE_TO_EV
+        assert float(out[0].GetProp(E_TOT_PROP)) == pytest.approx(
+            expected_hartree, rel=1e-9
+        )
+        # Dividing by 27.211 a second time would land here instead.
+        assert float(out[0].GetProp(E_TOT_PROP)) != pytest.approx(
+            expected_hartree / HARTREE_TO_EV, rel=1e-3
+        )
+        assert out[0].GetProp(E_TOT_HARTREE_PROP) == out[0].GetProp(E_TOT_PROP)
+
+
+class TestTautomerSelectionReadsTheSameUnit:
+    """``select_tautomers`` has always read Hartree; now every writer agrees."""
+
+    def test_relative_tautomer_energy_is_kcal_per_mol(self, tmp_path, monkeypatch):
+        import Auto3D.batch_opt.batchopt as bo
+        from Auto3D.tautomer import select_tautomers
+
+        _stub_model_boundary(monkeypatch, ENERGIES_EV[:2])
+        inp = tmp_path / "in.sdf"
+        out = tmp_path / "opt.sdf"
+        _write_input(inp, ["id1@taut0_0_0", "id1@taut1_0_0"])
+        bo.optimizing(
+            str(inp), str(out), "AIMNET", torch.device("cpu"),
+            {"opt_steps": 1, "opttol": 0.01, "patience": 1, "batchsize_atoms": 1024},
+        ).run()
+
+        selected = select_tautomers(str(out), k=2)
+        mols = [m for m in Chem.SDMolSupplier(selected, removeHs=False) if m]
+        rel = sorted(float(m.GetProp("E_tautomer_relative(kcal/mol)")) for m in mols)
+        assert rel[0] == pytest.approx(0.0, abs=1e-9)
+        assert rel[1] == pytest.approx(1.0, abs=1e-6)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -7,16 +7,24 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 from Auto3D.filtering import filter_unique_optimized, _filter_within_cluster
+from Auto3D.utils.energy import set_e_tot_from_ev
 
 
-def _create_mol_with_energy(smiles: str, energy: float, converged: bool = True) -> Chem.Mol:
-    """Helper to create a test molecule with properties set."""
+def _create_mol_with_energy(smiles: str, energy_ev: float, converged: bool = True) -> Chem.Mol:
+    """Helper to create a test molecule with properties set.
+
+    ``energy_ev`` is in eV, which is the unit this module's thresholds
+    (``rmsd_threshold``'s companion ``energy_tol``, ``energy_cluster_window``)
+    are documented in and the unit the filters compare in. The SDF property
+    itself is written in Hartree, through the same boundary helper the
+    optimizer uses, because that is what a real input file carries.
+    """
     mol = Chem.MolFromSmiles(smiles)
     mol = Chem.AddHs(mol)
     AllChem.EmbedMolecule(mol, randomSeed=42)
     AllChem.MMFFOptimizeMolecule(mol)
     mol.SetProp('Converged', 'true' if converged else 'false')
-    mol.SetProp('E_tot', str(energy))
+    set_e_tot_from_ev(mol, energy_ev)
     return mol
 
 
@@ -128,7 +136,9 @@ class TestFilterUniqueOptimized:
             rmsd_threshold=0.5
         )
 
-        energies = [float(mol.GetProp('E_tot')) for mol in result]
+        from Auto3D.utils.energy import e_tot_ev
+
+        energies = [e_tot_ev(mol) for mol in result]
         assert energies == sorted(energies)
 
     def test_energy_clustering_groups_similar_energies(self):
@@ -201,12 +211,12 @@ class TestFilterUniqueBehavior:
         """
         from Auto3D.utils import filter_unique
 
-        def conformer(seed: float, energy: float) -> Chem.Mol:
+        def conformer(seed: float, energy_ev: float) -> Chem.Mol:
             m = Chem.AddHs(Chem.MolFromSmiles("CCCCCCO"))  # flexible chain
             AllChem.EmbedMolecule(m, randomSeed=seed)
             AllChem.MMFFOptimizeMolecule(m)
             m.SetProp("Converged", "true")
-            m.SetProp("E_tot", str(energy))
+            set_e_tot_from_ev(m, energy_ev)
             return m
 
         mols = [conformer(42, -12.0), conformer(7, -11.0), conformer(123, -10.0)]
@@ -240,9 +250,11 @@ def test_filter_within_cluster_removehs_is_linear_and_nondestructive(monkeypatch
     mols = []
     base = Chem.AddHs(Chem.MolFromSmiles("CCCCO"))
     cids = AllChem.EmbedMultipleConfs(base, numConfs=5, randomSeed=1)
+    from Auto3D.utils.energy import set_e_tot_from_ev as _set_e
+
     for cid in cids:
         m = Chem.Mol(base, confId=int(cid))
-        m.SetProp("E_tot", "0.0")
+        _set_e(m, 0.0)
         m.SetProp("Converged", "true")
         mols.append(m)
     n_atoms = base.GetNumAtoms()  # heavy + explicit H (15 for CCCCO)
@@ -277,7 +289,8 @@ def test_rmsd_failure_keeps_both(monkeypatch):
     def make(name, e):
         m = Chem.AddHs(Chem.MolFromSmiles("CCO"))
         AllChem.EmbedMolecule(m, randomSeed=abs(hash(name)) % 1000)
-        m.SetProp("_Name", name); m.SetProp("E_tot", str(e))
+        m.SetProp("_Name", name)
+        set_e_tot_from_ev(m, e)
         return m
 
     def boom(*a, **k):

--- a/tests/test_isomer_engine_hardening.py
+++ b/tests/test_isomer_engine_hardening.py
@@ -279,7 +279,7 @@ class TestSpeFiltersAndAligns:
             def __init__(self, adapter):
                 self.adapter = adapter
 
-            def forward_batched(self, coords, numbers, charges):
+            def forward_batched(self, coords, numbers, charges, atom_mask=None):
                 n = coords.shape[0]
                 captured["n"] = n
                 es = torch.arange(1, n + 1, dtype=torch.float64) * 10.0

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -245,10 +245,14 @@ def test_aimnet2_adapter_padded_batch_matches_unpadded(aimnet_model):
     e_w, _ = ad.forward(water_c.unsqueeze(0), water_n.unsqueeze(0), torch.zeros(1))
     e_m, _ = ad.forward(meth_c.unsqueeze(0), meth_n.unsqueeze(0), torch.zeros(1))
 
-    # padded batch: water padded to 5 with species_pad=0
+    # padded batch: water padded to 5 with species_pad=0. The real-atom mask
+    # is passed explicitly (as pad_from_mols returns it); the adapter must not
+    # re-derive it from `species == species_pad`, which would also delete a
+    # legitimate atomic number 0 (an R-group `*` atom) -- audit C13.
     bc = torch.zeros(2,5,3); bc[0,:3]=water_c; bc[1,:5]=meth_c
     bn = torch.zeros(2,5,dtype=torch.long); bn[0,:3]=water_n; bn[1,:5]=meth_n
-    e_b, f_b = ad.forward(bc, bn, torch.zeros(2))
+    bm = torch.zeros(2,5,dtype=torch.bool); bm[0,:3]=True; bm[1,:5]=True
+    e_b, f_b = ad.forward(bc, bn, torch.zeros(2), atom_mask=bm)
     assert f_b.shape == (2,5,3)
     assert abs(float(e_b[0]) - float(e_w[0])) < 1e-2  # padded water == solo water (NaN-free!)
     assert abs(float(e_b[1]) - float(e_m[0])) < 1e-2

--- a/tests/test_model_wrapper.py
+++ b/tests/test_model_wrapper.py
@@ -70,7 +70,7 @@ class TestEnForceANIForwardBatched:
         """forward_batched should split large batches based on batchsize_atoms."""
         mock_adapter = MagicMock()
 
-        def mock_forward(coords, species, charges):
+        def mock_forward(coords, species, charges, atom_mask=None):
             batch_size = coords.shape[0]
             return torch.ones(batch_size), torch.ones(batch_size, coords.shape[1], 3)
 
@@ -116,7 +116,7 @@ class TestEnForceANIForwardBatched:
         """forward_batched should handle exact batch size boundaries."""
         mock_adapter = MagicMock()
 
-        def mock_forward(coords, species, charges):
+        def mock_forward(coords, species, charges, atom_mask=None):
             batch_size = coords.shape[0]
             return torch.ones(batch_size), torch.ones(batch_size, coords.shape[1], 3)
 
@@ -140,7 +140,7 @@ class TestEnForceANIForwardBatched:
         """forward_batched should process at least 1 molecule per batch."""
         mock_adapter = MagicMock()
 
-        def mock_forward(coords, species, charges):
+        def mock_forward(coords, species, charges, atom_mask=None):
             batch_size = coords.shape[0]
             return torch.ones(batch_size), torch.ones(batch_size, coords.shape[1], 3)
 
@@ -230,7 +230,7 @@ def test_forward_batched_retries_on_oom():
         coord_pad = 0.0
         species_pad = -1
 
-        def forward(self, coord, numbers, charges):
+        def forward(self, coord, numbers, charges, atom_mask=None):
             if coord.shape[0] > 1:
                 raise torch.cuda.OutOfMemoryError("CUDA out of memory (simulated)")
             return coord.pow(2).sum(dim=(1, 2)), torch.zeros_like(coord)

--- a/tests/test_optimization_engine.py
+++ b/tests/test_optimization_engine.py
@@ -199,7 +199,7 @@ class TestNSteps:
         """n_steps should stop early when all structures converge."""
         call_count = [0]
 
-        def mock_forward(coord, numbers, charges):
+        def mock_forward(coord, numbers, charges, atom_mask=None):
             call_count[0] += 1
             batch_size = coord.shape[0]
             # Return very small forces so convergence happens immediately
@@ -228,7 +228,7 @@ class TestNSteps:
         """n_steps should mark oscillating structures as converged (dropped)."""
         step_count = [0]
 
-        def mock_forward(coord, numbers, charges):
+        def mock_forward(coord, numbers, charges, atom_mask=None):
             step_count[0] += 1
             batch_size = coord.shape[0]
             # Return forces that never decrease (always same value)
@@ -285,7 +285,7 @@ class _ConstantForceNN:
         self.energy_stable = energy_stable
         self.calls = 0
 
-    def forward_batched(self, coord, numbers, charges):
+    def forward_batched(self, coord, numbers, charges, atom_mask=None):
         self.calls += 1
         batch = coord.shape[0]
         value = -10.0 if self.energy_stable else -10.0 - self.calls
@@ -427,7 +427,7 @@ def test_fmax_ignores_padded_atoms():
     from Auto3D.batch_opt.optimization_engine import n_steps
 
     class MockNN:
-        def forward_batched(self, coord, numbers, charges):
+        def forward_batched(self, coord, numbers, charges, atom_mask=None):
             e = torch.zeros(coord.shape[0])
             f = torch.zeros_like(coord)
             f[:, 0, :] = 100.0  # huge force on the real atom at index 0 (species 0)
@@ -454,7 +454,7 @@ def test_stored_energy_matches_stored_coord():
     from Auto3D.batch_opt.optimization_engine import n_steps
 
     class MockNN:
-        def forward_batched(self, coord, numbers, charges):
+        def forward_batched(self, coord, numbers, charges, atom_mask=None):
             e = (coord ** 2).sum(dim=(1, 2))
             f = -2.0 * coord
             return e, f
@@ -490,7 +490,7 @@ def test_stored_fmax_matches_stored_coord():
     from Auto3D.batch_opt.optimization_engine import n_steps
 
     class MockNN:
-        def forward_batched(self, coord, numbers, charges):
+        def forward_batched(self, coord, numbers, charges, atom_mask=None):
             e = (coord ** 2).sum(dim=(1, 2))
             f = -2.0 * coord
             return e, f
@@ -520,7 +520,7 @@ class TestNStepsIntegration:
         """n_steps should converge structures with decreasing forces."""
         step_count = [0]
 
-        def mock_forward(coord, numbers, charges):
+        def mock_forward(coord, numbers, charges, atom_mask=None):
             step_count[0] += 1
             batch_size = coord.shape[0]
             # Simulate forces that decrease with each step

--- a/tests/test_padding_invariance.py
+++ b/tests/test_padding_invariance.py
@@ -52,17 +52,22 @@ class TestPaddingInvariance:
         # (src/Auto3D/models/adapter.py:240, :302).
         coord_pad, species_pad = model.coord_pad, model.species_pad
 
-        # Alone: no padding at all.
-        c1, s1, q1, _ = pad_from_mols(
+        # Alone: no padding at all. The explicit atom_mask is forwarded in
+        # both calls: an adapter that has to strip padding (AIMNet2) takes it
+        # from here rather than re-deriving it from `species == species_pad`,
+        # which deletes a real atomic number 0 along with the padding
+        # (audit C13). Without it a padded AIMNET batch reaches the model with
+        # Z=0 ghosts at the origin and returns NaN.
+        c1, s1, q1, m1 = pad_from_mols(
             [small], engine, device, coord_pad=coord_pad, species_pad=species_pad
         )
-        e_alone = model.forward(c1, s1, q1)[0][0]
+        e_alone = model.forward(c1, s1, q1, atom_mask=m1)[0][0]
 
         # Batched with a larger molecule: `small` is now padded to `large`'s size.
-        c2, s2, q2, _ = pad_from_mols(
+        c2, s2, q2, m2 = pad_from_mols(
             [small, large], engine, device, coord_pad=coord_pad, species_pad=species_pad
         )
-        e_padded = model.forward(c2, s2, q2)[0][0]
+        e_padded = model.forward(c2, s2, q2, atom_mask=m2)[0][0]
 
         delta = abs(float(e_alone) - float(e_padded))
         assert delta < atol, (

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -97,7 +97,7 @@ class _SpeciesForceNN:
     def __init__(self, force_by_species: dict[int, float]) -> None:
         self.force_by_species = force_by_species
 
-    def forward_batched(self, coord, numbers, charges):
+    def forward_batched(self, coord, numbers, charges, atom_mask=None):
         e = torch.zeros(coord.shape[0])
         f = torch.zeros_like(coord)
         for row in range(coord.shape[0]):

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -9,21 +9,30 @@ import pytest
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
+from Auto3D.utils.energy import e_tot_ev, set_e_tot_from_ev
+
 
 def _create_mol_with_energy(
     smiles: str,
-    energy: float,
+    energy_ev: float,
     name: str,
     converged: bool = True,
 ) -> Chem.Mol:
-    """Helper to create a test molecule with properties set."""
+    """Helper to create a test molecule with properties set.
+
+    ``energy_ev`` is in eV -- the unit ``energy_cluster_window`` and the
+    duplicate-energy tolerance are documented in, and the unit the ranker
+    compares in after converting on read. The ``E_tot`` property is written in
+    Hartree through the shared boundary helper, matching what
+    ``optimizing.run()`` puts in a real input file.
+    """
     mol = Chem.MolFromSmiles(smiles)
     mol = Chem.AddHs(mol)
     AllChem.EmbedMolecule(mol, randomSeed=42)
     AllChem.MMFFOptimizeMolecule(mol)
     mol.SetProp('_Name', name)
     mol.SetProp('Converged', 'true' if converged else 'false')
-    mol.SetProp('E_tot', str(energy))
+    set_e_tot_from_ev(mol, energy_ev)
     return mol
 
 
@@ -234,7 +243,7 @@ class TestConformerRankerTopK:
         # Should return exactly 1 molecule
         assert len(results) == 1
         # Should be the lowest energy one
-        assert float(results[0].GetProp('E_tot')) == -10.0
+        assert e_tot_ev(results[0]) == pytest.approx(-10.0)
 
     def test_top_k_equals_1_full_integration(self, tmp_path):
         """Integration test: k=1 should return single lowest-energy conformer."""
@@ -303,7 +312,7 @@ class TestConformerRankerTopK:
 
         # Must return the VALID conformer, not the broken lowest-energy one.
         assert len(results) == 1
-        assert float(results[0].GetProp('E_tot')) == -9.0
+        assert e_tot_ev(results[0]) == pytest.approx(-9.0)
 
     def test_top_k_equals_1_returns_empty_when_all_broken(self, tmp_path):
         """When k=1 and no conformer passes connectivity, return an empty list."""
@@ -583,7 +592,7 @@ class TestConformerRankerMissingConvergedProp:
         AllChem.EmbedMolecule(bad, randomSeed=42)
         AllChem.MMFFOptimizeMolecule(bad)
         bad.SetProp('_Name', "bad_1")
-        bad.SetProp('E_tot', str(-9.0))
+        set_e_tot_from_ev(bad, -9.0)
         assert not bad.HasProp('Converged')
 
         input_path = str(tmp_path / "input.sdf")

--- a/tests/test_thermo_helpers.py
+++ b/tests/test_thermo_helpers.py
@@ -1089,3 +1089,121 @@ class TestLoadHessianModelRouting:
         # ANI2xt/ANI2x branch above, which the previous test covers.)
         assert (name, device_arg, compile_model) == (str(fake_path), device, False)
         assert result.weight.dtype == torch.float64
+
+
+class TestCalculatorChargeInvalidatesCache:
+    """A charge change must discard the energy AND forces cached at the old one.
+
+    ASE decides whether a cached result is still valid with
+    ``Calculator.check_state`` -> ``compare_atoms``, which looks at positions,
+    atomic numbers, cell and pbc only. The molecular charge is invisible to it,
+    so a calculator whose charge was reassigned without ``reset()`` handed the
+    PREVIOUS molecule's energy and gradient to the next one whenever the two
+    shared a geometry. That is exactly a vertical IP/EA input -- one geometry,
+    two charges -- where the error is the whole ionization energy or electron
+    affinity (20-90 kcal/mol) and nothing in the output says so.
+
+    These tests assert the NUMBERS, not that a code path ran: the stub model's
+    energy and forces are functions of the charge, so a reused cache shows up
+    as an identical energy/force for two different charges.
+    """
+
+    @staticmethod
+    def _calculator(charge=0):
+        """A ``Calculator`` over a stub whose energy/forces depend on charge.
+
+        The stub owns one real ``nn.Parameter`` on the CPU purely so
+        ``Calculator.__init__`` reads device/dtype from it: the param-less
+        branch falls back to ``cuda`` whenever a GPU happens to be visible,
+        which would make this test machine-dependent. No NNP is loaded.
+        """
+        import torch
+        from torch import nn
+
+        from Auto3D.ASE.thermo import Calculator
+
+        class _ChargeDependentModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                # Anchors device=cpu / dtype=float32 for the ASE-facing tensors.
+                self.anchor = nn.Parameter(torch.zeros(1))
+                self.calls = 0
+
+            def forward(self, coords, species, charges):
+                self.calls += 1
+                q = float(charges.reshape(-1)[0].item())
+                # E = -1 eV per unit charge; F = +0.5 q eV/A along x on atom 0.
+                energy = torch.tensor([-1.0 * q], dtype=torch.double)
+                forces = torch.zeros_like(coords)
+                forces[0, 0, 0] = 0.5 * q
+                return energy, forces
+
+        model = _ChargeDependentModel()
+        return Calculator(model, charge, model_name="AIMNET"), model
+
+    @staticmethod
+    def _atoms():
+        from ase import Atoms
+
+        # One fixed geometry reused at both charges -- the vertical IP/EA case.
+        return Atoms("H2", [(0.0, 0.0, 0.0), (0.0, 0.0, 0.74)])
+
+    def test_energy_recomputed_after_set_charge(self):
+        calc, model = self._calculator(charge=0)
+        atoms = self._atoms()
+        atoms.calc = calc
+
+        e_neutral = atoms.get_potential_energy()
+        calc.set_charge(1)
+        e_cation = atoms.get_potential_energy()
+
+        assert e_neutral == pytest.approx(0.0)
+        # The number, not the code path: a reused cache returns 0.0 here.
+        assert e_cation == pytest.approx(-1.0)
+        assert e_cation != e_neutral
+        assert model.calls == 2
+
+    def test_forces_recomputed_after_set_charge(self):
+        calc, _ = self._calculator(charge=0)
+        atoms = self._atoms()
+        atoms.calc = calc
+
+        f_neutral = atoms.get_forces()
+        calc.set_charge(2)
+        f_cation = atoms.get_forces()
+
+        # BFGS reads forces, not energy: a stale gradient makes it "converge"
+        # in zero steps on the previous molecule's geometry.
+        assert f_neutral[0, 0] == pytest.approx(0.0)
+        assert f_cation[0, 0] == pytest.approx(1.0)
+        assert not np.allclose(f_neutral, f_cation)
+
+    def test_direct_charge_assignment_also_invalidates(self):
+        """``calc.charge = q`` is the same path as ``set_charge(q)``."""
+        calc, _ = self._calculator(charge=0)
+        atoms = self._atoms()
+        atoms.calc = calc
+
+        e_neutral = atoms.get_potential_energy()
+        calc.charge = -1
+        assert atoms.get_potential_energy() == pytest.approx(1.0)
+        assert atoms.get_potential_energy() != e_neutral
+
+    def test_charge_is_calculator_state_not_a_bare_attribute(self):
+        """The charge lives in ASE's own ``parameters`` dict."""
+        calc, _ = self._calculator(charge=0)
+        assert calc.parameters["charge"] == 0
+        calc.set_charge(-2)
+        assert calc.parameters["charge"] == -2
+        assert int(calc.charge.reshape(-1)[0].item()) == -2
+
+    def test_unchanged_charge_keeps_the_cache(self):
+        """Re-setting the same charge must not force a needless recompute."""
+        calc, model = self._calculator(charge=0)
+        atoms = self._atoms()
+        atoms.calc = calc
+
+        atoms.get_potential_energy()
+        calc.set_charge(0)
+        atoms.get_potential_energy()
+        assert model.calls == 1


### PR DESCRIPTION
Three defects that made Auto3D report **wrong numbers** — not crashes. All three were found by a systematic hunt run *after* the six-phase remediation closed all 14 Critical findings of the previous audit. **None was on that audit's list.**

## Cached energy and forces reused across different charges

`ASE/thermo.py` — `set_charge` reassigned `self.charge` and never called `self.reset()`. ASE's `check_state` delegates to `compare_atoms`, which compares positions, numbers, cell and pbc — **not** the calculator's charge.

So in `calc_thermo`'s shared-calculator loop, two records with the same geometry and different formal charge shared cached energy *and forces*. BFGS "converged" in zero steps on the previous molecule's forces, the stationary-point gate passed, and the reported `G_hartree` combined one molecule's electronic energy with another's Hessian.

A vertical IP/EA input — the same geometry at two charges — is ordinary use. **Error: the entire electron affinity, 20–90 kcal/mol, silently.**

Mutation-verified: with the fix reverted, the ion reports the neutral's energy *and* the neutral's force — `assert -0.0 == -1.0`.

## The last sentinel-derived atom mask

`models/adapter.py` rebuilt its real-atom mask as `species != self.species_pad`. `batch_opt/padding.py:40-48` states the rule this breaks, and names the exact hazard: a `species_pad` that collides with a real species index "would silently zero and exclude real atoms (audit C13)."

C13 fixed the optimizer and wrote the rule down. This consumer was missed — and a later reviewer, asked to confirm no such path remained, reported none.

`AIMNet2Adapter` uses `species_pad = 0`, so an R-group `*` atom (atomic number 0) was deleted as padding: `*CCO` scored as 8 atoms where the padder reported 9. Wrong species, and the dummy atom received exactly zero force so it stayed frozen through the whole optimization. `_requires_aimnet` routes precisely these molecules to this engine.

Now uses the explicit `atom_mask` that `pad_from_mols` already returns. `src/` has **zero** live sentinel-derived masks remaining.

## `E_tot` written in two different units

`batch_opt/batchopt.py` wrote `E_tot` in **eV**; `ASE/geometry.py` wrote the same tag in **Hartree**. All five in-package consumers hard-coded eV.

Feeding `opt_geometry` output to `ConformerRanker(window=2.0)` therefore opened a window **27.2× too wide**, kept 3 conformers where 2 belong, reported `E_rel` 0.037 kcal/mol where the truth is 1.000, and wrote an `E_tot(Hartree)` divided by 27.211 twice.

Fixed with one unit and one boundary: `Auto3D.utils.energy` is now the only module that knows the property's unit. Writers call `set_e_tot_from_ev`, readers call `e_tot_ev`/`try_e_tot_ev`, and writers also set a unit-labeled `E_tot(Hartree)` sibling so a file states its own unit. Three example notebooks that divided already-Hartree output by 27.2114 are fixed too.

## Testing

**1061 passed, 10 skipped, 0 xfailed** — identical across plain, `CUDA_VISIBLE_DEVICES=""` and `FORCE_COLOR=1`. 15 new tests, each asserting the **numeric** consequence rather than that a code path ran.

Every fix mutation-verified, with the failure reproducing the defect's signature — including the exact 3-instead-of-2 conformer count and the 0.037-vs-1.000 `E_rel` from the original demonstration.

A static slow-tier audit caught two slow tests that this change would otherwise have broken (`test_aimnet2_adapter_padded_batch_matches_unpadded`, `test_energy_unchanged_when_padded`); both now pass the explicit mask. They could not be executed locally — `pytest -m slow` needs a free GPU — so CI's slow job is their first real run.

## Known residual

Three example custom-NNP models in slow-tier test files still declare `species_pad = 0` alongside a sentinel mask — the same C13 collision, in code users copy. Behavior-neutral to fix, but only the slow tier exercises them, so it is reported rather than changed here.
