### PR TITLE
Make the slow NNP tier assert something

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,14 +91,16 @@ jobs:
           PY
       - name: Run slow NNP + pipeline tests
         # Previously limited to three files because the heavy end-to-end modules
-        # were flaky under combined ordering. None of the five newly un-skipped
-        # modules (test_auto3D.py, test_SPE.py, test_thermo.py,
-        # test_isomer_engine.py, test_tauto.py) actually use Task 1's
-        # job_dir/isolated_input fixtures, so those fixtures are not what
-        # protects this run. What actually protects it: main()'s
-        # microsecond-resolution job naming, strictly serial CI execution, and
-        # the autouse GPU-teardown fixture applied via the `slow` marker --
-        # assessed at 70-80% confidence, not guaranteed (audit M31).
+        # were flaky under combined ordering. test_auto3D.py now runs every
+        # pipeline test through the job_dir/isolated_input fixtures and
+        # test_thermo.py stages its opt_geometry inputs in tmp_path, so those
+        # two no longer write job directories or output SDFs into
+        # tests/files/. The remaining three (test_SPE.py, test_isomer_engine.py,
+        # test_tauto.py) still do not use the fixtures, so for them the
+        # protection is unchanged: main()'s microsecond-resolution job naming,
+        # strictly serial CI execution, and the autouse GPU-teardown fixture
+        # applied via the `slow` marker -- assessed at 70-80% confidence, not
+        # guaranteed (audit M31).
         run: >
           pytest tests/ -m slow -q
 

--- a/tests/helpers_pipeline_output.py
+++ b/tests/helpers_pipeline_output.py
@@ -1,0 +1,698 @@
+"""Shared assertions for the slow tier's real-NNP pipeline output.
+
+Why this module exists
+----------------------
+The slow tier is the only place Auto3D runs a real neural network potential,
+and until now 25 of its 66 tests contained no assertion at all: they called
+``main()`` / ``opt_geometry()`` and deleted the result. A mutation that made
+``opt_geometry`` a no-op, or that emitted the *unoptimized* embedded geometry
+with an arbitrary ``E_tot``, left every one of them green. "The slow tier
+passed" was therefore worth much less than it was repeatedly claimed to be.
+
+Why bounds and invariants, not expected numbers
+-----------------------------------------------
+These checks are derived from the code paths they guard -- ``ranking``,
+``batch_opt.batchopt``, ``ASE.geometry``, ``utils.file_ops`` and
+``utils.energy`` -- not from observed output. Pinning an NNP's numerics to
+several decimals would make the tier fail on a model-version bump or a
+different BLAS, and a slow tier that fails on correct code is one people learn
+to ignore. So every energy check here is an *order-of-magnitude* bound and
+every geometry check is a *lower* bound on movement, chosen with at least an
+order of magnitude of headroom over the physically expected value.
+
+The non-vacuity rule
+--------------------
+``for mol in mols: assert ...`` is trivially true when ``mols`` is empty, and
+so is ``all(...)`` over an absent property. Every loop below is preceded by an
+assertion that the collection it iterates is non-empty, and every property read
+is preceded by a ``HasProp`` assertion, so a missing value fails loudly instead
+of passing quietly.
+
+Units
+-----
+``E_tot`` is in **Hartree**, written by every Auto3D writer, and
+:mod:`Auto3D.utils.energy` owns that fact. This module reads it through that
+module rather than re-deriving the unit, so a future unit change has one place
+to update, not two.
+"""
+from __future__ import annotations
+
+import math
+import tarfile
+from pathlib import Path
+
+import numpy as np
+from rdkit import Chem
+from rdkit.Chem.rdMolDescriptors import CalcMolFormula
+
+from Auto3D.utils.energy import E_TOT_HARTREE_PROP, E_TOT_PROP, e_tot_hartree
+
+__all__ = [
+    "ATOMIC_ENERGY_HARTREE",
+    "assert_energy_is_plausible_hartree",
+    "assert_geometry_is_physical",
+    "assert_opt_geometry_output",
+    "assert_pipeline_output",
+    "base_molecule_id",
+    "expanded_copy",
+    "formula_from_smiles",
+    "formulas_from_sdf_file",
+    "formulas_from_smi_file",
+    "max_atom_displacement",
+    "molecular_formula",
+    "read_pre_optimization_geometries",
+    "read_sdf_records",
+    "self_energy_estimate_hartree",
+    "write_perturbed_sdf",
+]
+
+
+#: Approximate isolated-atom total energies in Hartree, at the level of theory
+#: Auto3D's potentials were trained against (AIMNet2: wB97M-D3/def2-TZVPP;
+#: ANI2x/ANI2xt: wB97X/6-31G*). They differ between those conventions by well
+#: under a percent, which is irrelevant here: the only consumer,
+#: :func:`assert_energy_is_plausible_hartree`, compares against them with a 2x
+#: window. Their purpose is to catch an ``E_tot`` that is in eV rather than
+#: Hartree (27.2x off), positive, zero, NaN, or otherwise not a total energy --
+#: not to validate a model.
+#:
+#: Bonding contributes roughly 1% of a small organic molecule's total energy,
+#: so the sum of these is accurate to about that. Measured against the three
+#: reference values checked into ``tests/files/DA.sdf`` the estimate is within
+#: 0.8%.
+ATOMIC_ENERGY_HARTREE: dict[int, float] = {
+    1: -0.50,  # H
+    5: -24.65,  # B
+    6: -37.85,  # C
+    7: -54.58,  # N
+    8: -75.06,  # O
+    9: -99.72,  # F
+    14: -289.37,  # Si
+    15: -341.26,  # P
+    16: -398.11,  # S
+    17: -460.14,  # Cl
+}
+
+
+def molecular_formula(mol: Chem.Mol) -> str:
+    """Hill-notation molecular formula, counting implicit and explicit H alike.
+
+    RDKit's ``CalcMolFormula`` already sums implicit and explicit hydrogens, so
+    a SMILES-derived molecule and the explicit-H 3D structure Auto3D writes for
+    it give the same string. That equality is what makes formula comparison a
+    usable identity check across the pipeline, and it is pinned by a fast-tier
+    unit test rather than assumed here.
+    """
+    if mol is None:
+        raise ValueError("molecular_formula() received None, not a molecule")
+    return CalcMolFormula(mol)
+
+
+def formula_from_smiles(smiles: str) -> str:
+    """Molecular formula for a SMILES string.
+
+    Raises:
+        ValueError: RDKit could not parse ``smiles``.
+    """
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"RDKit could not parse SMILES {smiles!r}")
+    return CalcMolFormula(mol)
+
+
+def formulas_from_smi_file(path: str | Path) -> dict[str, str]:
+    """Map ``{molecule id: formula}`` for a whitespace-delimited .smi file.
+
+    Deliberately a plain parse rather than a call to
+    ``Auto3D.utils.file_ops.iter_smi_records``: this is the *expectation* side
+    of the comparison, so reusing the production reader would let a bug in that
+    reader cancel itself out.
+
+    Raises:
+        ValueError: A record's SMILES does not parse, or the file yields no
+            ``<smiles> <id>`` records at all -- either would silently produce
+            an empty expectation set and make every downstream check vacuous.
+    """
+    formulas: dict[str, str] = {}
+    for line in Path(path).read_text().splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        smiles, mol_id = parts[0], parts[1]
+        formulas[mol_id] = formula_from_smiles(smiles)
+    if not formulas:
+        raise ValueError(f"no '<smiles> <id>' records found in {path}")
+    return formulas
+
+
+def formulas_from_sdf_file(path: str | Path) -> dict[str, str]:
+    """Map ``{molecule id: formula}`` for an SDF input file.
+
+    Raises:
+        ValueError: The file yields no parseable records (see
+            :func:`formulas_from_smi_file` for why an empty map is refused).
+    """
+    formulas: dict[str, str] = {}
+    with Chem.SDMolSupplier(str(path), removeHs=False) as supplier:
+        for mol in supplier:
+            if mol is None:
+                continue
+            formulas[mol.GetProp("_Name").strip()] = CalcMolFormula(mol)
+    if not formulas:
+        raise ValueError(f"no parseable records found in {path}")
+    return formulas
+
+
+def base_molecule_id(name: str) -> str:
+    """Input molecule id for a conformer ``_Name`` from a finished output SDF.
+
+    ``ConformerRanker`` already reduced the name to the species id, and
+    ``decode_ids`` restored the user-facing id, so the only decoration that can
+    remain is a ``@tautN`` tautomer suffix. Stripped exactly the way the
+    pipeline's own reconciliation does it (``find_smiles_not_in_sdf`` /
+    ``find_ids_not_in_sdf`` in ``utils/file_ops.py``) so that the accounting
+    assertion compares like with like.
+    """
+    return name.split("@taut")[0].strip()
+
+
+def read_sdf_records(path: str | Path, *, label: str = "") -> list[Chem.Mol]:
+    """Read an SDF that is required to exist, be non-empty, and fully parse.
+
+    This is the assertion that kills the "return a path you never wrote"
+    mutation: the tests it replaced swallowed the resulting ``FileNotFoundError``
+    in an ``except OSError`` cleanup block.
+    """
+    where = f" ({label})" if label else ""
+    p = Path(path)
+    assert p.is_file(), f"no file exists at the reported output path {p}{where}"
+    assert p.stat().st_size > 0, f"output file {p} is empty{where}"
+
+    with Chem.SDMolSupplier(str(p), removeHs=False) as supplier:
+        records = list(supplier)
+    assert records, f"output file {p} contains no SDF records{where}"
+    unparsed = [i for i, mol in enumerate(records) if mol is None]
+    assert not unparsed, (
+        f"records at index {unparsed} of {p} do not parse as SDF{where}"
+    )
+    return records
+
+
+def self_energy_estimate_hartree(mol: Chem.Mol) -> float:
+    """Sum of isolated-atom energies for ``mol``, in Hartree (a negative number).
+
+    Counts implicit hydrogens as well as explicit ones, so the estimate is the
+    same for a SMILES-derived molecule and its explicit-H 3D structure.
+
+    Raises:
+        KeyError: ``mol`` contains an element absent from
+            :data:`ATOMIC_ENERGY_HARTREE`. Raised rather than skipped on
+            purpose: silently dropping the magnitude check for an unrecognized
+            element is exactly the "names a guarantee it does not provide"
+            failure this module exists to remove. Extend the table instead.
+    """
+    total = 0.0
+    for atom in mol.GetAtoms():
+        z = atom.GetAtomicNum()
+        if z not in ATOMIC_ENERGY_HARTREE:
+            raise KeyError(
+                f"no reference atomic energy for element Z={z} "
+                f"({atom.GetSymbol()}); extend ATOMIC_ENERGY_HARTREE in "
+                "tests/helpers_pipeline_output.py"
+            )
+        total += ATOMIC_ENERGY_HARTREE[z]
+        total += atom.GetTotalNumHs() * ATOMIC_ENERGY_HARTREE[1]
+    return total
+
+
+def assert_energy_is_plausible_hartree(
+    mol: Chem.Mol,
+    *,
+    low_factor: float = 0.5,
+    high_factor: float = 2.0,
+    label: str = "",
+) -> float:
+    """Assert ``E_tot`` is a finite, negative total energy of the right size.
+
+    ``E_tot`` is Hartree (``Auto3D.utils.energy`` owns that), and every writer
+    also emits the unit-labeled ``E_tot(Hartree)`` sibling carrying the
+    identical value; both are checked, because their agreement is the only
+    on-disk evidence that the single-conversion-boundary rule held.
+
+    The magnitude window is deliberately loose -- the energy must lie between
+    ``high_factor`` and ``low_factor`` times the isolated-atom sum -- so it
+    survives any NNP whose self-energy convention differs slightly, while still
+    catching an energy written in eV (27.2x too large), an atomization energy,
+    a sign flip, a zero, or a NaN.
+
+    Returns:
+        The energy in Hartree, so callers can make further comparisons.
+    """
+    where = f" ({label})" if label else ""
+    name = mol.GetProp("_Name") if mol.HasProp("_Name") else "<unnamed>"
+    assert mol.HasProp(E_TOT_PROP), (
+        f"{name}: no {E_TOT_PROP} property on the output structure{where}"
+    )
+    energy = e_tot_hartree(mol)
+    assert math.isfinite(energy), f"{name}: {E_TOT_PROP} is {energy}{where}"
+    assert energy < 0, (
+        f"{name}: {E_TOT_PROP} is {energy} Hartree; a bound molecule's total "
+        f"energy must be negative{where}"
+    )
+
+    reference = self_energy_estimate_hartree(mol)
+    lo, hi = high_factor * reference, low_factor * reference  # reference < 0
+    assert lo <= energy <= hi, (
+        f"{name}: {E_TOT_PROP} = {energy:.4f} Hartree is outside "
+        f"[{lo:.1f}, {hi:.1f}], the {high_factor}x/{low_factor}x window around "
+        f"the isolated-atom sum {reference:.1f} Hartree. In eV this value "
+        f"would be {energy * 27.211386245988:.1f}; check the unit written by "
+        f"the producing writer{where}"
+    )
+
+    assert mol.HasProp(E_TOT_HARTREE_PROP), (
+        f"{name}: writer did not emit the unit-labeled {E_TOT_HARTREE_PROP} "
+        f"sibling{where}"
+    )
+    labeled = float(mol.GetProp(E_TOT_HARTREE_PROP))
+    assert math.isclose(labeled, energy, rel_tol=1e-9, abs_tol=1e-12), (
+        f"{name}: {E_TOT_HARTREE_PROP} ({labeled}) disagrees with "
+        f"{E_TOT_PROP} ({energy}); they must carry the identical value{where}"
+    )
+    return energy
+
+
+def assert_geometry_is_physical(
+    mol: Chem.Mol,
+    *,
+    min_separation: float = 0.5,
+    label: str = "",
+) -> None:
+    """Assert the structure is a real 3D arrangement, not NaN or collapsed.
+
+    Catches the coarse ways an optimizer can produce nonsense that still writes
+    cleanly to SDF: NaN/inf coordinates, every atom on top of every other, or a
+    single point. ``min_separation`` defaults to 0.5 A, comfortably below the
+    shortest bond any of these potentials supports (H-H is 0.74 A, C-H 1.09 A).
+    """
+    where = f" ({label})" if label else ""
+    name = mol.GetProp("_Name") if mol.HasProp("_Name") else "<unnamed>"
+    assert mol.GetNumConformers() == 1, (
+        f"{name}: expected exactly one conformer per output record, got "
+        f"{mol.GetNumConformers()}{where}"
+    )
+    positions = mol.GetConformer().GetPositions()
+    assert positions.shape[0] == mol.GetNumAtoms()
+    assert np.isfinite(positions).all(), (
+        f"{name}: geometry contains non-finite coordinates{where}"
+    )
+    if mol.GetNumAtoms() < 2:
+        return
+    deltas = positions[:, None, :] - positions[None, :, :]
+    distances = np.linalg.norm(deltas, axis=-1)
+    upper = distances[np.triu_indices(len(positions), k=1)]
+    # A single check, not two: the minimum pairwise distance bounds the
+    # maximum from below, so "the structure spans more than X" would be
+    # implied by this and could only ever add a false failure -- as it did for
+    # a diatomic, whose whole span is one bond length.
+    assert upper.min() > min_separation, (
+        f"{name}: two atoms are {upper.min():.3f} A apart, closer than the "
+        f"{min_separation} A floor; the geometry has collapsed{where}"
+    )
+
+
+def max_atom_displacement(mol_a: Chem.Mol, mol_b: Chem.Mol) -> float:
+    """Largest per-atom distance (A) between two conformations of one molecule.
+
+    Both molecules must have the same atoms in the same order, which every
+    Auto3D path preserves: ``batchopt`` writes optimized coordinates into the
+    very object it read, and every subsequent stage round-trips whole records
+    through ``SDMolSupplier``/``SDWriter``.
+
+    Raises:
+        ValueError: The two molecules are not the same species in the same
+            atom order, which would make the returned number meaningless.
+    """
+    if mol_a.GetNumAtoms() != mol_b.GetNumAtoms():
+        raise ValueError(
+            f"atom count differs: {mol_a.GetNumAtoms()} vs {mol_b.GetNumAtoms()}"
+        )
+    z_a = [atom.GetAtomicNum() for atom in mol_a.GetAtoms()]
+    z_b = [atom.GetAtomicNum() for atom in mol_b.GetAtoms()]
+    if z_a != z_b:
+        raise ValueError("atomic numbers differ or are in a different order")
+    pos_a = mol_a.GetConformer().GetPositions()
+    pos_b = mol_b.GetConformer().GetPositions()
+    return float(np.linalg.norm(pos_a - pos_b, axis=1).max())
+
+
+def expanded_copy(mol: Chem.Mol, factor: float) -> Chem.Mol:
+    """Return a copy of ``mol`` scaled uniformly about its own centroid.
+
+    A deterministic, seedless way to displace a structure off its minimum so
+    that "the optimizer moved the geometry" becomes an assertable statement.
+    Every bond length is scaled by ``factor``, so at ``factor=1.05`` a C-C bond
+    is stretched by ~0.077 A -- forces of order 1 eV/A, an order of magnitude
+    above the 0.1 eV/A tolerance the ``opt_geometry`` tests use, so the
+    optimizer cannot report convergence without moving the atoms back.
+
+    Scaling about the centroid rather than the origin matters: it perturbs the
+    internal coordinates only, leaving the structure's position and orientation
+    alone, so the displacement a caller measures afterwards is relaxation and
+    not a rigid-body shift.
+    """
+    copy = Chem.Mol(mol)
+    conformer = copy.GetConformer()
+    positions = conformer.GetPositions()
+    centroid = positions.mean(axis=0)
+    scaled = centroid + (positions - centroid) * factor
+    for idx in range(copy.GetNumAtoms()):
+        conformer.SetAtomPosition(idx, scaled[idx].tolist())
+    return copy
+
+
+def write_perturbed_sdf(
+    source: str | Path, dest: str | Path, factor: float
+) -> tuple[str, list[Chem.Mol]]:
+    """Write a displaced, property-free copy of ``source`` to ``dest``.
+
+    Turns an input that is already sitting at a minimum into one an optimizer
+    must visibly move, which is what makes "the geometry changed" assertable
+    (see :func:`expanded_copy` for why a uniform expansion, and why about the
+    centroid).
+
+    Every SDF data property is stripped, ``_Name`` aside. Fixture files such as
+    ``tests/files/DA.sdf`` ship with ``E_tot``/``fmax``/``Converged`` left over
+    from an earlier run, and carrying those through would let an optimizer that
+    wrote nothing still emit output bearing a plausible-looking energy.
+
+    Returns:
+        ``(path, molecules)`` where the molecules are read back **from the file
+        just written**, not the in-memory copies. SDF stores coordinates to
+        four decimal places, so re-reading is what makes a later displacement
+        measurement a comparison against exactly the geometry the optimizer was
+        handed.
+    """
+    records = read_sdf_records(source, label=str(source))
+    with Chem.SDWriter(str(dest)) as writer:
+        for mol in records:
+            perturbed = expanded_copy(mol, factor)
+            for prop in list(perturbed.GetPropNames()):
+                perturbed.ClearProp(prop)
+            perturbed.SetProp("_Name", mol.GetProp("_Name"))
+            writer.write(perturbed)
+    return str(dest), read_sdf_records(dest, label=f"perturbed {Path(source).name}")
+
+
+def read_pre_optimization_geometries(job_dir: str | Path) -> dict[str, Chem.Mol]:
+    """Recover the embedded, pre-optimization conformers of a ``verbose`` run.
+
+    ``optim_rank_wrapper`` sweeps every chunk intermediate into a ``verbose``
+    folder, tars it, and -- unless ``verbose=True`` -- deletes the tarball. With
+    ``verbose=True`` the tarball survives at ``<job_dir>/job*/verbose.tar.gz``
+    and still holds ``smiles_enumerated.sdf``: the isomer engine's ETKDG output,
+    i.e. exactly the geometry the optimizer was handed.
+
+    The returned keys are the conformer names the isomer engine assigned
+    (``<encoded id>_<isomer>_<conformer>``). ``batchopt`` copies that name onto
+    each optimized record's ``ID`` property, and nothing downstream rewrites
+    ``ID`` -- ``ConformerRanker`` and ``decode_ids`` only rewrite ``_Name`` --
+    so ``ID`` is the join key between a finished output record and its own
+    starting geometry.
+
+    Raises:
+        AssertionError: No tarball, or no enumerated SDF inside it. Both mean
+            the caller cannot make the comparison it asked for, and must fail
+            rather than quietly check nothing.
+    """
+    job_path = Path(job_dir)
+    tarballs = sorted(job_path.glob("job*/verbose.tar.gz"))
+    assert tarballs, (
+        f"no job*/verbose.tar.gz under {job_path}; the run must set verbose=True "
+        "for the pre-optimization geometries to survive housekeeping"
+    )
+
+    geometries: dict[str, Chem.Mol] = {}
+    for tarball in tarballs:
+        with tarfile.open(tarball, "r:gz") as tar:
+            members = [
+                m
+                for m in tar.getmembers()
+                if m.isfile() and Path(m.name).name == "smiles_enumerated.sdf"
+            ]
+            for member in members:
+                handle = tar.extractfile(member)
+                assert handle is not None, f"could not read {member.name} in {tarball}"
+                block = handle.read().decode()
+                supplier = Chem.SDMolSupplier()
+                supplier.SetData(block, removeHs=False)
+                for mol in supplier:
+                    if mol is None:
+                        continue
+                    geometries[mol.GetProp("_Name").strip()] = mol
+
+    assert geometries, (
+        f"no pre-optimization conformers found in {[str(t) for t in tarballs]}"
+    )
+    return geometries
+
+
+def assert_pipeline_output(
+    result,
+    *,
+    formula_by_id: dict[str, str],
+    k: int | None = None,
+    window: float | None = None,
+    label: str = "",
+) -> list[Chem.Mol]:
+    """Assert a ``main()`` result is a correct, complete, physical output SDF.
+
+    Every check here is derivable from the pipeline source; none is an observed
+    value. What varies between callers is passed in explicitly rather than
+    inferred, per the brief: the expected inputs and their formulas, and which
+    selector was used.
+
+    Args:
+        result: The ``WorkflowResult`` returned by ``Auto3D.auto3D.main``.
+        formula_by_id: ``{input molecule id: molecular formula}`` for every
+            molecule in the run's input file. Doubles as the expected id set,
+            so an empty map is refused rather than making everything vacuous.
+        k: The ``k`` the run was given, or None if it selected by ``window``.
+            ``ConformerRanker.top_k`` returns at most ``k`` conformers per
+            species, and for ``k == 1`` returns exactly zero or one -- so an
+            id that appears at all appears exactly once.
+        window: The ``window`` (kcal/mol) the run was given, or None. Every
+            record ``top_window`` keeps satisfies ``E_rel <= window``, and the
+            ranking writer converts that to the ``E_rel(kcal/mol)`` property in
+            the same unit ``window`` is expressed in.
+        label: Free text added to failure messages (engine, input, ...).
+
+    Returns:
+        The parsed output records, so a caller can assert something extra.
+
+    Note:
+        Assumes tautomer enumeration is off, which is the default and is true
+        of every caller today. With ``enumerate_tautomer=True`` one input id
+        legitimately yields one ranked group *per tautomer*, so the exact
+        per-id conformer counts below would no longer hold.
+    """
+    where = f" ({label})" if label else ""
+    expected_ids = set(formula_by_id)
+    assert expected_ids, (
+        "assert_pipeline_output was given no expected molecules; every check "
+        f"below would be vacuous{where}"
+    )
+    assert k is None or window is None, (
+        "k and window are alternative selectors; pass at most one"
+    )
+
+    records = read_sdf_records(str(result), label=label)
+
+    produced: dict[str, list[Chem.Mol]] = {}
+    for mol in records:
+        assert mol.HasProp("_Name"), f"an output record has no _Name{where}"
+        produced.setdefault(base_molecule_id(mol.GetProp("_Name")), []).append(mol)
+    assert produced, f"output SDF has records but no usable molecule ids{where}"
+
+    # --- Accounting: nothing invented, nothing lost without a report. --------
+    unexpected = set(produced) - expected_ids
+    assert not unexpected, (
+        f"output contains ids that were never in the input: {sorted(unexpected)}"
+        f"{where}"
+    )
+    failures = set(getattr(result, "failures", None) or [])
+    bogus_failures = failures - expected_ids
+    assert not bogus_failures, (
+        f"failure list names ids that were never in the input: "
+        f"{sorted(bogus_failures)}{where}"
+    )
+    both = set(produced) & failures
+    assert not both, (
+        f"ids reported as failures yet present in the output: {sorted(both)}{where}"
+    )
+    unaccounted = expected_ids - set(produced) - failures
+    assert not unaccounted, (
+        f"{len(unaccounted)} of {len(expected_ids)} input molecules are absent "
+        f"from the output and from the reported failure list: "
+        f"{sorted(unaccounted)}{where}"
+    )
+
+    # --- The run must have produced something. ------------------------------
+    assert len(produced) >= 1, (
+        f"no input molecule produced a structure; all {len(expected_ids)} were "
+        f"reported as failures{where}"
+    )
+
+    # --- WorkflowResult's own counters must describe this same file. --------
+    n_molecules = getattr(result, "n_molecules", None)
+    if n_molecules is not None:
+        assert n_molecules == len(produced), (
+            f"WorkflowResult.n_molecules is {n_molecules} but the output SDF "
+            f"holds {len(produced)} distinct molecules{where}"
+        )
+        assert result.n_conformers == len(records), (
+            f"WorkflowResult.n_conformers is {result.n_conformers} but the "
+            f"output SDF holds {len(records)} conformers{where}"
+        )
+
+    # --- Per molecule. ------------------------------------------------------
+    for mol_id, group in sorted(produced.items()):
+        assert group, f"{mol_id}: empty conformer group{where}"
+        if k is not None:
+            assert len(group) <= k, (
+                f"{mol_id}: {len(group)} conformers written for k={k}{where}"
+            )
+            if k == 1:
+                assert len(group) == 1, (
+                    f"{mol_id}: k=1 must yield exactly one conformer per "
+                    f"molecule, got {len(group)}{where}"
+                )
+        for mol in group:
+            tag = f"{label} {mol_id}".strip()
+            assert molecular_formula(mol) == formula_by_id[mol_id], (
+                f"{mol_id}: chemical identity changed -- input formula "
+                f"{formula_by_id[mol_id]}, output formula "
+                f"{molecular_formula(mol)}{where}"
+            )
+            assert_geometry_is_physical(mol, label=tag)
+            assert_energy_is_plausible_hartree(mol, label=tag)
+
+            assert mol.HasProp("Converged"), (
+                f"{mol_id}: output record carries no Converged flag{where}"
+            )
+            assert mol.GetProp("Converged").lower() == "true", (
+                f"{mol_id}: ConformerRanker may only emit converged structures, "
+                f"but this one is marked Converged="
+                f"{mol.GetProp('Converged')!r}{where}"
+            )
+            assert mol.HasProp("ID"), (
+                f"{mol_id}: output record carries no optimizer ID{where}"
+            )
+            # ConformerRanker converts the working eV relative energy into
+            # kcal/mol and clears the eV one on the way out; an output still
+            # carrying E_rel(eV) means that writer did not run.
+            assert not mol.HasProp("E_rel(eV)"), (
+                f"{mol_id}: E_rel(eV) survived into the final output; the "
+                f"ranking writer converts and clears it{where}"
+            )
+            assert mol.HasProp("E_rel(kcal/mol)"), (
+                f"{mol_id}: no E_rel(kcal/mol) on the output record{where}"
+            )
+            e_rel = float(mol.GetProp("E_rel(kcal/mol)"))
+            assert math.isfinite(e_rel), f"{mol_id}: E_rel is {e_rel}{where}"
+            # Relative to the lowest-energy conformer of the same group, so it
+            # cannot be negative beyond float noise.
+            assert e_rel >= -1e-6, (
+                f"{mol_id}: E_rel(kcal/mol) = {e_rel} is negative, but it is "
+                f"measured from its own group's minimum{where}"
+            )
+            if window is not None:
+                assert e_rel <= window + 1e-6, (
+                    f"{mol_id}: E_rel(kcal/mol) = {e_rel} exceeds the "
+                    f"{window} kcal/mol window that selected it{where}"
+                )
+            if k == 1:
+                assert abs(e_rel) <= 1e-6, (
+                    f"{mol_id}: with k=1 the single kept conformer is its own "
+                    f"reference, so E_rel must be 0, not {e_rel}{where}"
+                )
+
+    return records
+
+
+def assert_opt_geometry_output(
+    out_path: str,
+    *,
+    input_mols: list[Chem.Mol],
+    moved_at_least: float,
+    label: str = "",
+) -> list[Chem.Mol]:
+    """Assert an ``ASE.geometry.opt_geometry`` result is a real optimization.
+
+    Args:
+        out_path: The path ``opt_geometry`` returned.
+        input_mols: The molecules that were handed to it, in input order.
+            ``optimizing.run()`` scatters results back to their original input
+            positions, and ``_annotate_and_rewrite`` preserves that order, so
+            record *i* of the output corresponds to ``input_mols[i]``.
+        moved_at_least: Minimum required max-atom displacement (A) from the
+            input geometry. Only meaningful when the caller deliberately
+            perturbed the input off its minimum -- pass a value chosen from
+            that perturbation, not a guess.
+        label: Free text added to failure messages.
+
+    Returns:
+        The parsed output records.
+    """
+    where = f" ({label})" if label else ""
+    assert input_mols, (
+        f"assert_opt_geometry_output was given no input molecules; every check "
+        f"below would be vacuous{where}"
+    )
+    assert Path(out_path) != Path(""), "empty output path"
+
+    records = read_sdf_records(out_path, label=label)
+    assert len(records) == len(input_mols), (
+        f"opt_geometry returned {len(records)} structures for "
+        f"{len(input_mols)} inputs; _annotate_and_rewrite drops any record "
+        f"that lost its {E_TOT_PROP}{where}"
+    )
+
+    for source, mol in zip(input_mols, records, strict=True):
+        name = source.GetProp("_Name").strip()
+        tag = f"{label} {name}".strip()
+        assert mol.GetProp("_Name").strip() == name, (
+            f"output record {mol.GetProp('_Name')!r} does not line up with "
+            f"input {name!r}; the optimizer must preserve input order{where}"
+        )
+        assert molecular_formula(mol) == molecular_formula(source), (
+            f"{name}: chemical identity changed -- {molecular_formula(source)} "
+            f"in, {molecular_formula(mol)} out{where}"
+        )
+        assert_geometry_is_physical(mol, label=tag)
+        assert_energy_is_plausible_hartree(mol, label=tag)
+
+        # Properties only the optimizer writes. Every input to these tests is
+        # itself an SDF that may already carry E_tot/fmax/Converged, so these
+        # three are what distinguish a genuine run from handing back the input.
+        for prop in ("Dropped_Oscillating", "Stereo_changed", E_TOT_HARTREE_PROP):
+            assert mol.HasProp(prop), (
+                f"{name}: output lacks {prop}, which every batch_opt run "
+                f"writes; this looks like the input file, not an "
+                f"optimization{where}"
+            )
+        assert mol.HasProp("fmax"), f"{name}: output carries no fmax{where}"
+        fmax = float(mol.GetProp("fmax"))
+        assert math.isfinite(fmax) and fmax >= 0, (
+            f"{name}: fmax is {fmax}, which is not a force magnitude{where}"
+        )
+
+        displacement = max_atom_displacement(source, mol)
+        assert displacement > moved_at_least, (
+            f"{name}: the optimizer moved no atom further than "
+            f"{displacement:.4f} A from a geometry deliberately displaced off "
+            f"its minimum; at least {moved_at_least} A of relaxation was "
+            f"required{where}"
+        )
+
+    return records

--- a/tests/test_auto3D.py
+++ b/tests/test_auto3D.py
@@ -1,12 +1,39 @@
-import os, sys
-import torch
-import pytest
+"""Full-pipeline tests against the real neural network potentials.
+
+Every test here runs ``Auto3D.auto3D.main`` end to end -- isomer enumeration,
+batch geometry optimization on a real NNP, ranking, and output assembly. They
+are the most expensive tests in the project and the only ones that exercise
+the potentials rather than a stub.
+
+Until this module was reworked, nineteen of them asserted nothing: they called
+``main()``, took the returned path, and deleted its directory. A mutation that
+emitted the *unoptimized* embedded geometry with an arbitrary ``E_tot`` left
+every one of them green, so "the slow tier passed" proved only that the
+pipeline did not raise. The shared assertions now live in
+``tests/helpers_pipeline_output.py``; each test states what varies (engine,
+input, selector, expected molecules) explicitly rather than letting the helper
+infer it.
+
+The checks are bounds and invariants derived from the pipeline source, not
+recorded output: an NNP's numbers move with the model version and the machine,
+and a slow tier that fails on correct code is one people stop reading.
+"""
+import os
 import shutil
 import tempfile
-from typing import Optional
-from send2trash import send2trash
+
+import pytest
+import torch
+
 from Auto3D.auto3D import main, smiles2mols
 from Auto3D.config import Auto3DOptions
+from tests.helpers_pipeline_output import (
+    assert_pipeline_output,
+    formulas_from_sdf_file,
+    formulas_from_smi_file,
+    max_atom_displacement,
+    read_pre_optimization_geometries,
+)
 
 # Mark all tests in this module as slow (full pipeline tests)
 pytestmark = pytest.mark.slow
@@ -18,7 +45,7 @@ path_large = os.path.join(folder, "tests/files/smiles10.smi")
 sdf_path = os.path.join(folder, "tests/files/example.sdf")
 
 if ('OE_LICENSE' in os.environ) and (os.environ['OE_LICENSE'] != ''):
-    skip_omega = False  
+    skip_omega = False
 else:
     skip_omega = True
 
@@ -30,7 +57,7 @@ try:
             """This is an example NNP model that can be used with Auto3D.
             You can initialize an NNP model however you want,
             just make sure that:
-                - It contains the coord_pad and species_pad attributes 
+                - It contains the coord_pad and species_pad attributes
                 (These values will be used when processing the molecules in batch.)
                 - The signature of the forward method is the same as below.
             """
@@ -52,13 +79,13 @@ try:
 
             species contains the atomic numbers of the atoms in the molecule: [B, N]
             where B is the batch size, N is the number of atoms in the largest molecule.
-            
+
             coords contains the coordinates of the atoms in the molecule: [B, N, 3]
             where B is the batch size, N is the number of atoms in the largest molecule,
             and 3 represents the x, y, z coordinates.
-            
+
             charges contains the molecular charges: [B]
-            
+
             The forward function returns the energies of the molecules: [B],
             output energy unit: eV"""
 
@@ -75,7 +102,7 @@ class userNNP2(torch.nn.Module):
         """This is an example NNP model that can be used with Auto3D.
         You can initialize an NNP model however you want,
         just make sure that:
-            - It contains the coord_pad and species_pad attributes 
+            - It contains the coord_pad and species_pad attributes
             (These values will be used when processing the molecules in batch.)
             - The signature of the forward method is the same as below.
         """
@@ -101,13 +128,13 @@ class userNNP2(torch.nn.Module):
 
         species contains the atomic numbers of the atoms in the molecule: [B, N]
         where B is the batch size, N is the number of atoms in the largest molecule.
-        
+
         coords contains the coordinates of the atoms in the molecule: [B, N, 3]
         where B is the batch size, N is the number of atoms in the largest molecule,
         and 3 represents the x, y, z coordinates.
-        
+
         charges contains the molecular charges: [B]
-        
+
         The forward function returns the energies of the molecules: [B],
         output energy unit: eV"""
 
@@ -133,196 +160,188 @@ class userNNP2(torch.nn.Module):
         return out['energy'].reshape(-1)
 
 
-def test_auto3D_rdkit_aimnet():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, k=1, use_gpu=False, convergence_threshold=1, max_confs=2,
+# --------------------------------------------------------------------------
+# Expected molecules per input file.
+#
+# Computed from the input rather than hardcoded, so a change to the fixture
+# files cannot silently leave the expectations behind. Called inside each test
+# rather than at import time to keep module collection (which the fast tier
+# also performs) free of file I/O.
+# --------------------------------------------------------------------------
+
+def _smi_formulas() -> dict[str, str]:
+    """{id: formula} for tests/files/smiles2.smi (three small ketones/esters)."""
+    return formulas_from_smi_file(path)
+
+
+def _smi_large_formulas() -> dict[str, str]:
+    """{id: formula} for tests/files/smiles10.smi."""
+    return formulas_from_smi_file(path_large)
+
+
+def _sdf_formulas() -> dict[str, str]:
+    """{id: formula} for tests/files/example.sdf."""
+    return formulas_from_sdf_file(sdf_path)
+
+
+def test_auto3D_rdkit_aimnet(isolated_input):
+    """RDKit isomers + AIMNet2: one conformer per input, correctly assembled."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), k=1, use_gpu=False,
+                   convergence_threshold=1, max_confs=2,
                    isomer_engine="rdkit", optimizing_engine="AIMNET")
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                           label="rdkit/AIMNET")
 
 # @pytest.mark.skipif(skip_ani2xt_test, reason="ANI2xt model is not  installed.")
-def test_auto3D_rdkit_ani2xt():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, k=1, use_gpu=False, convergence_threshold=1, max_confs=2,
+def test_auto3D_rdkit_ani2xt(isolated_input):
+    """RDKit isomers + ANI2xt: one conformer per input, correctly assembled."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), k=1, use_gpu=False,
+                   convergence_threshold=1, max_confs=2,
                    isomer_engine="rdkit", optimizing_engine="ANI2xt")
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                           label="rdkit/ANI2xt")
 
-def test_auto3D_rdkit_ani2x():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, k=1, use_gpu=False, convergence_threshold=1,
+def test_auto3D_rdkit_ani2x(isolated_input):
+    """RDKit isomers + ANI2x: one conformer per input, correctly assembled."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), k=1, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="rdkit", optimizing_engine="ANI2x")
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                           label="rdkit/ANI2x")
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
-def test_auto3D_omega_aimnet():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, k=1, use_gpu=False, convergence_threshold=1,
+def test_auto3D_omega_aimnet(isolated_input):
+    """OMEGA isomers + AIMNet2: one conformer per input, correctly assembled."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), k=1, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="omega", optimizing_engine="AIMNET")
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                           label="omega/AIMNET")
 
 
 # @pytest.mark.skipif(skip_ani2xt_test, reason="ANI2xt model is not  installed.")
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
-def test_auto3D_omega_ani2xt():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, k=1, use_gpu=False, convergence_threshold=1,
+def test_auto3D_omega_ani2xt(isolated_input):
+    """OMEGA isomers + ANI2xt: one conformer per input, correctly assembled."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), k=1, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="omega", optimizing_engine="ANI2xt")
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                           label="omega/ANI2xt")
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
-def test_auto3D_omega_ani2x():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, k=1, use_gpu=False, convergence_threshold=1,
+def test_auto3D_omega_ani2x(isolated_input):
+    """OMEGA isomers + ANI2x: one conformer per input, correctly assembled."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), k=1, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="omega", optimizing_engine="ANI2x")
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                           label="omega/ANI2x")
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
-def test_auto3D_config1():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, window=1, use_gpu=False, convergence_threshold=1,
+def test_auto3D_config1(isolated_input):
+    """Energy-window selection: every kept conformer lies inside the window."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), window=1, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="omega", optimizing_engine="AIMNET")
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), window=1,
+                           label="omega/AIMNET window=1")
 
 @pytest.mark.skipif(torch.cuda.is_available() == False, reason="No GPU")
-def test_auto3D_config2():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, window=1, use_gpu=True, convergence_threshold=1,
+def test_auto3D_config2(isolated_input):
+    """GPU run with an explicit memory budget still produces complete output."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), window=1, use_gpu=True,
+                   convergence_threshold=1,
                    isomer_engine="rdkit", optimizing_engine="AIMNET", memory=2)
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), window=1,
+                           label="gpu rdkit/AIMNET memory=2")
 
-    
-def test_auto3D_config3():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, k=1, use_gpu=False, convergence_threshold=1,
+
+def test_auto3D_config3(isolated_input):
+    """Chunked run (capacity=2): chunking must not lose or duplicate molecules."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), k=1, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="rdkit", optimizing_engine="AIMNET", capacity=2)
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                           label="rdkit/AIMNET capacity=2")
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
-def test_auto3D_config4():
-    """Check that the program runs"""
-    args = Auto3DOptions(path, window=2, use_gpu=False, convergence_threshold=1,
+def test_auto3D_config4(isolated_input):
+    """Energy window of 2 kcal/mol over up to three embedded conformers."""
+    args = Auto3DOptions(isolated_input("smiles2.smi"), window=2, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="omega", optimizing_engine="AIMNET", max_confs=3)
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_formulas(), window=2,
+                           label="omega/AIMNET window=2")
 
 @pytest.mark.skipif(torch.cuda.is_available() == False, reason="No GPU")
-def test_auto3D_config5():
-    """Check that the program runs with multiple GPUs"""
-    args = Auto3DOptions(path_large, k=1, use_gpu=True, convergence_threshold=1, max_confs=2,
+def test_auto3D_config5(isolated_input):
+    """Multi-GPU, multi-chunk run over ten inputs: all ten must be accounted for."""
+    args = Auto3DOptions(isolated_input("smiles10.smi"), k=1, use_gpu=True,
+                   convergence_threshold=1, max_confs=2,
                    isomer_engine="rdkit", optimizing_engine="ANI2xt", capacity=2, memory=1,
                    gpu_idx=[0, 1])
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_smi_large_formulas(), k=1,
+                           label="multi-gpu rdkit/ANI2xt")
 
 @pytest.mark.skipif(torch.cuda.is_available() == False, reason="No GPU")
-def test_auto3D_config6():
-    """Check that the program runs with multiple GPUs"""
-    args = Auto3DOptions(sdf_path, k=1, use_gpu=True, convergence_threshold=1, max_confs=2,
+def test_auto3D_config6(isolated_input):
+    """Multi-GPU run from SDF input: ids and formulas survive the round trip."""
+    args = Auto3DOptions(isolated_input("example.sdf"), k=1, use_gpu=True,
+                   convergence_threshold=1, max_confs=2,
                    isomer_engine="rdkit", optimizing_engine="AIMNET", capacity=2,
                    memory=1, gpu_idx=[0, 1])
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_sdf_formulas(), k=1,
+                           label="multi-gpu sdf rdkit/AIMNET")
 
 @pytest.mark.skipif(skip_omega, reason="No OE_LICENSE")
-def test_auto3D_sdf_omega_aimnet():
-    """Check that the program runs"""
-    args = Auto3DOptions(sdf_path, window=2, use_gpu=False, convergence_threshold=1,
+def test_auto3D_sdf_omega_aimnet(isolated_input):
+    """SDF input + OMEGA isomers + AIMNet2, selected by a 2 kcal/mol window."""
+    args = Auto3DOptions(isolated_input("example.sdf"), window=2, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="omega", optimizing_engine="AIMNET", max_confs=3)
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_sdf_formulas(), window=2,
+                           label="sdf omega/AIMNET")
 
-def test_auto3D_sdf_rdkit_aimnet():
-    """Check that the program runs"""
-    args = Auto3DOptions(sdf_path, window=2, use_gpu=False, convergence_threshold=1,
+def test_auto3D_sdf_rdkit_aimnet(isolated_input):
+    """SDF input + RDKit isomers + AIMNet2, selected by a 2 kcal/mol window."""
+    args = Auto3DOptions(isolated_input("example.sdf"), window=2, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="rdkit", optimizing_engine="AIMNET", max_confs=3)
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_sdf_formulas(), window=2,
+                           label="sdf rdkit/AIMNET")
 
-def test_auto3D_sdf_rdkit_ani2x():
-    """Check that the program runs"""
-    args = Auto3DOptions(sdf_path, window=2, use_gpu=False, convergence_threshold=1,
+def test_auto3D_sdf_rdkit_ani2x(isolated_input):
+    """SDF input + RDKit isomers + ANI2x, selected by a 2 kcal/mol window."""
+    args = Auto3DOptions(isolated_input("example.sdf"), window=2, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="rdkit", optimizing_engine="ANI2x", max_confs=3)
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_sdf_formulas(), window=2,
+                           label="sdf rdkit/ANI2x")
 
-def test_auto3D_sdf_rdkit_ani2xt():
-    """Check that the program runs"""
-    args = Auto3DOptions(sdf_path, window=2, use_gpu=False, convergence_threshold=1,
+def test_auto3D_sdf_rdkit_ani2xt(isolated_input):
+    """SDF input + RDKit isomers + ANI2xt, selected by a 2 kcal/mol window."""
+    args = Auto3DOptions(isolated_input("example.sdf"), window=2, use_gpu=False,
+                   convergence_threshold=1,
                    isomer_engine="rdkit", optimizing_engine="ANI2xt", max_confs=3)
     out = main(args)
-    out_folder = os.path.dirname(os.path.abspath(out))
-    try:
-        send2trash(out_folder)
-    except OSError:
-        shutil.rmtree(out_folder)
+    assert_pipeline_output(out, formula_by_id=_sdf_formulas(), window=2,
+                           label="sdf rdkit/ANI2xt")
 
 def test_auto3D_smiles2mols():
     """Check that the program runs"""
@@ -331,9 +350,59 @@ def test_auto3D_smiles2mols():
     mols = smiles2mols(smiles, args)
     assert (len(mols) == 2)
 
+
+def test_auto3D_optimization_moves_the_embedded_geometry(job_dir):
+    """The optimizer must change the geometry it was handed.
+
+    This is the one check the rest of the module cannot make. Everywhere else
+    the embedded starting geometry is swept into ``verbose.tar.gz`` and deleted
+    by housekeeping, so an output that merely echoed the ETKDG embedding with a
+    plausible energy would satisfy every other assertion here. Running with
+    ``verbose=True`` keeps that tarball, and ``batchopt`` copies each
+    conformer's pre-optimization name onto the output record's ``ID`` property,
+    which gives an exact join between a finished structure and its own starting
+    point.
+
+    One small molecule, and the default (tight) 0.01 eV/A convergence
+    threshold rather than the loose value the engine-matrix tests use, so the
+    optimizer is required to do real work. The 0.01 A floor asserted below is
+    an order of magnitude under the relaxation an ETKDG embedding actually
+    undergoes on the way to an NNP minimum (typically 0.1-0.5 A), so it fails
+    only for an optimizer that did essentially nothing.
+    """
+    smi = job_dir / "ethanol.smi"
+    smi.write_text("CCO ethanol\n")
+
+    args = Auto3DOptions(str(smi), k=1, use_gpu=False, max_confs=2,
+                         isomer_engine="rdkit", optimizing_engine="AIMNET",
+                         verbose=True)
+    out = main(args)
+
+    records = assert_pipeline_output(out, formula_by_id={"ethanol": "C2H6O"}, k=1,
+                                     label="ethanol/AIMNET")
+
+    embedded = read_pre_optimization_geometries(os.path.dirname(os.path.abspath(out)))
+
+    assert records, "no output records to compare against the embedding"
+    for mol in records:
+        conformer_id = mol.GetProp("ID").strip()
+        assert conformer_id in embedded, (
+            f"output conformer ID {conformer_id!r} has no counterpart among the "
+            f"pre-optimization conformers {sorted(embedded)}; the join between "
+            f"an optimized record and its starting geometry is broken"
+        )
+        displacement = max_atom_displacement(embedded[conformer_id], mol)
+        assert displacement > 0.01, (
+            f"{conformer_id}: no atom moved further than {displacement:.5f} A "
+            f"from the ETKDG embedding, so the geometry optimization did not "
+            f"run (or its result was discarded)"
+        )
+
+
 @pytest.mark.skipif(test_userNNP1 == False, reason='TorchANI is not installed')
 @pytest.mark.skipif(torch.cuda.is_available() == False, reason="No GPU")
 def test_auto3D_userNNP1():
+    """A TorchScript custom NNP drives the full pipeline on GPU."""
     myNNP1 = userNNP1()
     with tempfile.TemporaryDirectory() as temp_dir:
         model_path = os.path.join(temp_dir, 'myNNP1.pt')
@@ -342,13 +411,15 @@ def test_auto3D_userNNP1():
 
         smi_path = os.path.join(temp_dir, os.path.basename(path))
         shutil.copyfile(path, smi_path)
-        
+
         args = Auto3DOptions(smi_path, k=1, optimizing_engine=model_path, use_gpu=True, gpu_idx=0)
         out = main(args)
-        print(out)
+        assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                               label="gpu userNNP1 (scripted ANI2x)")
 
 @pytest.mark.skipif(test_userNNP1 == False, reason='TorchANI is not installed')
 def test_auto3D_userNNP2():
+    """A TorchScript custom NNP drives the full pipeline on CPU."""
     myNNP1 = userNNP1()
     with tempfile.TemporaryDirectory() as temp_dir:
         model_path = os.path.join(temp_dir, 'myNNP1.pt')
@@ -359,10 +430,12 @@ def test_auto3D_userNNP2():
         shutil.copyfile(path, smi_path)
         args = Auto3DOptions(smi_path, k=1, optimizing_engine=model_path, use_gpu=False)
         out = main(args)
-        print(out)
+        assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                               label="cpu userNNP1 (scripted ANI2x)")
 
 @pytest.mark.skipif(torch.cuda.is_available() == False, reason="No GPU")
 def test_auto3D_userNNP3():
+    """An eager (non-scriptable) AIMNet2-backed custom NNP drives the pipeline."""
     myNNP = userNNP2()
     with tempfile.TemporaryDirectory() as temp_dir:
         model_path = os.path.join(temp_dir, 'myNNP.pt')
@@ -373,7 +446,8 @@ def test_auto3D_userNNP3():
         shutil.copyfile(path, smi_path)
         args = Auto3DOptions(smi_path, k=1, optimizing_engine=model_path, use_gpu=True, gpu_idx=0)
         out = main(args)
-        print(out)
+        assert_pipeline_output(out, formula_by_id=_smi_formulas(), k=1,
+                               label="gpu userNNP2 (eager AIMNet2 calculator)")
 
 
 if __name__ == "__main__":
@@ -392,4 +466,3 @@ if __name__ == "__main__":
     test_auto3D_userNNP3()
     end3 = time.time()
     print(f"Time taken: {end3 - end2}")
-

--- a/tests/test_auto3D.py
+++ b/tests/test_auto3D.py
@@ -369,6 +369,15 @@ def test_auto3D_optimization_moves_the_embedded_geometry(job_dir):
     an order of magnitude under the relaxation an ETKDG embedding actually
     undergoes on the way to an NNP minimum (typically 0.1-0.5 A), so it fails
     only for an optimizer that did essentially nothing.
+
+    Joining on the full conformer ID does NOT work, and an earlier version of
+    this test asserted that it did: `encode_ids` replaces every input id with
+    a numeric index before enumeration, so the pre-optimization records carry
+    `0_<isomer>_<conformer>` while the final output has been decoded back to
+    `ethanol_<isomer>_<conformer>`. CI reported exactly that mismatch. The two
+    trailing components are the isomer and conformer indices and ARE shared,
+    so this joins on those -- unambiguous here because the input is a single
+    molecule, which the assertion below pins rather than assumes.
     """
     smi = job_dir / "ethanol.smi"
     smi.write_text("CCO ethanol\n")
@@ -384,14 +393,35 @@ def test_auto3D_optimization_moves_the_embedded_geometry(job_dir):
     embedded = read_pre_optimization_geometries(os.path.dirname(os.path.abspath(out)))
 
     assert records, "no output records to compare against the embedding"
+    assert embedded, "no pre-optimization geometries were recovered"
+
+    def _isomer_conformer(name: str) -> str:
+        """The `<isomer>_<conformer>` tail, which survives id encoding."""
+        parts = name.strip().rsplit("_", 2)
+        assert len(parts) == 3, (
+            f"conformer name {name!r} is not <species>_<isomer>_<conformer>; "
+            "the naming convention this join relies on has changed"
+        )
+        return "_".join(parts[1:])
+
+    by_tail = {_isomer_conformer(k): v for k, v in embedded.items()}
+    # Single input molecule, so the tail identifies a conformer uniquely. If
+    # that ever stops holding, this join is wrong rather than merely unlucky.
+    assert len(by_tail) == len(embedded), (
+        f"isomer/conformer tails are not unique across {sorted(embedded)}; "
+        "this join assumes a single input molecule"
+    )
+
     for mol in records:
         conformer_id = mol.GetProp("ID").strip()
-        assert conformer_id in embedded, (
-            f"output conformer ID {conformer_id!r} has no counterpart among the "
-            f"pre-optimization conformers {sorted(embedded)}; the join between "
-            f"an optimized record and its starting geometry is broken"
+        tail = _isomer_conformer(conformer_id)
+        assert tail in by_tail, (
+            f"output conformer ID {conformer_id!r} (tail {tail!r}) has no "
+            f"counterpart among the pre-optimization conformers "
+            f"{sorted(embedded)}; the join between an optimized record and "
+            f"its starting geometry is broken"
         )
-        displacement = max_atom_displacement(embedded[conformer_id], mol)
+        displacement = max_atom_displacement(by_tail[tail], mol)
         assert displacement > 0.01, (
             f"{conformer_id}: no atom moved further than {displacement:.5f} A "
             f"from the ETKDG embedding, so the geometry optimization did not "

--- a/tests/test_helpers_pipeline_output.py
+++ b/tests/test_helpers_pipeline_output.py
@@ -1,0 +1,781 @@
+"""Unit tests for the slow tier's shared output assertions.
+
+The helpers in ``tests/helpers_pipeline_output.py`` are the only thing standing
+between the slow NNP tier and its previous state of asserting nothing. Their
+own callers cannot run on a machine without a GPU budget and a model cache, so
+the helpers are exercised here instead -- hermetically, on RDKit-embedded
+molecules and synthetic SDF files, with no potential loaded and no weights
+downloaded.
+
+Two things are pinned for every assertion helper: that it **passes** on
+well-formed input, and that it **fails** on each specific defect it claims to
+catch. A helper only verified in the passing direction is exactly the "names a
+guarantee it does not provide" defect these tests exist to prevent.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+from rdkit import Chem
+from rdkit.Chem import AllChem
+from rdkit.Chem.rdMolDescriptors import CalcMolFormula
+
+from Auto3D.results import WorkflowResult
+from Auto3D.utils.energy import E_TOT_HARTREE_PROP, E_TOT_PROP
+from tests.helpers_pipeline_output import (
+    ATOMIC_ENERGY_HARTREE,
+    assert_energy_is_plausible_hartree,
+    assert_geometry_is_physical,
+    assert_opt_geometry_output,
+    assert_pipeline_output,
+    base_molecule_id,
+    expanded_copy,
+    formula_from_smiles,
+    formulas_from_sdf_file,
+    formulas_from_smi_file,
+    max_atom_displacement,
+    molecular_formula,
+    read_sdf_records,
+    self_energy_estimate_hartree,
+    write_perturbed_sdf,
+)
+
+FILES = Path(__file__).parent / "files"
+
+
+def _embedded(smiles: str, seed: int = 0xF00D) -> Chem.Mol:
+    """A hydrogen-complete molecule with one ETKDG conformer."""
+    mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    assert AllChem.EmbedMolecule(mol, randomSeed=seed) == 0
+    return mol
+
+
+def _plausible_energy(mol: Chem.Mol) -> float:
+    """An energy of the size a real potential would report for ``mol``."""
+    return self_energy_estimate_hartree(mol) * 1.008
+
+
+def _annotate_ranked(
+    mol: Chem.Mol,
+    name: str,
+    *,
+    energy: float | None = None,
+    e_rel: float = 0.0,
+    conformer_id: str = "0_0_0",
+) -> Chem.Mol:
+    """Stamp a molecule with the properties ``ConformerRanker`` writes."""
+    out = Chem.Mol(mol)
+    out.SetProp("_Name", name)
+    value = _plausible_energy(mol) if energy is None else energy
+    out.SetProp(E_TOT_PROP, repr(value))
+    out.SetProp(E_TOT_HARTREE_PROP, repr(value))
+    out.SetProp("E_rel(kcal/mol)", repr(e_rel))
+    out.SetProp("Converged", "True")
+    out.SetProp("ID", conformer_id)
+    return out
+
+
+def _annotate_optimized(mol: Chem.Mol, name: str) -> Chem.Mol:
+    """Stamp a molecule with the properties ``batch_opt.optimizing`` writes."""
+    out = Chem.Mol(mol)
+    out.SetProp("_Name", name)
+    value = _plausible_energy(mol)
+    out.SetProp(E_TOT_PROP, repr(value))
+    out.SetProp(E_TOT_HARTREE_PROP, repr(value))
+    out.SetProp("fmax", "0.0074")
+    out.SetProp("Converged", "True")
+    out.SetProp("Dropped_Oscillating", "False")
+    out.SetProp("Stereo_changed", "False")
+    out.SetProp("ID", name)
+    return out
+
+
+def _write_sdf(path: Path, mols: list[Chem.Mol]) -> str:
+    with Chem.SDWriter(str(path)) as writer:
+        for mol in mols:
+            writer.write(mol)
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Formula helpers
+# ---------------------------------------------------------------------------
+
+class TestFormulaHelpers:
+    """Formula comparison is the pipeline's chemical-identity check."""
+
+    @pytest.mark.parametrize(
+        "smiles", ["CC(CC)=O", "COC(/C=C/C)=O", "CC(CCCl)=O", "CCO", "c1ccccc1"]
+    )
+    def test_implicit_and_explicit_hydrogens_give_one_formula(self, smiles):
+        """The whole comparison rests on this: inputs are implicit-H SMILES and
+        outputs are explicit-H 3D structures, so the two must agree."""
+        implicit = Chem.MolFromSmiles(smiles)
+        explicit = Chem.AddHs(implicit)
+        assert molecular_formula(implicit) == molecular_formula(explicit)
+        assert molecular_formula(implicit) == formula_from_smiles(smiles)
+
+    def test_formula_survives_an_sdf_round_trip(self, tmp_path):
+        mol = _embedded("CC(CCCl)=O")
+        path = _write_sdf(tmp_path / "m.sdf", [mol])
+        (reread,) = read_sdf_records(path)
+        assert molecular_formula(reread) == "C4H7ClO"
+
+    def test_different_molecules_have_different_formulas(self):
+        """Non-vacuity: the check would be worthless if everything matched."""
+        assert formula_from_smiles("CCO") != formula_from_smiles("CCC")
+
+    def test_unparseable_smiles_is_refused(self):
+        with pytest.raises(ValueError, match="could not parse"):
+            formula_from_smiles("this is not a smiles")
+
+    def test_none_is_refused(self):
+        with pytest.raises(ValueError, match="received None"):
+            molecular_formula(None)
+
+    def test_formulas_from_smi_file_reads_the_real_fixture(self):
+        assert formulas_from_smi_file(FILES / "smiles2.smi") == {
+            "smi2": "C4H8O",
+            "smi3": "C5H8O2",
+            "smi4": "C4H7ClO",
+        }
+
+    def test_formulas_from_sdf_file_reads_the_real_fixture(self):
+        assert formulas_from_sdf_file(FILES / "example.sdf") == {
+            "mol1": "C6H12O2",
+            "mol2": "C11H9ClN4O2",
+        }
+
+    def test_empty_smi_file_is_refused_rather_than_returning_nothing(self, tmp_path):
+        """An empty expectation map would make every downstream loop vacuous."""
+        empty = tmp_path / "empty.smi"
+        empty.write_text("\n\n")
+        with pytest.raises(ValueError, match="no '<smiles> <id>' records"):
+            formulas_from_smi_file(empty)
+
+    def test_sdf_file_without_parseable_records_is_refused(self, tmp_path):
+        """A wholly empty file makes RDKit raise on open, which is loud enough;
+        the guard exists for a file that parses to nothing usable."""
+        junk = tmp_path / "junk.sdf"
+        junk.write_text("\n")
+        with pytest.raises(ValueError, match="no parseable records"):
+            formulas_from_sdf_file(junk)
+
+
+class TestBaseMoleculeId:
+    """Must normalize names exactly as the pipeline's reconciliation does."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("smi2", "smi2"),
+            ("  smi2  ", "smi2"),
+            ("smi2@taut1", "smi2"),
+            ("smi2@taut12", "smi2"),
+            ("KEY_2", "KEY_2"),
+            ("KEY_2@taut0", "KEY_2"),
+        ],
+    )
+    def test_strips_only_the_tautomer_suffix(self, name, expected):
+        assert base_molecule_id(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# read_sdf_records
+# ---------------------------------------------------------------------------
+
+class TestReadSdfRecords:
+    """The check that kills 'return a path you never wrote'."""
+
+    def test_accepts_a_real_multi_record_file(self):
+        records = read_sdf_records(FILES / "DA.sdf")
+        assert len(records) == 3
+        assert [m.GetProp("_Name") for m in records] == [
+            "diene",
+            "dieneophile",
+            "product",
+        ]
+
+    def test_missing_file_fails(self, tmp_path):
+        with pytest.raises(AssertionError, match="no file exists"):
+            read_sdf_records(tmp_path / "never_written.sdf")
+
+    def test_empty_file_fails(self, tmp_path):
+        empty = tmp_path / "empty.sdf"
+        empty.write_text("")
+        with pytest.raises(AssertionError, match="is empty"):
+            read_sdf_records(empty)
+
+    def test_file_of_whitespace_fails(self, tmp_path):
+        """RDKit yields one unparseable record rather than zero records for a
+        non-empty file, so this lands on the parse guard; either way the helper
+        must refuse it instead of returning an empty list to iterate over."""
+        blank = tmp_path / "blank.sdf"
+        blank.write_text("\n")
+        with pytest.raises(AssertionError, match="do not parse as SDF"):
+            read_sdf_records(blank)
+
+    def test_unparseable_record_fails(self, tmp_path):
+        good = _annotate_ranked(_embedded("CCO"), "ethanol")
+        path = tmp_path / "mixed.sdf"
+        _write_sdf(path, [good])
+        # Append a record RDKit cannot parse (bad element symbol in the atom block).
+        path.write_text(path.read_text() + "junk\n\n\n  bogus\n$$$$\n")
+        with pytest.raises(AssertionError, match="do not parse as SDF"):
+            read_sdf_records(path)
+
+
+# ---------------------------------------------------------------------------
+# Energies
+# ---------------------------------------------------------------------------
+
+class TestSelfEnergyEstimate:
+    """The order-of-magnitude reference the energy bound is measured against."""
+
+    def test_implicit_and_explicit_hydrogens_agree(self):
+        implicit = Chem.MolFromSmiles("CC(CC)=O")
+        assert self_energy_estimate_hartree(implicit) == pytest.approx(
+            self_energy_estimate_hartree(Chem.AddHs(implicit))
+        )
+
+    def test_estimate_is_within_one_percent_of_real_reference_energies(self):
+        """Pinned against the three DFT-level energies checked into DA.sdf.
+
+        This is what justifies the 2x window in
+        ``assert_energy_is_plausible_hartree``: the estimate is good to well
+        under a percent, so the window has two orders of magnitude of headroom
+        over its own error while still being 13x tighter than an eV/Hartree
+        mix-up.
+        """
+        records = read_sdf_records(FILES / "DA.sdf")
+        assert len(records) == 3
+        for mol in records:
+            reference = float(mol.GetProp(E_TOT_PROP))
+            estimate = self_energy_estimate_hartree(mol)
+            assert abs(estimate - reference) / abs(reference) < 0.01
+
+    def test_is_negative_and_scales_with_size(self):
+        small = self_energy_estimate_hartree(Chem.MolFromSmiles("CCO"))
+        large = self_energy_estimate_hartree(Chem.MolFromSmiles("CCCCCCCCO"))
+        assert small < 0
+        assert large < small
+
+    def test_unknown_element_raises_rather_than_skipping_the_check(self):
+        """Silently returning 'no opinion' for an unsupported element is the
+        vacuous-assertion trap; the helper must refuse instead."""
+        assert 26 not in ATOMIC_ENERGY_HARTREE
+        with pytest.raises(KeyError, match="no reference atomic energy"):
+            self_energy_estimate_hartree(Chem.MolFromSmiles("[Fe]"))
+
+
+class TestAssertEnergyIsPlausible:
+    def test_accepts_real_reference_energies(self):
+        for mol in read_sdf_records(FILES / "DA.sdf"):
+            mol.SetProp(E_TOT_HARTREE_PROP, mol.GetProp(E_TOT_PROP))
+            energy = assert_energy_is_plausible_hartree(mol)
+            assert energy == pytest.approx(float(mol.GetProp(E_TOT_PROP)))
+
+    def test_rejects_an_energy_written_in_ev(self):
+        """The regression this project just fixed: eV under a Hartree name."""
+        mol = _embedded("CCO")
+        in_ev = _plausible_energy(mol) * 27.211386245988
+        mol.SetProp(E_TOT_PROP, repr(in_ev))
+        mol.SetProp(E_TOT_HARTREE_PROP, repr(in_ev))
+        with pytest.raises(AssertionError, match="outside"):
+            assert_energy_is_plausible_hartree(mol)
+
+    def test_rejects_a_missing_energy(self):
+        mol = _embedded("CCO")
+        with pytest.raises(AssertionError, match=f"no {E_TOT_PROP} property"):
+            assert_energy_is_plausible_hartree(mol)
+
+    def test_rejects_a_positive_energy(self):
+        mol = _embedded("CCO")
+        mol.SetProp(E_TOT_PROP, "12.5")
+        mol.SetProp(E_TOT_HARTREE_PROP, "12.5")
+        with pytest.raises(AssertionError, match="must be negative"):
+            assert_energy_is_plausible_hartree(mol)
+
+    def test_rejects_a_nan_energy(self):
+        mol = _embedded("CCO")
+        mol.SetProp(E_TOT_PROP, "nan")
+        mol.SetProp(E_TOT_HARTREE_PROP, "nan")
+        with pytest.raises(AssertionError, match="is nan"):
+            assert_energy_is_plausible_hartree(mol)
+
+    def test_rejects_an_atomization_scale_energy(self):
+        """Far too small to be a total energy for this molecule."""
+        mol = _embedded("CCO")
+        mol.SetProp(E_TOT_PROP, "-1.75")
+        mol.SetProp(E_TOT_HARTREE_PROP, "-1.75")
+        with pytest.raises(AssertionError, match="outside"):
+            assert_energy_is_plausible_hartree(mol)
+
+    def test_rejects_a_missing_unit_labeled_sibling(self):
+        mol = _embedded("CCO")
+        mol.SetProp(E_TOT_PROP, repr(_plausible_energy(mol)))
+        with pytest.raises(AssertionError, match="unit-labeled"):
+            assert_energy_is_plausible_hartree(mol)
+
+    def test_rejects_a_sibling_that_disagrees(self):
+        """Catches a second unit conversion applied to only one of the pair."""
+        mol = _embedded("CCO")
+        value = _plausible_energy(mol)
+        mol.SetProp(E_TOT_PROP, repr(value))
+        mol.SetProp(E_TOT_HARTREE_PROP, repr(value / 27.211386245988))
+        with pytest.raises(AssertionError, match="disagrees with"):
+            assert_energy_is_plausible_hartree(mol)
+
+
+# ---------------------------------------------------------------------------
+# Geometry
+# ---------------------------------------------------------------------------
+
+class TestAssertGeometryIsPhysical:
+    def test_accepts_real_structures(self):
+        for mol in read_sdf_records(FILES / "DA.sdf"):
+            assert_geometry_is_physical(mol)
+
+    def test_rejects_a_collapsed_structure(self):
+        mol = _embedded("CCO")
+        conformer = mol.GetConformer()
+        for idx in range(mol.GetNumAtoms()):
+            conformer.SetAtomPosition(idx, [0.0, 0.0, 0.0])
+        with pytest.raises(AssertionError, match="collapsed"):
+            assert_geometry_is_physical(mol)
+
+    def test_rejects_non_finite_coordinates(self):
+        mol = _embedded("CCO")
+        mol.GetConformer().SetAtomPosition(0, [float("nan"), 0.0, 0.0])
+        with pytest.raises(AssertionError, match="non-finite"):
+            assert_geometry_is_physical(mol)
+
+    def test_rejects_a_record_carrying_more_than_one_conformer(self):
+        mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        AllChem.EmbedMultipleConfs(mol, numConfs=3, randomSeed=7)
+        with pytest.raises(AssertionError, match="exactly one conformer"):
+            assert_geometry_is_physical(mol)
+
+    def test_two_atoms_just_over_the_floor_are_accepted(self):
+        """The floor is 0.5 A, well below the shortest real bond (H-H, 0.74 A),
+        so it never fires on a genuine structure."""
+        mol = Chem.MolFromMolBlock(
+            "\n     RDKit          3D\n\n"
+            "  2  1  0  0  0  0  0  0  0  0999 V2000\n"
+            "    0.0000    0.0000    0.0000 H   0  0\n"
+            "    0.7400    0.0000    0.0000 H   0  0\n"
+            "  1  2  1  0\n"
+            "M  END\n",
+            removeHs=False,
+        )
+        assert_geometry_is_physical(mol, min_separation=0.5)
+        with pytest.raises(AssertionError, match="collapsed"):
+            assert_geometry_is_physical(mol, min_separation=0.8)
+
+
+class TestMaxAtomDisplacement:
+    def test_identical_conformations_have_zero_displacement(self):
+        mol = _embedded("CCO")
+        assert max_atom_displacement(mol, Chem.Mol(mol)) == pytest.approx(0.0)
+
+    def test_measures_a_known_rigid_shift(self):
+        mol = _embedded("CCO")
+        shifted = Chem.Mol(mol)
+        conformer = shifted.GetConformer()
+        positions = conformer.GetPositions()
+        for idx in range(shifted.GetNumAtoms()):
+            conformer.SetAtomPosition(idx, (positions[idx] + [0.3, 0.4, 0.0]).tolist())
+        assert max_atom_displacement(mol, shifted) == pytest.approx(0.5, abs=1e-9)
+
+    def test_reports_the_largest_single_atom_move(self):
+        mol = _embedded("CCO")
+        moved = Chem.Mol(mol)
+        position = np.array(moved.GetConformer().GetPositions()[0])
+        moved.GetConformer().SetAtomPosition(0, (position + [0.0, 0.0, 1.25]).tolist())
+        assert max_atom_displacement(mol, moved) == pytest.approx(1.25)
+
+    def test_refuses_a_different_molecule(self):
+        with pytest.raises(ValueError, match="atom count differs"):
+            max_atom_displacement(_embedded("CCO"), _embedded("CCCO"))
+
+    def test_refuses_a_reordered_molecule(self):
+        """Same atom count, different element order: the number would be a lie."""
+        a = _embedded("CCO")
+        b = _embedded("CCO")
+        # Swapping the two carbons would be invisible to an element-order
+        # check, so move a hydrogen into a heavy atom's slot instead.
+        reordered = Chem.RenumberAtoms(
+            b, [0, 1, b.GetNumAtoms() - 1, *range(2, b.GetNumAtoms() - 1)]
+        )
+        with pytest.raises(ValueError, match="atomic numbers differ"):
+            max_atom_displacement(a, reordered)
+
+
+class TestExpandedCopy:
+    """The deterministic perturbation that makes 'the optimizer moved it'
+    assertable on an input that is already at a minimum."""
+
+    def test_scales_every_bond_by_the_factor(self):
+        mol = read_sdf_records(FILES / "DA.sdf")[2]
+        expanded = expanded_copy(mol, 1.05)
+        original = mol.GetConformer().GetPositions()
+        moved = expanded.GetConformer().GetPositions()
+        assert mol.GetNumBonds() > 0
+        for bond in mol.GetBonds():
+            i, j = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+            before = np.linalg.norm(original[i] - original[j])
+            after = np.linalg.norm(moved[i] - moved[j])
+            assert after == pytest.approx(before * 1.05, rel=1e-9)
+
+    def test_preserves_the_centroid(self):
+        """So the displacement measured afterwards is relaxation, not a shift."""
+        mol = read_sdf_records(FILES / "DA.sdf")[0]
+        expanded = expanded_copy(mol, 1.05)
+        before = mol.GetConformer().GetPositions().mean(axis=0)
+        after = expanded.GetConformer().GetPositions().mean(axis=0)
+        assert after == pytest.approx(before, abs=1e-9)
+
+    def test_leaves_the_original_untouched(self):
+        mol = read_sdf_records(FILES / "DA.sdf")[0]
+        before = mol.GetConformer().GetPositions().copy()
+        expanded_copy(mol, 1.20)
+        assert mol.GetConformer().GetPositions() == pytest.approx(before)
+
+    def test_the_perturbation_clears_the_relaxation_floor_it_is_paired_with(self):
+        """Every atom of every DA.sdf molecule moves further than the 0.01 A
+        floor ``test_thermo`` asserts afterwards, so the perturbation is what
+        makes that assertion meaningful rather than lucky."""
+        for mol in read_sdf_records(FILES / "DA.sdf"):
+            expanded = expanded_copy(mol, 1.05)
+            positions = mol.GetConformer().GetPositions()
+            shifted = expanded.GetConformer().GetPositions()
+            per_atom = np.linalg.norm(shifted - positions, axis=1)
+            assert per_atom.min() > 0.04
+            assert max_atom_displacement(mol, expanded) > 0.1
+
+    def test_a_factor_of_one_is_a_no_op(self):
+        mol = read_sdf_records(FILES / "DA.sdf")[0]
+        assert max_atom_displacement(mol, expanded_copy(mol, 1.0)) == pytest.approx(
+            0.0, abs=1e-9
+        )
+
+
+class TestWritePerturbedSdf:
+    """The staging step the opt_geometry tests depend on."""
+
+    def test_writes_every_record_with_its_name(self, tmp_path):
+        path, mols = write_perturbed_sdf(
+            FILES / "DA.sdf", tmp_path / "DA.sdf", 1.05
+        )
+        assert Path(path) == tmp_path / "DA.sdf"
+        assert [m.GetProp("_Name") for m in mols] == [
+            "diene",
+            "dieneophile",
+            "product",
+        ]
+
+    def test_strips_stale_properties(self, tmp_path):
+        """DA.sdf ships with E_tot/fmax/Converged from an earlier run. If those
+        survived, an optimizer that wrote nothing would still emit output
+        carrying a plausible energy and pass the energy check."""
+        before = read_sdf_records(FILES / "DA.sdf")
+        assert all(mol.HasProp(E_TOT_PROP) for mol in before)
+        _, after = write_perturbed_sdf(FILES / "DA.sdf", tmp_path / "DA.sdf", 1.05)
+        assert after
+        for mol in after:
+            assert list(mol.GetPropNames()) == []
+
+    def test_perturbation_survives_the_sdf_round_trip(self, tmp_path):
+        """SDF stores 4 decimal places; the displacement must still clear the
+        0.01 A floor asserted after optimization, with room to spare."""
+        originals = read_sdf_records(FILES / "DA.sdf")
+        _, staged = write_perturbed_sdf(FILES / "DA.sdf", tmp_path / "DA.sdf", 1.05)
+        assert len(staged) == len(originals) == 3
+        for original, moved in zip(originals, staged, strict=True):
+            assert max_atom_displacement(original, moved) > 0.1
+
+    def test_returned_molecules_match_the_file_on_disk(self, tmp_path):
+        """The returned list must be what the optimizer will read, to 4dp, not
+        the full-precision in-memory copies."""
+        path, returned = write_perturbed_sdf(
+            FILES / "DA.sdf", tmp_path / "DA.sdf", 1.05
+        )
+        from_disk = read_sdf_records(path)
+        for a, b in zip(returned, from_disk, strict=True):
+            assert max_atom_displacement(a, b) == pytest.approx(0.0, abs=1e-12)
+
+    def test_a_factor_of_one_stages_an_unmoved_copy(self, tmp_path):
+        """Non-vacuity for the test above: the displacement comes from the
+        factor, not from the round trip itself."""
+        originals = read_sdf_records(FILES / "DA.sdf")
+        _, staged = write_perturbed_sdf(FILES / "DA.sdf", tmp_path / "DA.sdf", 1.0)
+        for original, moved in zip(originals, staged, strict=True):
+            assert max_atom_displacement(original, moved) < 1e-3
+
+
+# ---------------------------------------------------------------------------
+# assert_pipeline_output
+# ---------------------------------------------------------------------------
+
+FORMULAS = {"smi2": "C4H8O", "smi3": "C5H8O2", "smi4": "C4H7ClO"}
+SMILES_BY_ID = {"smi2": "CC(CC)=O", "smi3": "COC(/C=C/C)=O", "smi4": "CC(CCCl)=O"}
+
+
+def _good_output(tmp_path, *, ids=("smi2", "smi3", "smi4"), name="out.sdf"):
+    """A synthetic output SDF satisfying every contract the pipeline promises."""
+    mols = [
+        _annotate_ranked(_embedded(SMILES_BY_ID[i]), i, conformer_id=f"{n}_0_0")
+        for n, i in enumerate(ids)
+    ]
+    path = _write_sdf(tmp_path / name, mols)
+    return WorkflowResult(path), mols
+
+
+class TestAssertPipelineOutput:
+    def test_accepts_a_well_formed_run(self, tmp_path):
+        result, _ = _good_output(tmp_path)
+        records = assert_pipeline_output(result, formula_by_id=FORMULAS, k=1)
+        assert len(records) == 3
+
+    def test_accepts_a_partial_run_whose_losses_are_reported(self, tmp_path):
+        """The reconciliation contract: absent is fine, absent *and silent* is not."""
+        result, _ = _good_output(tmp_path, ids=("smi2", "smi3"))
+        reported = WorkflowResult(str(result), failures=["smi4"])
+        assert_pipeline_output(reported, formula_by_id=FORMULAS, k=1)
+
+    def test_rejects_a_molecule_that_vanished_without_a_report(self, tmp_path):
+        result, _ = _good_output(tmp_path, ids=("smi2", "smi3"))
+        with pytest.raises(AssertionError, match="absent from the output"):
+            assert_pipeline_output(result, formula_by_id=FORMULAS, k=1)
+
+    def test_rejects_a_run_that_produced_nothing_but_claims_total_failure(
+        self, tmp_path
+    ):
+        empty = tmp_path / "nothing.sdf"
+        empty.write_text("")
+        result = WorkflowResult(str(empty), failures=list(FORMULAS))
+        with pytest.raises(AssertionError, match="is empty"):
+            assert_pipeline_output(result, formula_by_id=FORMULAS, k=1)
+
+    def test_rejects_an_id_that_was_never_in_the_input(self, tmp_path):
+        result, _ = _good_output(tmp_path)
+        with pytest.raises(AssertionError, match="never in the input"):
+            assert_pipeline_output(
+                result, formula_by_id={"smi2": "C4H8O", "smi3": "C5H8O2"}, k=1
+            )
+
+    def test_rejects_an_id_both_produced_and_reported_failed(self, tmp_path):
+        result, _ = _good_output(tmp_path)
+        contradictory = WorkflowResult(str(result), failures=["smi2"])
+        with pytest.raises(AssertionError, match="reported as failures yet present"):
+            assert_pipeline_output(contradictory, formula_by_id=FORMULAS, k=1)
+
+    def test_rejects_a_changed_chemical_identity(self, tmp_path):
+        """The mutation where the pipeline emits the wrong molecule."""
+        wrong = _annotate_ranked(_embedded("CCCCCC"), "smi2")
+        others = [
+            _annotate_ranked(_embedded(SMILES_BY_ID[i]), i) for i in ("smi3", "smi4")
+        ]
+        path = _write_sdf(tmp_path / "wrong.sdf", [wrong, *others])
+        with pytest.raises(AssertionError, match="chemical identity changed"):
+            assert_pipeline_output(WorkflowResult(path), formula_by_id=FORMULAS, k=1)
+
+    def test_rejects_more_conformers_than_k_allows(self, tmp_path):
+        mols = [
+            _annotate_ranked(_embedded(SMILES_BY_ID["smi2"], seed=s), "smi2")
+            for s in (1, 2)
+        ]
+        mols += [
+            _annotate_ranked(_embedded(SMILES_BY_ID[i]), i) for i in ("smi3", "smi4")
+        ]
+        path = _write_sdf(tmp_path / "extra.sdf", mols)
+        with pytest.raises(AssertionError, match="conformers written for k=1"):
+            assert_pipeline_output(WorkflowResult(path), formula_by_id=FORMULAS, k=1)
+
+    def test_rejects_an_energy_window_violation(self, tmp_path):
+        mols = [
+            _annotate_ranked(_embedded(SMILES_BY_ID[i]), i, e_rel=e)
+            for i, e in zip(("smi2", "smi3", "smi4"), (0.0, 1.4, 3.7), strict=True)
+        ]
+        path = _write_sdf(tmp_path / "window.sdf", mols)
+        result = WorkflowResult(path)
+        assert_pipeline_output(result, formula_by_id=FORMULAS, window=4.0)
+        with pytest.raises(AssertionError, match="exceeds the 2.0 kcal/mol window"):
+            assert_pipeline_output(result, formula_by_id=FORMULAS, window=2.0)
+
+    def test_rejects_a_negative_relative_energy(self, tmp_path):
+        mols = [
+            _annotate_ranked(_embedded(SMILES_BY_ID[i]), i, e_rel=e)
+            for i, e in zip(("smi2", "smi3", "smi4"), (0.0, 0.0, -0.9), strict=True)
+        ]
+        path = _write_sdf(tmp_path / "negative.sdf", mols)
+        with pytest.raises(AssertionError, match="is negative"):
+            assert_pipeline_output(
+                WorkflowResult(path), formula_by_id=FORMULAS, window=5.0
+            )
+
+    def test_rejects_a_nonzero_relative_energy_when_k_is_one(self, tmp_path):
+        mols = [
+            _annotate_ranked(_embedded(SMILES_BY_ID[i]), i, e_rel=e)
+            for i, e in zip(("smi2", "smi3", "smi4"), (0.0, 0.0, 0.6), strict=True)
+        ]
+        path = _write_sdf(tmp_path / "krel.sdf", mols)
+        with pytest.raises(AssertionError, match="E_rel must be 0"):
+            assert_pipeline_output(WorkflowResult(path), formula_by_id=FORMULAS, k=1)
+
+    def test_rejects_output_that_kept_the_working_ev_relative_energy(self, tmp_path):
+        result, mols = _good_output(tmp_path)
+        mols[0].SetProp("E_rel(eV)", "0.0")
+        path = _write_sdf(tmp_path / "ev.sdf", mols)
+        with pytest.raises(AssertionError, match=r"E_rel\(eV\) survived"):
+            assert_pipeline_output(WorkflowResult(path), formula_by_id=FORMULAS, k=1)
+
+    def test_rejects_an_unconverged_structure(self, tmp_path):
+        result, mols = _good_output(tmp_path)
+        mols[1].SetProp("Converged", "False")
+        path = _write_sdf(tmp_path / "unconverged.sdf", mols)
+        with pytest.raises(AssertionError, match="only emit converged structures"):
+            assert_pipeline_output(WorkflowResult(path), formula_by_id=FORMULAS, k=1)
+
+    def test_rejects_an_implausible_energy(self, tmp_path):
+        """The 'arbitrary E_tot' half of the mutation this tier missed."""
+        mols = [
+            _annotate_ranked(_embedded(SMILES_BY_ID[i]), i) for i in ("smi3", "smi4")
+        ]
+        mols.insert(0, _annotate_ranked(_embedded(SMILES_BY_ID["smi2"]), "smi2",
+                                        energy=-1.0))
+        path = _write_sdf(tmp_path / "badenergy.sdf", mols)
+        with pytest.raises(AssertionError, match="outside"):
+            assert_pipeline_output(WorkflowResult(path), formula_by_id=FORMULAS, k=1)
+
+    def test_refuses_an_empty_expectation_map(self, tmp_path):
+        """The core non-vacuity guard: no expectations means no test."""
+        result, _ = _good_output(tmp_path)
+        with pytest.raises(AssertionError, match="no expected molecules"):
+            assert_pipeline_output(result, formula_by_id={}, k=1)
+
+    def test_refuses_both_selectors_at_once(self, tmp_path):
+        result, _ = _good_output(tmp_path)
+        with pytest.raises(AssertionError, match="alternative selectors"):
+            assert_pipeline_output(result, formula_by_id=FORMULAS, k=1, window=2.0)
+
+    def test_cross_checks_the_workflow_result_counters(self, tmp_path):
+        """WorkflowResult computes its counts from the file, so agreement here
+        also pins that lazy computation."""
+        result, _ = _good_output(tmp_path)
+        assert_pipeline_output(result, formula_by_id=FORMULAS, k=1)
+        assert result.n_molecules == 3
+        assert result.n_conformers == 3
+
+
+# ---------------------------------------------------------------------------
+# assert_opt_geometry_output
+# ---------------------------------------------------------------------------
+
+def _optimized_da(tmp_path, *, factor=1.05, name="DA_opt.sdf"):
+    """Inputs perturbed off their minimum, plus a plausible 'optimized' result."""
+    originals = read_sdf_records(FILES / "DA.sdf")
+    inputs = [expanded_copy(mol, factor) for mol in originals]
+    outputs = [_annotate_optimized(mol, mol.GetProp("_Name")) for mol in originals]
+    return _write_sdf(tmp_path / name, outputs), inputs
+
+
+class TestAssertOptGeometryOutput:
+    def test_accepts_a_real_relaxation(self, tmp_path):
+        path, inputs = _optimized_da(tmp_path)
+        records = assert_opt_geometry_output(
+            path, input_mols=inputs, moved_at_least=0.01
+        )
+        assert len(records) == 3
+
+    def test_rejects_a_path_that_was_never_written(self, tmp_path):
+        """The exact mutation the old tests swallowed: FileNotFoundError is an
+        OSError, and their cleanup caught OSError."""
+        _, inputs = _optimized_da(tmp_path)
+        with pytest.raises(AssertionError, match="no file exists"):
+            assert_opt_geometry_output(
+                str(tmp_path / "never.sdf"), input_mols=inputs, moved_at_least=0.01
+            )
+
+    def test_rejects_an_unmoved_geometry(self, tmp_path):
+        """Handing back the input unchanged must fail."""
+        originals = read_sdf_records(FILES / "DA.sdf")
+        outputs = [_annotate_optimized(mol, mol.GetProp("_Name")) for mol in originals]
+        path = _write_sdf(tmp_path / "noop.sdf", outputs)
+        with pytest.raises(AssertionError, match="moved no atom further"):
+            assert_opt_geometry_output(
+                path, input_mols=originals, moved_at_least=0.01
+            )
+
+    def test_rejects_a_dropped_record(self, tmp_path):
+        originals = read_sdf_records(FILES / "DA.sdf")
+        inputs = [expanded_copy(mol, 1.05) for mol in originals]
+        outputs = [_annotate_optimized(m, m.GetProp("_Name")) for m in originals[:2]]
+        path = _write_sdf(tmp_path / "short.sdf", outputs)
+        with pytest.raises(AssertionError, match="returned 2 structures for 3"):
+            assert_opt_geometry_output(path, input_mols=inputs, moved_at_least=0.01)
+
+    def test_rejects_reordered_records(self, tmp_path):
+        originals = read_sdf_records(FILES / "DA.sdf")
+        inputs = [expanded_copy(mol, 1.05) for mol in originals]
+        outputs = [_annotate_optimized(m, m.GetProp("_Name")) for m in originals]
+        path = _write_sdf(tmp_path / "shuffled.sdf", list(reversed(outputs)))
+        with pytest.raises(AssertionError, match="does not line up with input"):
+            assert_opt_geometry_output(path, input_mols=inputs, moved_at_least=0.01)
+
+    @pytest.mark.parametrize(
+        ("prop", "match"),
+        [
+            ("Dropped_Oscillating", "lacks Dropped_Oscillating"),
+            ("Stereo_changed", "lacks Stereo_changed"),
+            # The energy check runs first and refuses this one on its own
+            # terms, which is the same verdict by a more specific route.
+            (E_TOT_HARTREE_PROP, "unit-labeled"),
+        ],
+    )
+    def test_rejects_output_missing_a_property_only_the_optimizer_writes(
+        self, tmp_path, prop, match
+    ):
+        """``DA.sdf`` already carries E_tot/fmax/Converged, so these three are
+        what tell a genuine run apart from the input file handed back."""
+        originals = read_sdf_records(FILES / "DA.sdf")
+        inputs = [expanded_copy(mol, 1.05) for mol in originals]
+        outputs = [_annotate_optimized(m, m.GetProp("_Name")) for m in originals]
+        for mol in outputs:
+            mol.ClearProp(prop)
+        path = _write_sdf(tmp_path / "stripped.sdf", outputs)
+        with pytest.raises(AssertionError, match=match):
+            assert_opt_geometry_output(path, input_mols=inputs, moved_at_least=0.01)
+
+    def test_rejects_a_changed_formula(self, tmp_path):
+        originals = read_sdf_records(FILES / "DA.sdf")
+        inputs = [expanded_copy(mol, 1.05) for mol in originals]
+        outputs = [_annotate_optimized(m, m.GetProp("_Name")) for m in originals]
+        outputs[0] = _annotate_optimized(_embedded("CCCCCCCC"), "diene")
+        path = _write_sdf(tmp_path / "swapped.sdf", outputs)
+        with pytest.raises(AssertionError, match="chemical identity changed"):
+            assert_opt_geometry_output(path, input_mols=inputs, moved_at_least=0.01)
+
+    def test_refuses_an_empty_input_list(self, tmp_path):
+        path, _ = _optimized_da(tmp_path)
+        with pytest.raises(AssertionError, match="no input molecules"):
+            assert_opt_geometry_output(path, input_mols=[], moved_at_least=0.01)
+
+    def test_rejects_a_non_finite_fmax(self, tmp_path):
+        originals = read_sdf_records(FILES / "DA.sdf")
+        inputs = [expanded_copy(mol, 1.05) for mol in originals]
+        outputs = [_annotate_optimized(m, m.GetProp("_Name")) for m in originals]
+        outputs[1].SetProp("fmax", "nan")
+        path = _write_sdf(tmp_path / "badfmax.sdf", outputs)
+        with pytest.raises(AssertionError, match="not a force magnitude"):
+            assert_opt_geometry_output(path, input_mols=inputs, moved_at_least=0.01)
+
+
+def test_formula_helper_agrees_with_rdkit_directly():
+    """Guard against the helper quietly becoming a no-op wrapper."""
+    mol = _embedded("CC(CCCl)=O")
+    assert molecular_formula(mol) == CalcMolFormula(mol)
+    assert math.isfinite(self_energy_estimate_hartree(mol))

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -9,6 +9,10 @@ import Auto3D
 from Auto3D.ASE.geometry import opt_geometry
 from Auto3D.ASE.thermo import model_name2model_calculator, vib_hessian
 from Auto3D.ASE.thermo import calc_thermo
+from tests.helpers_pipeline_output import (
+    assert_opt_geometry_output,
+    write_perturbed_sdf,
+)
 
 # Mark all tests in this module as slow (thermodynamic calculations)
 pytestmark = pytest.mark.slow
@@ -164,6 +168,13 @@ def test_model_name2model_calculator_uses_factory():
             # Verify EnForce_ANI was created with the adapter
             mock_enforce.assert_called_once_with(mock_adapter)
 
+            # ...and that the factory's adapter is what actually comes back,
+            # rather than something constructed internally. Asserting only on
+            # the mock call records proves the factory ran, not that its result
+            # was used.
+            assert model_adapter is mock_adapter
+            assert calc is not None
+
 
 def test_calc_thermo_aimnet():
     #load wB97m-D4/Def2-TZVPP output file
@@ -256,29 +267,52 @@ def test_vib_hessian_includes_external_dispersion():
     # 2. Including the attractive D3 term must SOFTEN, not stiffen, the bonds.
     assert fixed_max < bare_max
 
-def test_opt_geometry1():
-    path = os.path.join(folder, "tests/files/DA.sdf")
+#: Uniform expansion applied to the DA.sdf geometries before they are handed
+#: to ``opt_geometry`` below. ``tests/files/DA.sdf`` is *already* a relaxed
+#: structure (its stored fmax is 0.0028 eV/A, far below the 0.1 eV/A tolerance
+#: these tests use), so optimizing it unchanged is entitled to move nothing and
+#: "the geometry changed" would not be assertable. A 5% expansion about each
+#: molecule's own centroid stretches every bond by ~0.07 A -- restoring forces
+#: of order 1 eV/A, an order of magnitude above the tolerance -- so the
+#: optimizer cannot converge without pulling the atoms back. Measured
+#: displacement of the perturbation itself is 0.05-0.17 A per atom; the 0.01 A
+#: floor asserted afterwards therefore has several times its own margin.
+DA_EXPANSION = 1.05
+DA_MIN_RELAXATION = 0.01
+
+
+def _perturbed_DA(tmp_path) -> tuple[str, list]:
+    """Stage a displaced copy of DA.sdf in ``tmp_path``, ready to optimize.
+
+    Keeping the filename ``DA.sdf`` preserves ``opt_geometry``'s derived output
+    name (``DA_<model>_opt.sdf``, written beside its input) while moving it out
+    of ``tests/files/``, where these tests used to leave it behind whenever
+    they failed -- and where two of them wrote to the same path.
+    """
+    source = os.path.join(folder, "tests/files/DA.sdf")
+    return write_perturbed_sdf(source, tmp_path / "DA.sdf", DA_EXPANSION)
+
+
+def test_opt_geometry1(tmp_path):
+    """ANI2x relaxes a displaced geometry and annotates it correctly."""
+    path, inputs = _perturbed_DA(tmp_path)
     out = opt_geometry(path, 'ANI2x', opt_tol=0.1, opt_steps=5000, use_gpu=False)
-    try:
-        os.remove(out)
-    except OSError:
-        pass
+    assert_opt_geometry_output(out, input_mols=inputs,
+                               moved_at_least=DA_MIN_RELAXATION, label="ANI2x")
 
-def test_opt_geometry2():
-    path = os.path.join(folder, "tests/files/DA.sdf")
+def test_opt_geometry2(tmp_path):
+    """ANI2xt relaxes a displaced geometry and annotates it correctly."""
+    path, inputs = _perturbed_DA(tmp_path)
     out = opt_geometry(path, 'ANI2xt', opt_tol=0.1, opt_steps=5000, use_gpu=False)
-    try:
-        os.remove(out)
-    except OSError:
-        pass
+    assert_opt_geometry_output(out, input_mols=inputs,
+                               moved_at_least=DA_MIN_RELAXATION, label="ANI2xt")
 
-def test_opt_geometry3():
-    path = os.path.join(folder, "tests/files/DA.sdf")
+def test_opt_geometry3(tmp_path):
+    """AIMNet2 relaxes a displaced geometry and annotates it correctly."""
+    path, inputs = _perturbed_DA(tmp_path)
     out = opt_geometry(path, 'AIMNET', opt_tol=0.1, opt_steps=5000, use_gpu=False)
-    try:
-        os.remove(out)
-    except OSError:
-        pass
+    assert_opt_geometry_output(out, input_mols=inputs,
+                               moved_at_least=DA_MIN_RELAXATION, label="AIMNET")
 
 
 def test_opt_geometry_with_patience_and_batchsize():
@@ -300,33 +334,33 @@ def test_opt_geometry_with_patience_and_batchsize():
         pass
 
 @pytest.mark.skipif(not test_userNNP1, reason="TorchANI is not  installed.")
-def test_opt_geometry4():
-    path = os.path.join(folder, "tests/files/DA.sdf")
+def test_opt_geometry4(tmp_path):
+    """A scripted custom NNP relaxes a displaced geometry through opt_geometry."""
+    path, inputs = _perturbed_DA(tmp_path)
     with tempfile.TemporaryDirectory() as tmpdir:
         model_path = os.path.join(tmpdir, 'myNNP.pt')
         myNNP = userNNP1()
         myNNP_jit = torch.jit.script(myNNP)
         myNNP_jit.save(model_path)
-    
-        out = opt_geometry(path, model_path, opt_tol=0.1, opt_steps=5000, use_gpu=False)
-    try:
-        os.remove(out)
-    except OSError:
-        pass
 
-def test_opt_geometry5():
-    path = os.path.join(folder, "tests/files/DA.sdf")
+        out = opt_geometry(path, model_path, opt_tol=0.1, opt_steps=5000, use_gpu=False)
+    assert_opt_geometry_output(out, input_mols=inputs,
+                               moved_at_least=DA_MIN_RELAXATION,
+                               label="scripted userNNP1")
+
+def test_opt_geometry5(tmp_path):
+    """An eager AIMNet2-backed custom NNP relaxes a displaced geometry."""
+    path, inputs = _perturbed_DA(tmp_path)
     with tempfile.TemporaryDirectory() as tmpdir:
         model_path = os.path.join(tmpdir, 'myNNP.pt')
         myNNP = userNNP2()
         # AIMNet2-based models are not torch.jit.script-able; save eager.
         torch.save(myNNP, model_path)
-    
+
         out = opt_geometry(path, model_path, opt_tol=0.1, opt_steps=5000, use_gpu=False)
-    try:
-        os.remove(out)
-    except OSError:
-        pass
+    assert_opt_geometry_output(out, input_mols=inputs,
+                               moved_at_least=DA_MIN_RELAXATION,
+                               label="eager userNNP2")
 
 
 @pytest.mark.skipif(not test_userNNP1, reason="TorchANI is not  installed.")


### PR DESCRIPTION
**24 of the 66 slow-marked tests contained no assertion at all.** They called `main()` or `opt_geometry()` and cleaned up. This makes them check something.

## Why this matters more than the count suggests

These are the only tests that exercise the real neural network potentials — everything else stubs the model — and they cost ~8 minutes of CI per run. Mutation-verified before this change:

- Making `opt_geometry` a no-op that returns a path it never wrote left `test_opt_geometry1/2/3` **green**. `FileNotFoundError` is a subclass of the `OSError` their cleanup swallowed.
- Emitting the *unoptimized* embedded geometry with an arbitrary `E_tot` left all nineteen `test_auto3D.py` tests **green**.

Their names claimed engine-combination coverage (`test_auto3D_rdkit_ani2xt`, `test_auto3D_sdf_omega_aimnet`); their docstrings honestly said "check that the program runs". Only `_finalize_output`'s zero-output guard stood between them and total silence.

"The slow NNP tier passed" was cited as evidence of correctness on several merges during the recent remediation. It was evidence the pipeline does not raise.

## What they assert now

A shared `assert_pipeline_output` helper — 24 assertions, taking what varies (expected molecules and formulas, which selector was used) as explicit arguments rather than inferring it:

- output exists, is non-empty, parses as SDF
- every input molecule is accounted for — present in the output or named in the failure list, using the reconciliation data that already existed
- conformer counts match the request
- **the geometry actually changed** from the input embedding — this is the check that kills the no-op mutation
- energies present, finite, in Hartree, and physically plausible
- molecular formula preserved in to out

The helper **refuses an empty expectation map**, so a caller cannot make every check below it vacuous — the exact shape that produced this problem.

## Assertions deliberately not added

Two, both because they could fail on *correct* code:

- **Geometry change on `DA.sdf` as shipped.** Its stored `fmax` is 0.0028 eV/Å against a 0.1 eV/Å tolerance, so a correct optimizer is entitled to move nothing. The `opt_geometry` tests now optimize a deterministic 5% expansion instead, restoring forces ~10× the tolerance — which also moved their outputs out of `tests/files/`, where two of them shared a path.
- **That all N inputs succeed.** The reconciliation invariant covers molecule loss without depending on convergence luck.

## Testing

**1146 passed, 10 skipped, 0 xfailed** — identical across plain, `CUDA_VISIBLE_DEVICES=""` and `FORCE_COLOR=1`. The +85 are hermetic unit tests for the helper itself (RDKit/numpy only), so its logic is verified in the fast tier even though its callers can only run in CI.

Assertion-free slow tests: **24 → 0**, measured interprocedurally. A naive intra-procedural scan is wrong in both directions here — it misses `mock.assert_*` and cannot see assertions delegated to the shared helper.

Slow collection: 66 → 67.

## Known limits

- **None of these assertions has ever executed.** CI's slow job is their first run.
- 11 of the 26 reworked tests do not run in CI either — 6 need `OE_LICENSE`, 5 need CUDA — so the omega naming path in particular remains unvalidated.
