### PR TITLE
Stop four silent fallbacks from changing the answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -581,6 +581,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tolerance keep their documented eV meaning and no public parameter changed
   units.
 
+- **Conformer names always carry `<isomer>_<conformer>`, in every mode.**
+  The SMILES path with `enumerate_isomer=False` used to append only the
+  conformer index, so a conformer's `ID` read `<species>_<conformer>` there
+  and `<species>_<isomer>_<conformer>` everywhere else.
+  `Auto3D.ranking.species_id` strips two trailing components, which made
+  `KEY_2_0` ambiguous -- species `KEY_2` conformer 0, or species `KEY` isomer
+  2 conformer 0? -- and `smiles2smi` mints exactly ids like `KEY_2`, for the
+  **second of two different molecules that share a standard InChIKey**
+  (a tautomer pair the standard key conflates, or the same molecule written
+  two ways). Both then grouped as one species: `k=1` returned a single
+  conformer for the pair, and because selection is by energy across the
+  merged group, the survivor could be the other molecule's geometry carrying
+  this molecule's name. `smiles2mols` returned a silently shorter list.
+
+  **What changes:** with `enumerate_isomer=False` and SMILES input, the `ID`
+  property of an output record gains one component --  `mol_3` becomes
+  `mol_0_3` (the isomer index is always 0 in that mode, since there is
+  exactly one "isomer": the molecule as written). The record's `_Name` (the
+  species id) is unchanged, as is every other mode and both SDF-input paths.
+  **What to do:** a script that parses `ID` with `split("_")` should read the
+  first component for the species id and the last for the conformer index, or
+  use `Auto3D.ranking.species_id`. Runs made with `enumerate_isomer=False`
+  and two inputs sharing an InChIKey lost a molecule and should be re-run.
+
 ### Added
 
 - **`auto3d validate` accepts `--json`**, the one result-producing command
@@ -602,6 +626,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The Rich error panel is unchanged and still goes to stderr.
 
 ### Fixed
+
+- **`calc_thermo` no longer runs one call on two devices at two precisions.**
+  For a custom NNP holding no `nn.Parameter` (one that builds its backend
+  lazily), `ASE/thermo.Calculator.__init__` had no parameter to read a device
+  off and chose
+  `torch.device("cuda" if torch.cuda.is_available() else "cpu")` with
+  `torch.double`. `use_gpu` and `gpu_idx` never reached it, so
+  `calc_thermo(..., use_gpu=False)` -- or `auto3d thermo ... --no-gpu` --
+  relaxed the geometry on **cuda:0 in float64** while the fmax pre-check and
+  the Hessian ran on **cpu in float32**: a GPU seized on a shared box against
+  an explicit `--no-gpu`, `gpu_idx` ignored entirely (always device 0), and a
+  Hessian built at a different precision from the geometry it describes.
+  Nothing was logged. `calc_thermo` now threads the device it already
+  resolved through `check_gpu_requested` + `get_device(gpu_idx, use_gpu)` --
+  Auto3D's single GPU policy -- into the calculator, and a `Calculator`
+  constructed with neither a device nor a parameter to infer one from stays
+  on CPU/float32 instead of taking a GPU nobody asked for.
+
+- **Auto3D no longer turns off a caller's deterministic algorithms.**
+  Every entry point calls `configure_torch`, which wrote
+  `torch.use_deterministic_algorithms(False)`,
+  `torch.backends.cudnn.deterministic = False` and
+  `torch.backends.cudnn.benchmark = False` unconditionally -- process-global
+  state. A script that called `torch.use_deterministic_algorithms(True)` for
+  reproducibility lost it for the rest of the process the moment it called
+  Auto3D, with nothing logged and no way to ask for it back; the next
+  nondeterministic op then silently produced a nondeterministic result
+  instead of raising, which is precisely the signal that setting exists to
+  obtain. `TorchConfig.deterministic` and `TorchConfig.cudnn_benchmark` now
+  default to `None`, meaning "leave the process's setting alone"; an explicit
+  `True`/`False` is still applied in both directions. `allow_tf32` keeps
+  being applied unconditionally -- it is a real Auto3D option with a
+  documented default. New `TorchConfig.deterministic_warn_only` (default
+  `True`, as before) lets a caller ask for `use_deterministic_algorithms` to
+  raise rather than warn.
+
+- **A conformer with no `Converged` property is no longer deleted.** The
+  three convergence filters (`ConformerRanker`,
+  `filtering.filter_unique_optimized`, `utils.chemistry.filter_unique`) read
+  the property inside `try/except KeyError` and treated its absence as
+  "did not converge". Only `batch_opt` writes that property, so the public
+  `ConformerRanker` -- pointed at an `opt_geometry` output, an ORCA/Gaussian
+  export or a hand-built conformer set -- dropped **every** record, returned
+  `[]`, wrote a **0-byte SDF** and exited 0. The only message was an INFO
+  line on a logger tree with no handler outside `main()`. Absence of the
+  property now means "not filtered on convergence" and the record is kept
+  (`Auto3D.utils.convergence` is the single owner of this property);
+  an explicit `Converged=false` is still dropped. Two related changes to
+  `ConformerRanker.run`: a record with no `E_tot` now raises
+  `InputValidationError` (exit 2) naming the record instead of emitting a
+  bare `KeyError` from inside RDKit, and selecting 0 structures from a
+  non-empty input now logs a **WARNING** -- which `logging.lastResort` puts
+  on stderr even for a caller who never configured logging -- instead of an
+  INFO nobody sees.
+
+- **The `userNNP2` example in the test suite padded species with 0.** Atomic
+  number 0 is a real element there (an R-group `*` atom), so the example's own
+  `mask = species != self.species_pad` deleted dummy atoms from the batch --
+  in code users copy. It now uses `-1`, matching
+  `docs/source/howto/custom_nnp.rst` and `pad_from_mols`' default.
 
 - **A charge change no longer reuses the previous molecule's energy and
   forces.** `ASE/thermo.py`'s `Calculator.set_charge` reassigned the charge

--- a/docs/source/migration-4.0.rst
+++ b/docs/source/migration-4.0.rst
@@ -113,6 +113,61 @@ was swallowed, and the molecule was reported as failed.
 Recompute any ANI2xt thermochemistry from 3.x. AIMNet2 and ANI2x results are
 unaffected.
 
+Two inputs that share an InChIKey, with ``enumerate_isomer=False``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Distinct inputs can share a standard InChIKey -- a tautomer pair the standard
+key conflates, or the same molecule written two ways. ``smiles2smi`` renames
+the second one ``<KEY>_2`` *specifically so it is not dropped*.
+
+With SMILES input and ``enumerate_isomer=False``, 3.x/4.0-pre named conformers
+``<species>_<conformer>`` -- one trailing component, where every other mode
+appends two (``<species>_<isomer>_<conformer>``).
+:func:`Auto3D.ranking.species_id` strips two, so ``KEY_0`` and ``KEY_2_0``
+both reduced to ``KEY``: the two molecules landed in one ranking group,
+``k=1`` returned a **single** conformer for the pair, and because selection is
+by energy across the merged group, the survivor could be the *other*
+molecule's geometry carrying this molecule's name. ``smiles2mols`` returned a
+silently shorter list; the only signal was a stderr WARNING from
+``find_smiles_not_in_sdf`` naming the missing id.
+
+**Re-run anything that used** ``enumerate_isomer=False`` **on a SMILES/`.smi`
+input containing two molecules with the same standard InChIKey.** Every other
+combination is unaffected: the SDF input paths and the isomer-enumerating
+SMILES path already appended both components.
+
+Conformer ``ID`` gains a component in that one mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The cure is the naming, not a cleverer parse: a parser that has to infer how
+many components were appended is the defect. Both SMILES modes now append the
+isomer index, which for ``enumerate_isomer=False`` is always 0 -- there is
+exactly one "isomer", the molecule as written.
+
+.. list-table::
+   :widths: 40 30 30
+   :header-rows: 1
+
+   * - Producer
+     - ``ID`` in 3.x / 4.0-pre
+     - ``ID`` in 4.0
+   * - SMILES input, ``enumerate_isomer=True``
+     - ``mol_1_3``
+     - ``mol_1_3`` (unchanged)
+   * - SMILES input, ``enumerate_isomer=False``
+     - ``mol_3``
+     - **``mol_0_3``**
+   * - SDF input, either setting
+     - ``mol_1_3``
+     - ``mol_1_3`` (unchanged)
+
+The record's ``_Name`` -- the species id ConformerRanker writes into the final
+output -- is unchanged in every case. Only the ``ID`` property, and the names
+inside the intermediate/``--verbose`` files, gain the component. A script that
+parses ``ID`` with ``split("_")`` should take the **first** component for the
+species id and the **last** for the conformer index, or call
+``Auto3D.ranking.species_id``.
+
 Custom NNPs that pad species with 0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -161,6 +216,25 @@ before optimization and can invert a center by the same mechanism: a
 conformer whose configuration changes there is discarded before optimization
 ever sees it, with a warning logged, instead of reaching the neural-network
 check already inverted and passing through unnoticed.
+
+``calc_thermo`` with a param-less custom NNP
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your custom NNP holds no ``nn.Parameter`` -- a buffer-only model, a
+closed-form potential, or one that builds its backend lazily on first call --
+3.x/4.0-pre had nothing to read a device off in the ASE calculator and chose
+``cuda`` whenever a GPU was visible, in ``float64``. ``use_gpu`` and
+``gpu_idx`` never reached that decision, so ``calc_thermo(..., use_gpu=False)``
+relaxed the geometry on **cuda:0 in float64** while the fmax pre-check and the
+Hessian ran on **cpu in float32** -- one call, two devices, two precisions,
+and ``gpu_idx`` ignored (always device 0). Nothing was logged.
+
+4.0 threads the device ``calc_thermo`` already resolved (through
+``check_gpu_requested`` and ``get_device(gpu_idx, use_gpu)``) into the
+calculator, and a param-less model defaults to CPU/float32 rather than taking
+a GPU nobody asked for. **Numbers change** for such a model: the relaxation
+now runs in float32, consistently with the Hessian built on it. Recompute if
+you relied on the float64 half.
 
 ``calc_thermo`` relaxes more, and further
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -448,6 +522,13 @@ error. ``model_name`` is now a required keyword-only argument on both.
    calc = Calculator(model, charge=0, model_name="ANI2xt")
    inp = mol2aimnet_input(mol, device, model_name="ANI2xt")
 
+``Calculator`` also accepts optional ``device`` and ``dtype`` keywords. Pass
+the device you resolved (Auto3D's own callers pass
+``get_device(gpu_idx, use_gpu)``) rather than letting the calculator infer
+one; a model with no ``nn.Parameter`` has nothing to infer from, and the
+inference used to take cuda:0 whenever a GPU was visible. Omitting both still
+reads them off the model's parameters, and falls back to CPU/float32.
+
 SDF input
 ~~~~~~~~~
 
@@ -474,6 +555,60 @@ conformers, not 24. A molecule with two independent unspecified centers (e.g.
 threonine) keeps two surviving diastereomers, so the same ``max_confs=12``
 does produce up to 24 there. A stereoisomer ETKDG cannot embed is now named in
 a logged warning instead of disappearing from the output with no trace.
+
+``ConformerRanker`` on a file Auto3D's optimizer did not write
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ConformerRanker`` (aliased ``Auto3D.ranking.ranking``) is public and
+documented, and only ``batch_opt`` writes the ``Converged`` SD property. The
+three convergence filters treated a missing ``Converged`` as "did not
+converge", so ranking an ``opt_geometry`` output, an ORCA/Gaussian export or a
+hand-built conformer set dropped **every** record: ``[]`` returned, a
+**0-byte** SDF written, exit 0, and the only message an INFO line on a logger
+tree with no handler outside ``main()``.
+
+A record that never claimed to be an optimizer output is not a record that
+failed one. A missing ``Converged`` now means "not filtered on convergence"
+and the record is kept; the connectivity, stereochemistry, RMSD and energy
+filters still apply to it, and an explicit ``Converged=false`` is still
+dropped. ``Auto3D.utils.convergence`` is the single owner of the property.
+
+Two related changes on the same path:
+
+- a record with no ``E_tot`` raises ``InputValidationError`` (exit 2) naming
+  the record, instead of a bare ``KeyError('E_tot')`` from inside RDKit --
+  ranking is selection by energy, and a record without one cannot be ranked;
+- selecting 0 structures from a non-empty input logs a **WARNING** naming the
+  input, the output and the count. ``logging.lastResort`` puts WARNING and
+  above on stderr even for a caller who never ran ``configure_logging``, which
+  is every direct API caller.
+
+Callers who *relied* on the old behavior to filter unconverged records must
+set ``Converged`` explicitly on their input.
+
+Determinism and cuDNN flags are left alone unless asked for
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``configure_torch`` -- called by ``main``, ``smiles2mols``, ``calc_spe``,
+``opt_geometry`` and ``calc_thermo`` on the way in -- wrote
+``torch.use_deterministic_algorithms(False)``,
+``torch.backends.cudnn.deterministic = False`` and
+``torch.backends.cudnn.benchmark = False`` unconditionally. Those are
+process-global settings the caller may own: a script that enabled determinism
+for reproducibility lost it for the rest of the process, silently.
+
+``TorchConfig.deterministic`` and ``TorchConfig.cudnn_benchmark`` are now
+``bool | None`` with a ``None`` default meaning "leave the process's setting
+alone". Passing ``True`` or ``False`` still applies it in both directions, so
+a run that enabled determinism can still restore fast mode.
+``TorchConfig.allow_tf32`` is unchanged and still applied unconditionally --
+it is a real Auto3D option with a documented default. The new
+``TorchConfig.deterministic_warn_only`` (default ``True``) lets a caller ask
+``use_deterministic_algorithms`` to raise rather than warn.
+
+If you construct ``TorchConfig`` yourself and relied on its defaults to
+*disable* determinism or cuDNN benchmarking, pass the value explicitly:
+``TorchConfig(allow_tf32=False, deterministic=False, cudnn_benchmark=False)``.
 
 Configuration and validation changes
 -------------------------------------

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -311,8 +311,31 @@ def _resolve_multiplicity(mol: Chem.Mol) -> int:
     return multiplicity
 
 
+def _devices_agree(a: torch.device, b: torch.device) -> bool:
+    """True when two devices name the same hardware.
+
+    ``torch.device("cuda")`` and ``torch.device("cuda:0")`` are different
+    objects but the same device, so an unindexed device compares equal to any
+    index of the same type. Used only to decide whether a mismatch is worth a
+    warning.
+    """
+    if a.type != b.type:
+        return False
+    if a.index is None or b.index is None:
+        return True
+    return a.index == b.index
+
+
 class Calculator(ase.calculators.calculator.Calculator):
     """ASE calculator interface for AIMNET and ANI2xt.
+
+    ``device`` and ``dtype`` are the caller's, not this class's to guess.
+    ``calc_thermo`` resolves the device once, through
+    ``check_gpu_requested`` + ``get_device(gpu_idx, use_gpu=...)`` -- Auto3D's
+    single GPU policy -- and threads the result here, so every tensor in a
+    ``calc_thermo`` call lives on the one device the user asked for. Omitting
+    both arguments reads them off the model's own parameters, and falls back
+    to CPU/float32 for a model that has none.
 
     The molecular charge is part of the calculator's own ASE state
     (``self.parameters['charge']``), not a bare attribute the caller mutates.
@@ -342,7 +365,7 @@ class Calculator(ase.calculators.calculator.Calculator):
     #: before the first assignment in ``__init__``.
     default_parameters = {'charge': 0}
 
-    def __init__(self, model, charge=0, *, model_name):
+    def __init__(self, model, charge=0, *, model_name, device=None, dtype=None):
         super().__init__()
         self.model = model
         # Engine name in Auto3D's own convention (e.g. 'ANI2xt'), used by
@@ -352,15 +375,40 @@ class Calculator(ase.calculators.calculator.Calculator):
         params = list(self.model.parameters())
         for p in params:
             p.requires_grad_(False)
-        if params:
-            self.device = params[0].device
-            self.dtype = params[0].dtype
+        param_device = params[0].device if params else None
+        param_dtype = params[0].dtype if params else None
+        if device is not None:
+            self.device = torch.device(device)
+            if param_device is not None and not _devices_agree(param_device, self.device):
+                logger.warning(
+                    "Calculator was asked for device %s but the model's "
+                    "parameters are on %s; the ASE-facing tensors follow the "
+                    "requested device.", self.device, param_device,
+                )
+        elif param_device is not None:
+            self.device = param_device
         else:
             # Param-less custom model (e.g. one that builds its NNP backend
-            # lazily): it handles device/dtype internally from the input tensors,
-            # so fall back to a sensible default for the ASE-facing tensors.
-            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-            self.dtype = torch.double
+            # lazily) and no device from the caller. CPU is the only answer
+            # that cannot violate Auto3D's GPU policy: this branch used to read
+            # torch.cuda.is_available() and seize cuda:0 even when the caller
+            # had asked for use_gpu=False, which check_gpu_requested/get_device
+            # had already resolved to CPU. That made one calc_thermo call run
+            # on two devices -- BFGS and the ASE energy on cuda:0, the fmax
+            # pre-check and the Hessian on cpu -- and ignored gpu_idx entirely
+            # (always device 0). Nothing was logged, so nobody could find out.
+            self.device = torch.device("cpu")
+        if dtype is not None:
+            self.dtype = dtype
+        elif param_dtype is not None:
+            self.dtype = param_dtype
+        else:
+            # float32, not float64: mol2aimnet_input, the charge tensor below,
+            # and every model adapter Auto3D ships are float32. Defaulting a
+            # param-less model to torch.double relaxed the geometry at one
+            # precision and built the Hessian on it at another, inside a single
+            # calc_thermo call.
+            self.dtype = torch.float32
         # Goes through the `charge` setter below, so `self.parameters['charge']`
         # and the tensor `calculate()` reads are populated from one place.
         self.charge = charge
@@ -451,7 +499,12 @@ def model_name2model_calculator(model_name: str, device=torch.device('cpu'), cha
 
     Args:
         model_name: Model name ('AIMNET', 'ANI2x', 'ANI2xt') or path to custom model.
-        device: Target device for the model.
+        device: Target device for the model. Threaded into the calculator as
+            well, so the ASE-facing tensors land on the same device as the
+            rest of the call rather than on whatever the calculator would
+            infer. A custom NNP with no parameters has no device to infer
+            from, and inferring one is how ``use_gpu=False`` used to end up
+            running on cuda:0.
         charge: Molecular charge for the calculator.
 
     Returns:
@@ -461,7 +514,7 @@ def model_name2model_calculator(model_name: str, device=torch.device('cpu'), cha
 
     # Wrap in EnForce_ANI for compatibility with existing code
     model = EnForce_ANI(model_adapter)
-    calculator = Calculator(model, charge, model_name=model_name)
+    calculator = Calculator(model, charge, model_name=model_name, device=device)
 
     return model_adapter, calculator
 

--- a/src/Auto3D/batch_opt/batchopt.py
+++ b/src/Auto3D/batch_opt/batchopt.py
@@ -40,6 +40,7 @@ from Auto3D.batch_opt.model_wrapper import EnForce_ANI
 from Auto3D.batch_opt.optimization_engine import n_steps, print_stats  # noqa: F401
 from Auto3D.constants import INITIAL_ENERGY_SENTINEL, INITIAL_FMAX_SENTINEL
 from Auto3D.model_factory import create_model
+from Auto3D.utils.convergence import set_converged
 from Auto3D.utils.energy import set_e_tot_from_ev
 from Auto3D.utils.stereo_check import apply_optimized_coords
 
@@ -342,7 +343,10 @@ class optimizing:
                 # fmax stays in eV/Angstrom (opt_tol's unit); it is a force, not
                 # an energy, and no consumer converts it.
                 mol.SetProp('fmax', str(fmaxs[i]))
-                mol.SetProp('Converged', str(convergence_i))
+                # Routed through the single owner of this property so the
+                # writer and the three filters that read it cannot drift
+                # (Auto3D.utils.convergence).
+                set_converged(mol, convergence_i)
                 # Mark structures dropped due to oscillation for diagnostics
                 is_oscillating = converged_i and osc_count_i >= patience
                 mol.SetProp('Dropped_Oscillating', str(is_oscillating))

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -11,6 +11,7 @@ from Auto3D.constants import (
     DEFAULT_RMSD_THRESHOLD,
 )
 from Auto3D.utils import check_connectivity
+from Auto3D.utils.convergence import converged_or_unfiltered
 from Auto3D.utils.energy import e_tot_ev, try_e_tot_ev
 from Auto3D.utils.stereo_check import stereo_preserved
 
@@ -32,8 +33,11 @@ def filter_unique_optimized(
     much smaller than n for molecules with diverse energies.
 
     Args:
-        mols: List of RDKit Mol objects with 'E_tot' (Hartree) and 'Converged'
-            properties. Records marked 'Stereo_changed' are excluded.
+        mols: List of RDKit Mol objects with 'E_tot' (Hartree) and, optionally,
+            'Converged' properties. A record whose 'Converged' property is
+            explicitly false is dropped; a record without the property is kept
+            (it is not filtered on convergence). Records marked
+            'Stereo_changed' are excluded.
         rmsd_threshold: RMSD threshold for considering structures similar (Angstrom).
         energy_cluster_window: Energy window for clustering (eV). Unchanged:
             the stored Hartree energies are converted to eV on read
@@ -43,16 +47,19 @@ def filter_unique_optimized(
     Returns:
         List of unique molecules, sorted by energy (lowest first).
     """
-    # Filter converged structures with valid connectivity
+    # Filter converged structures with valid connectivity. A record with no
+    # 'Converged' property is not filtered on convergence (see
+    # Auto3D.utils.convergence): treating its absence as failure deleted every
+    # record of any SDF batchopt did not write.
     valid_mols = []
     for mol in mols:
         if mol is None:
             continue
-        try:
-            converged = mol.GetProp('Converged').lower() == 'true'
-        except KeyError:
-            converged = False
-        if converged and stereo_preserved(mol) and check_connectivity(mol):
+        if (
+            converged_or_unfiltered(mol)
+            and stereo_preserved(mol)
+            and check_connectivity(mol)
+        ):
             valid_mols.append(mol)
 
     if not valid_mols:

--- a/src/Auto3D/isomer_engine.py
+++ b/src/Auto3D/isomer_engine.py
@@ -246,6 +246,26 @@ class RDKitIsomer:
                     line = isomer.strip() + '\t' + new_name + '\n'
                     f.write(line)
 
+    def write_single_isomer_smi(self) -> None:
+        """Copy the input .smi through, appending the isomer index 0 to each id.
+
+        The no-enumeration counterpart of :meth:`write_enumerated_smi`: this
+        branch produces exactly one "isomer" per input -- the molecule as the
+        user wrote it -- so its index is always 0. Writing it keeps the two
+        branches' output shape identical, which is what makes a conformer name
+        parseable at all (see :func:`Auto3D.ranking.species_id`).
+
+        Streams records instead of going through :meth:`read` so duplicate ids
+        still reach ``hash_enumerated_smi_IDs`` (which renames them) exactly as
+        they did when this branch handed it the input file directly; ``read()``
+        returns a dict and would collapse them into one.
+        """
+        with open(self.enumerated_smi_path, 'w+') as f:
+            for _line_no, smi, name in iter_smi_records(
+                self.input_f, on_malformed="skip"
+            ):
+                f.write(f"{smi.strip()}\t{str(name).strip()}_0\n")
+
     def embed_conformer(self, smi: str) -> Chem.Mol | None:
         """Embed multiple 3D conformers for a SMILES string.
 
@@ -301,7 +321,21 @@ class RDKitIsomer:
             hash_enumerated_smi_IDs(self.enumerated_smi_path_reduced,
                                     self.enumerated_smi_hashed_path)
         else:
-            hash_enumerated_smi_IDs(self.input_f,
+            # No stereoisomer enumeration -- but the conformer names must still
+            # carry BOTH trailing components, or they cannot be parsed back.
+            # Emitting only "<species>_<conformer>" here made "KEY_2_0"
+            # ambiguous: species "KEY_2" conformer 0 (this branch) or species
+            # "KEY" isomer 2 conformer 0 (the branch above)?
+            # `smiles2smi` mints exactly ids like "KEY_2" -- for the SECOND of
+            # two DIFFERENT input molecules that share a standard InChIKey --
+            # so that neither is dropped. `ranking.species_id` then grouped
+            # both under "KEY", and `k=1` returned a single conformer for the
+            # pair, possibly the other molecule's geometry under this
+            # molecule's name. Writing the isomer index makes the parse
+            # unambiguous instead of asking the parser to guess which branch
+            # produced the name.
+            self.write_single_isomer_smi()
+            hash_enumerated_smi_IDs(self.enumerated_smi_path,
                                     self.enumerated_smi_hashed_path)
 
         logger.info("Enumerating conformers/rotamers, removing duplicates...")
@@ -386,9 +420,9 @@ class RDKitSdfIsomer:
     ``remove_enantiomers`` -- since mirror images are exactly degenerate under
     any reflection-invariant potential. Conformers are named
     ``<name>_<isomer>_<conformer>`` uniformly, including when there is only one
-    isomer, so this path's own output has one consistent shape to parse (the
-    SMILES path is not identical: with ``enumerate_isomers`` disabled there it
-    emits only two components). The isomer component is what
+    isomer, so this path's own output has one consistent shape to parse -- the
+    same shape the SMILES path emits, with or without ``enumerate_isomers``.
+    The isomer component is what
     :func:`Auto3D.utils.file_ops.decode_ids` relies on to rebuild
     ``<original>_<isomer>_<conformer>`` IDs after the pipeline's numeric-ID
     encoding step; :class:`~Auto3D.ranking.ConformerRanker` groups on the

--- a/src/Auto3D/ranking.py
+++ b/src/Auto3D/ranking.py
@@ -6,10 +6,11 @@ import pandas as pd
 from rdkit import Chem
 
 from Auto3D.config import SELECTOR_FIELDS, check_selectors_mutually_exclusive
-from Auto3D.exceptions import ConfigurationError
+from Auto3D.exceptions import ConfigurationError, InputValidationError
 from Auto3D.filtering import filter_unique_optimized
 from Auto3D.utils import ev2kcalpermol, filter_unique
 from Auto3D.utils.chemistry import check_connectivity
+from Auto3D.utils.convergence import converged_or_unfiltered, has_convergence_flag
 from Auto3D.utils.energy import E_TOT_HARTREE_PROP, E_TOT_PROP, e_tot_ev
 from Auto3D.utils.logging_config import get_logger
 from Auto3D.utils.stereo_check import stereo_preserved
@@ -22,12 +23,13 @@ def species_id(name: str) -> str:
     """Recover the species id from a conformer's ``_Name``.
 
     Conformer names are ``<species_id>_<isomer>_<conformer>``: two trailing
-    integer components appended after the id every caller of this module
-    actually feeds it -- the SDF input path always (RDKitSdfIsomer names
-    "uniformly, including when there is only one isomer" per its docstring),
-    and the SMILES path (RDKitIsomer) with the default ``enumerate_isomer``
-    enabled (isomer index from ``write_enumerated_smi``, conformer index from
-    ``embed_conformer``).
+    integer components appended after the id by every producer, in every
+    mode. The SDF input path (RDKitSdfIsomer) names "uniformly, including
+    when there is only one isomer" per its docstring; the SMILES path
+    (RDKitIsomer) takes the isomer index from ``write_enumerated_smi`` when
+    ``enumerate_isomer`` is on and from ``write_single_isomer_smi`` (always
+    0 -- one "isomer", the molecule as written) when it is off. The
+    conformer index comes from ``embed_conformer`` either way.
 
     Stripping on the FIRST underscore is wrong whenever ``species_id`` itself
     contains an underscore -- notably ``smiles2smi``'s InChIKey-collision
@@ -38,15 +40,17 @@ def species_id(name: str) -> str:
     conformers of one species still group together AND a disambiguated id
     like ``KEY_2`` stays distinct from ``KEY``.
 
-    Known residual gap (pre-existing, not introduced here): the SMILES path
-    with ``enumerate_isomer=False`` appends only ONE trailing component (the
-    conformer index, no isomer index), so a disambiguated id there produces a
-    name indistinguishable in shape from the isomer-enabled case (e.g.
-    ``KEY_2_0`` could be species "KEY_2" conformer 0, or species "KEY" isomer
-    2 conformer 0) -- this function cannot tell them apart without knowing
-    which mode produced the name. An InChIKey collision combined with
-    ``enumerate_isomer=False`` still mis-groups, exactly as it did before this
-    fix; unlike the default path, this combination has no test pinning it.
+    That disambiguation is only recoverable because every producer appends
+    the same NUMBER of components. Until 4.0 the SMILES path with
+    ``enumerate_isomer=False`` appended only the conformer index, which made
+    ``KEY_2_0`` mean either species "KEY_2" conformer 0 or species "KEY"
+    isomer 2 conformer 0 -- indistinguishable here, so an InChIKey collision
+    in that mode merged two DIFFERENT input molecules into one ranking group
+    and ``k=1`` returned one conformer for the pair. The cure is the naming
+    (``RDKitIsomer.write_single_isomer_smi``), not a cleverer parse: a parser
+    that has to infer how many components were appended is the defect.
+    Pinned by ``tests/test_ranking.py`` and
+    ``tests/test_isomer_engine_hardening.py``.
     """
     return name.strip().rsplit("_", 2)[0].strip()
 
@@ -242,6 +246,10 @@ class ConformerRanker:
                 ConfigurationError -- this is the same guard, raising the
                 same exception type, for callers that construct
                 ConformerRanker directly).
+            InputValidationError: If a record carries no ``E_tot`` property.
+                Ranking is selection by energy; a record with no energy
+                cannot be ranked, and refusing the file beats emitting a
+                bare ``KeyError('E_tot')`` from inside RDKit.
         """
         logger.info("Begin to select structures that satisfy the requirements...")
         # Delegated to Auto3D.config rather than re-implemented here. This was
@@ -261,23 +269,54 @@ class ConformerRanker:
         results = []
 
         mols, names, energies = [], [], []
+        n_records = 0
+        n_unconverged = 0
+        n_unflagged = 0
         # Context-managed so the SDF file handle is released promptly rather than
         # left to GC. The mols are materialized into `mols` inside the block.
         with Chem.SDMolSupplier(self.input_path, removeHs=False) as supplier:
-            for mol in supplier:
+            for position, mol in enumerate(supplier):
                 if mol is None:
+                    logger.warning(
+                        "Skipping record %d of %s: RDKit could not parse it.",
+                        position, self.input_path,
+                    )
                     continue
-                # Guard the Converged read: a record lacking the property is
-                # treated as not-converged and skipped, matching the lenient
-                # pattern the RMSD filters use (filter_unique / filtering).
-                try:
-                    converged = mol.GetProp('Converged').lower() == 'true'
-                except KeyError:
-                    converged = False
-                if converged:
-                    mols.append(mol)
-                    names.append(species_id(mol.GetProp('_Name')))
-                    energies.append(e_tot_ev(mol))
+                n_records += 1
+                # Only an EXPLICIT Converged=false is a failed optimization.
+                # A record with no such property never claimed to be an
+                # optimizer output at all -- ConformerRanker is public, and
+                # any SDF batchopt did not write (opt_geometry output, an
+                # ORCA/Gaussian export, a hand-built conformer set) carries
+                # none -- and dropping those returned [], wrote a 0-byte file
+                # and exited 0. See Auto3D.utils.convergence.
+                if not converged_or_unfiltered(mol):
+                    n_unconverged += 1
+                    continue
+                if not has_convergence_flag(mol):
+                    n_unflagged += 1
+                if not mol.HasProp(E_TOT_PROP):
+                    name = mol.GetProp("_Name").strip() if mol.HasProp("_Name") else ""
+                    raise InputValidationError(
+                        f"Record {position} "
+                        f"{'(' + name + ') ' if name else ''}of "
+                        f"{self.input_path} has no {E_TOT_PROP!r} property. "
+                        "ConformerRanker selects by energy, so every record "
+                        "needs one.",
+                        hint=(
+                            f"Add {E_TOT_PROP!r} (Hartree) to every record, or "
+                            "rank a file produced by Auto3D's optimizer."
+                        ),
+                    )
+                mols.append(mol)
+                names.append(species_id(mol.GetProp('_Name')))
+                energies.append(e_tot_ev(mol))
+        if n_unflagged:
+            logger.info(
+                "%d of %d record(s) in %s carry no 'Converged' property; they "
+                "are not filtered on convergence.",
+                n_unflagged, n_records, self.input_path,
+            )
 
         df = pd.DataFrame({"names": names, "energies": energies, "mols": mols})
         groups = df.groupby("names")
@@ -293,6 +332,19 @@ class ConformerRanker:
                                     'specified. Append "--k=1" if you'
                                     'only want one structure per SMILES')
             results += top_results
+
+        if n_records and not results:
+            # A non-empty input that selects nothing writes a 0-byte SDF and
+            # returns []. WARNING, not INFO: `logging.lastResort` puts WARNING
+            # and above on stderr even for a caller who never ran
+            # configure_logging, which is every direct API caller.
+            logger.warning(
+                "Selected 0 structures from %d record(s) in %s, so %s is "
+                "empty: %d record(s) are marked Converged=false and the rest "
+                "were dropped by the connectivity, stereochemistry or "
+                "energy-window filters.",
+                n_records, self.input_path, self.out_path, n_unconverged,
+            )
 
         with Chem.SDWriter(self.out_path) as f:
             for mol in results:

--- a/src/Auto3D/torch_config.py
+++ b/src/Auto3D/torch_config.py
@@ -5,6 +5,20 @@ This module provides a centralized way to configure PyTorch backend settings
 like TF32 precision and cuDNN benchmark mode. The settings are applied
 globally to the PyTorch backends.
 
+**These settings are process-global state the caller may already own.** Every
+Auto3D entry point (``main``, ``smiles2mols``, ``calc_spe``, ``opt_geometry``,
+``calc_thermo``) calls :func:`configure_torch` on the way in, so anything this
+module writes unconditionally is written into *the caller's* process and stays
+that way after Auto3D returns. Only ``allow_tf32`` is written unconditionally,
+because it is a real Auto3D option with a documented default
+(``Auto3DOptions.allow_tf32``, ``--allow-tf32``) that the user chose by
+choosing Auto3D's default. ``cudnn_benchmark`` and ``deterministic`` have no
+Auto3D-level option, so they default to ``None`` = "leave the process's
+setting exactly as it was". A script that calls
+``torch.use_deterministic_algorithms(True)`` before Auto3D keeps determinism
+afterwards; before this, Auto3D turned it off silently and offered no way to
+ask for it back.
+
 Example:
     >>> from Auto3D.torch_config import TorchConfig, configure_torch
     >>> config = TorchConfig(allow_tf32=True)
@@ -29,13 +43,30 @@ class TorchConfig:
                    Default False for maximum precision in scientific computing.
                    TF32 provides ~3x speedup on Ampere GPUs with slightly reduced
                    precision (10-bit mantissa vs 23-bit for FP32).
-        cudnn_benchmark: Enable cuDNN autotuner for potential speedups.
-                        When True, cuDNN will benchmark multiple convolution
-                        algorithms and select the fastest. Best for fixed-size
-                        inputs. Default False.
-        deterministic: Enable deterministic algorithms. When True, operations will
-                      use deterministic implementations (may be slower). Required
-                      for full reproducibility. Default False.
+                   **Always applied**, in both directions: it is a documented
+                   Auto3D option and False is the answer Auto3D's default gives.
+        cudnn_benchmark: Enable the cuDNN autotuner. When True, cuDNN benchmarks
+                        multiple convolution algorithms and selects the fastest;
+                        best for fixed-size inputs. ``None`` (the default) leaves
+                        ``torch.backends.cudnn.benchmark`` exactly as the calling
+                        process set it.
+        deterministic: Enable deterministic algorithms. ``True`` requests them,
+                      ``False`` explicitly turns them off (so a run that enabled
+                      them can restore fast mode), and ``None`` -- the default --
+                      leaves both ``torch.use_deterministic_algorithms`` and
+                      ``torch.backends.cudnn.deterministic`` untouched. Auto3D
+                      itself never requests either value, so an entry point that
+                      builds ``TorchConfig(allow_tf32=...)`` cannot disturb a
+                      caller who configured determinism for reproducibility.
+        deterministic_warn_only: The ``warn_only`` flag handed to
+                      ``torch.use_deterministic_algorithms`` when
+                      ``deterministic`` is not None. Defaults to True because
+                      AIMNet2/ANI scatter and masked index-put ops have no
+                      deterministic CUDA kernel and would otherwise raise, which
+                      aborts the very optimization loop determinism is meant to
+                      make reproducible. Pass False to have PyTorch raise on a
+                      nondeterministic op instead -- the request is then honored
+                      rather than downgraded to a warning.
         random_seed: Random seed for reproducibility. When set, seeds PyTorch,
                     CUDA, and NumPy RNGs. Default None (no seeding).
 
@@ -49,8 +80,9 @@ class TorchConfig:
     """
 
     allow_tf32: bool = False
-    cudnn_benchmark: bool = False
-    deterministic: bool = False
+    cudnn_benchmark: bool | None = None
+    deterministic: bool | None = None
+    deterministic_warn_only: bool = True
     random_seed: int | None = None
 
 
@@ -61,9 +93,14 @@ def configure_torch(config: TorchConfig | None = None) -> None:
     provided configuration. It should be called early in the application
     lifecycle, before any GPU computations are performed.
 
+    Only what the config actually asks for is written: fields left at ``None``
+    (``cudnn_benchmark``, ``deterministic``) leave the corresponding
+    process-global flag alone. See the module docstring for why.
+
     Args:
         config: Configuration object. If None, uses default TorchConfig
-                which disables TF32 for maximum precision.
+                which disables TF32 for maximum precision and touches
+                nothing else.
 
     Example:
         >>> from Auto3D.torch_config import TorchConfig, configure_torch
@@ -93,7 +130,8 @@ def configure_torch(config: TorchConfig | None = None) -> None:
         torch.backends.cuda.matmul.fp32_precision = fp32_mode
     if hasattr(torch.backends.cudnn, "fp32_precision"):
         torch.backends.cudnn.fp32_precision = fp32_mode
-    torch.backends.cudnn.benchmark = config.cudnn_benchmark
+    if config.cudnn_benchmark is not None:
+        torch.backends.cudnn.benchmark = config.cudnn_benchmark
 
     # Reproducibility settings
     if config.random_seed is not None:
@@ -104,14 +142,16 @@ def configure_torch(config: TorchConfig | None = None) -> None:
         import numpy as np
         np.random.seed(config.random_seed)
 
-    # Set deterministic flags unconditionally so a later configure_torch() with
-    # deterministic=False actually turns determinism back off (previously these
-    # were only ever set to True, making them write-once-sticky). warn_only=True
-    # so AIMNet2/ANI scatter / masked index-put ops -- which have no
-    # deterministic CUDA kernel -- warn instead of raising and aborting the very
-    # optimization loop deterministic mode is meant to make reproducible.
-    torch.use_deterministic_algorithms(config.deterministic, warn_only=True)
-    torch.backends.cudnn.deterministic = config.deterministic
+    # Written only when the caller says which way they want it. An explicit
+    # False still turns determinism back off (these flags used to be
+    # write-once-sticky, so a process that enabled a reproducible run could
+    # never restore fast mode), but the default None no longer reaches in and
+    # disables determinism the caller set for their own reasons.
+    if config.deterministic is not None:
+        torch.use_deterministic_algorithms(
+            config.deterministic, warn_only=config.deterministic_warn_only
+        )
+        torch.backends.cudnn.deterministic = config.deterministic
 
 
 # Note: We intentionally do NOT apply any default configuration on module import.

--- a/src/Auto3D/utils/__init__.py
+++ b/src/Auto3D/utils/__init__.py
@@ -2,6 +2,7 @@
 
 This package contains utility functions split into focused modules:
 - chemistry: Energy conversions, molecular properties, geometry utilities
+- convergence: The single owner of the 'Converged' SDF property
 - stereochemistry: Functions for stereochemistry detection and manipulation
 - validation: Functions for input validation and filtering
 - file_ops: File I/O operations (SMILES files, SDF chunking, ID encoding)

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -28,6 +28,7 @@ from Auto3D.constants import (
     MAX_CONFORMERS_CAP,
     MIN_ATOM_DISTANCE,
 )
+from Auto3D.utils.convergence import converged_or_unfiltered
 from Auto3D.utils.energy import try_e_tot_ev
 from Auto3D.utils.stereo_check import stereo_descriptors_from_3d, stereo_preserved
 
@@ -485,8 +486,10 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
     then removes similar structures based on RMSD comparison.
 
     Args:
-        mols: List of RDKit molecule objects with 'Converged' property set.
-            Records marked 'Stereo_changed' are excluded.
+        mols: List of RDKit molecule objects, optionally carrying a 'Converged'
+            property. A record whose 'Converged' is explicitly false is
+            dropped; a record without the property is kept (not filtered on
+            convergence). Records marked 'Stereo_changed' are excluded.
         crit: RMSD threshold for considering two structures as identical.
             Structures with RMSD below this value are considered duplicates.
             Defaults to DEFAULT_RMSD_THRESHOLD (0.3 Angstroms).
@@ -505,13 +508,12 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
         >>> filter_unique([mol], crit=0.3)  # Returns list with 1 molecule
         [...]
     """
-    # Remove unconverged structures
+    # Remove structures that explicitly failed to converge. A record with no
+    # 'Converged' property is NOT filtered on convergence -- see
+    # Auto3D.utils.convergence for why absence is not failure.
     mols_: list[Chem.Mol] = []
     for mol in mols:
-        try:
-            convergence_flag = mol.GetProp("Converged").lower() == "true"
-        except KeyError:
-            convergence_flag = False
+        convergence_flag = converged_or_unfiltered(mol)
         has_valid_bonds = check_connectivity(mol)
         if convergence_flag and has_valid_bonds and stereo_preserved(mol):
             mols_.append(mol)

--- a/src/Auto3D/utils/convergence.py
+++ b/src/Auto3D/utils/convergence.py
@@ -1,0 +1,72 @@
+# src/Auto3D/utils/convergence.py
+"""The one place that knows what the ``Converged`` SDF property means.
+
+``Converged`` is written by :mod:`Auto3D.batch_opt.batchopt` for every record
+it optimizes -- ``"True"`` or ``"False"`` -- and read by the three filters that
+decide which conformers survive (:class:`Auto3D.ranking.ConformerRanker`,
+:func:`Auto3D.filtering.filter_unique_optimized`,
+:func:`Auto3D.utils.chemistry.filter_unique`).
+
+All three used to read it as::
+
+    try:
+        converged = mol.GetProp('Converged').lower() == 'true'
+    except KeyError:
+        converged = False
+
+which silently deletes every record of any SDF **not** produced by
+``batchopt``: an ``opt_geometry`` output, an ORCA/Gaussian export, a
+hand-built conformer set. ``ConformerRanker`` is public and documented, so
+pointing it at such a file returned ``[]``, wrote a **0-byte** SDF, and exited
+0. The only message was an INFO line on a logger tree that has no handler
+outside ``main()``.
+
+A record that never claimed to be the output of an optimization is not a
+record that failed one. Absence of the property therefore means "not filtered
+on convergence" -- the record is kept, and the other filters (connectivity,
+stereochemistry, RMSD, energy) still apply to it. An **explicit**
+``Converged=False`` still means what it says and is still dropped.
+"""
+from __future__ import annotations
+
+from rdkit import Chem
+
+__all__ = [
+    "CONVERGED_PROP",
+    "set_converged",
+    "has_convergence_flag",
+    "converged_or_unfiltered",
+]
+
+#: Name of the SD property. ``"True"``/``"False"``, compared case-insensitively.
+CONVERGED_PROP = "Converged"
+
+
+def set_converged(mol: Chem.Mol, converged: bool) -> None:
+    """Record whether the optimizer converged on this record.
+
+    Args:
+        mol: Molecule to annotate, in place.
+        converged: Whether the optimizer reached its force criterion (and, in
+            ``batchopt``, was not dropped for oscillating).
+    """
+    mol.SetProp(CONVERGED_PROP, str(bool(converged)))
+
+
+def has_convergence_flag(mol: Chem.Mol) -> bool:
+    """True if the record carries a ``Converged`` property at all."""
+    return mol.HasProp(CONVERGED_PROP)
+
+
+def converged_or_unfiltered(mol: Chem.Mol) -> bool:
+    """Whether ``mol`` passes the convergence filter.
+
+    Returns:
+        False only when the record explicitly says it did not converge.
+        A record with no ``Converged`` property is not filtered on
+        convergence -- it never claimed to be an optimizer output, so there is
+        no failed optimization to filter it out for -- and passes.
+    """
+    if not mol.HasProp(CONVERGED_PROP):
+        return True
+    return mol.GetProp(CONVERGED_PROP).strip().lower() == "true"

--- a/tests/test_SPE.py
+++ b/tests/test_SPE.py
@@ -88,7 +88,12 @@ class userNNP2(torch.nn.Module):
         self._calc_device = None
 
         self.coord_pad = 0  # int, the padding value for coordinates
-        self.species_pad = 0  # int, the padding value for species.
+        # -1, NOT 0: atomic number 0 is a real element here (an R-group '*'
+        # atom), and the mask in forward() below is `species !=
+        # self.species_pad`, so a species_pad of 0 silently deletes every
+        # dummy atom from the batch -- a different molecule than the one
+        # submitted. Matches docs/source/howto/custom_nnp.rst.
+        self.species_pad = -1  # int, the padding value for species.
 
     def forward(self,
                 species: torch.Tensor,
@@ -115,7 +120,8 @@ class userNNP2(torch.nn.Module):
             self._calc = AIMNet2Calculator("aimnet2", device=str(species.device))
             self._calc_device = species.device
         # Auto3D feeds padded (B, N) batches; use ragged mol_idx batching to drop
-        # padded atoms (AIMNet2 yields NaN on species-0 padding otherwise).
+        # padded atoms (AIMNet2 has no element for a padding slot and yields
+        # NaN if one reaches it).
         b, n = species.shape
         mask = species != self.species_pad
         coord_flat = coords[mask]

--- a/tests/test_auto3D.py
+++ b/tests/test_auto3D.py
@@ -116,7 +116,12 @@ class userNNP2(torch.nn.Module):
         self._calc_device = None
 
         self.coord_pad = 0  # int, the padding value for coordinates
-        self.species_pad = 0  # int, the padding value for species.
+        # -1, NOT 0: atomic number 0 is a real element here (an R-group '*'
+        # atom), and the mask in forward() below is `species !=
+        # self.species_pad`, so a species_pad of 0 silently deletes every
+        # dummy atom from the batch -- a different molecule than the one
+        # submitted. Matches docs/source/howto/custom_nnp.rst.
+        self.species_pad = -1  # int, the padding value for species.
 
     def forward(self,
                 species: torch.Tensor,
@@ -143,7 +148,8 @@ class userNNP2(torch.nn.Module):
             self._calc = AIMNet2Calculator("aimnet2", device=str(species.device))
             self._calc_device = species.device
         # Auto3D feeds padded (B, N) batches; use ragged mol_idx batching to drop
-        # padded atoms (AIMNet2 yields NaN on species-0 padding otherwise).
+        # padded atoms (AIMNet2 has no element for a padding slot and yields
+        # NaN if one reaches it).
         b, n = species.shape
         mask = species != self.species_pad
         coord_flat = coords[mask]

--- a/tests/test_custom_nnp_contract.py
+++ b/tests/test_custom_nnp_contract.py
@@ -462,3 +462,87 @@ def test_a_module_inheriting_torchs_forward_stub_is_rejected(tmp_path):
 
     with pytest.raises(ModelLoadError, match="no forward method of its own"):
         load_custom_nnp(str(path), torch.device("cpu"))
+
+
+class TestExampleCustomNNPsDoNotPadWithARealElement:
+    """The copyable ``userNNP2`` examples must not pad species with 0.
+
+    Atomic number 0 is a real element in a batch Auto3D builds -- an R-group
+    ``*`` atom -- and each example identifies padding with
+    ``mask = species != self.species_pad``. With ``species_pad = 0`` that
+    expression deletes every dummy atom before the energy call, so the model
+    scores a molecule the user never submitted (audit C13). ``pad_from_mols``
+    defaults to -1 and ``docs/source/howto/custom_nnp.rst`` already says -1;
+    these three examples said 0, and they are the code users copy.
+
+    The examples are driven through their OWN ``forward`` with the AIMNet2
+    calculator replaced by a recorder, so no NNP is loaded and nothing is
+    downloaded.
+    """
+
+    EXAMPLE_MODULES = ("tests.test_SPE", "tests.test_thermo", "tests.test_auto3D")
+
+    @staticmethod
+    def _padded_batch(model):
+        """The batch Auto3D itself builds, with the example's own pad values."""
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        from Auto3D.batch_opt.padding import pad_from_mols
+
+        mols = []
+        # Different sizes, so the batch really is padded; the first molecule
+        # carries an R-group atom (Z=0).
+        for smiles in ("*CCO", "C"):
+            mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+            assert AllChem.EmbedMolecule(mol, randomSeed=42) == 0
+            mols.append(mol)
+        coords, species, charges, _atom_mask = pad_from_mols(
+            mols,
+            "AIMNET",
+            CPU,
+            coord_pad=model.coord_pad,
+            species_pad=model.species_pad,
+        )
+        return mols, coords, species, charges
+
+    @pytest.mark.parametrize("module_name", EXAMPLE_MODULES)
+    def test_every_submitted_atom_reaches_the_model(self, module_name):
+        import importlib
+
+        module = importlib.import_module(module_name)
+        model = module.userNNP2()
+
+        mols, coords, species, charges = self._padded_batch(model)
+
+        received: dict = {}
+
+        class _RecordingCalculator:
+            """Stands in for AIMNet2Calculator; records what it is handed."""
+
+            def __call__(self, inputs, forces=False):
+                received.update(inputs)
+                n_mols = int(inputs["mol_idx"].max().item()) + 1
+                return {"energy": torch.zeros(n_mols)}
+
+        # Pre-seed the lazily built backend so forward() never imports aimnet.
+        model._calc = _RecordingCalculator()
+        model._calc_device = species.device
+
+        model(species, coords, charges)
+
+        assert received, f"{module_name}.userNNP2 never called its calculator"
+        counts = torch.bincount(
+            received["mol_idx"], minlength=len(mols)
+        ).tolist()
+        expected = [mol.GetNumAtoms() for mol in mols]
+        assert counts == expected, (
+            f"{module_name}.userNNP2 passed {counts} atoms per molecule to the "
+            f"calculator but was given {expected}: with species_pad="
+            f"{model.species_pad!r}, its own 'species != species_pad' mask "
+            "deletes real atoms"
+        )
+        assert 0 in received["numbers"].tolist(), (
+            f"{module_name}.userNNP2 dropped the R-group (Z=0) atom, so it "
+            "scored a different molecule than the one submitted"
+        )

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -28,6 +28,30 @@ def _create_mol_with_energy(smiles: str, energy_ev: float, converged: bool = Tru
     return mol
 
 
+class TestConvergenceFilterIsNotAnEraser:
+    """A record with no 'Converged' property must not be deleted.
+
+    ``filter_unique_optimized`` is reached by ``ConformerRanker`` on any SDF
+    the caller hands it, including files ``batchopt`` did not write -- which
+    carry no ``Converged`` property at all.
+    """
+
+    def test_missing_converged_property_is_kept(self):
+        mol = _create_mol_with_energy("CCO", -10.0)
+        mol.ClearProp("Converged")
+        assert not mol.HasProp("Converged"), "test premise"
+
+        result = filter_unique_optimized([mol], rmsd_threshold=0.3)
+        assert len(result) == 1, (
+            "a record that never claimed to be an optimizer output was deleted"
+        )
+
+    def test_explicit_false_is_still_dropped(self):
+        """Absence is not failure -- but a stated failure still is."""
+        mol = _create_mol_with_energy("CCO", -10.0, converged=False)
+        assert filter_unique_optimized([mol], rmsd_threshold=0.3) == []
+
+
 class TestFilterWithinCluster:
     """Tests for _filter_within_cluster function."""
 

--- a/tests/test_isomer_engine_hardening.py
+++ b/tests/test_isomer_engine_hardening.py
@@ -18,20 +18,22 @@ from Auto3D.isomer_engine import RDKitIsomer, RDKitSdfIsomer, TautomerEngine
 from Auto3D.utils.chemistry import calculate_conformer_count
 
 
-def _make_engine(tmp_path, smi_path):
+def _make_engine(tmp_path, smi_path, flipper=True, max_confs=None):
     """Build an RDKitIsomer with throwaway output paths."""
     job_name = os.path.join(tmp_path, "job_" + uuid.uuid4().hex)
     os.makedirs(job_name)
+    unique = uuid.uuid4().hex
     return RDKitIsomer(
         smi=str(smi_path),
-        smiles_enumerated=os.path.join(tmp_path, "enum.smi"),
-        smiles_enumerated_reduced=os.path.join(tmp_path, "reduced.smi"),
-        smiles_hashed=os.path.join(tmp_path, "hashed.smi"),
-        enumerated_sdf=os.path.join(tmp_path, "out.sdf"),
+        smiles_enumerated=os.path.join(tmp_path, f"enum_{unique}.smi"),
+        smiles_enumerated_reduced=os.path.join(tmp_path, f"reduced_{unique}.smi"),
+        smiles_hashed=os.path.join(tmp_path, f"hashed_{unique}.smi"),
+        enumerated_sdf=os.path.join(tmp_path, f"out_{unique}.sdf"),
         job_name=job_name,
-        max_confs=None,
+        max_confs=max_confs,
         threshold=0.3,
         np=1,
+        flipper=flipper,
     )
 
 
@@ -356,3 +358,79 @@ class TestSpeFiltersAndAligns:
         assert out is not None
         # An output file is produced (empty SDF -> no molecule records).
         assert os.path.exists(out)
+
+
+class TestConformerNameShapeIsModeIndependent:
+    """Both SMILES modes must append the SAME number of name components.
+
+    ``ranking.species_id`` recovers the species id by stripping the two
+    trailing ``<isomer>_<conformer>`` components. With ``enumerate_isomer``
+    off, this path used to append only the conformer index, so ``KEY_2_0``
+    was ambiguous -- species "KEY_2" conformer 0, or species "KEY" isomer 2
+    conformer 0? -- and ``smiles2smi`` mints ``KEY_2`` for the second of two
+    DIFFERENT molecules that share a standard InChIKey. Both then grouped as
+    "KEY".
+    """
+
+    def test_names_carry_isomer_and_conformer_without_enumeration(self, tmp_path):
+        """<species>_<isomer>_<conformer>, with the isomer index always 0."""
+        from Auto3D.ranking import species_id
+
+        smi = tmp_path / "in.smi"
+        smi.write_text("CCO KEY\n")
+        engine = _make_engine(str(tmp_path), smi, flipper=False, max_confs=2)
+        engine.run()
+
+        mols = [m for m in Chem.SDMolSupplier(engine.enumerated_sdf) if m is not None]
+        assert mols, "no conformers were written"
+        for mol in mols:
+            name = mol.GetProp("_Name")
+            parts = name.rsplit("_", 2)
+            assert len(parts) == 3, (
+                f"conformer name {name!r} has {len(parts)} component(s); "
+                "species_id strips two, so anything else is unparseable"
+            )
+            assert parts[1] == "0", (
+                f"{name!r}: the sole isomer must be index 0, got {parts[1]!r}"
+            )
+            assert species_id(name) == "KEY"
+            # The user-visible ID property carries the same name.
+            assert mol.GetProp("ID") == name
+
+    def test_a_disambiguated_id_stays_distinct_without_enumeration(self, tmp_path):
+        """``KEY`` and ``KEY_2`` are two molecules and must stay two species."""
+        from Auto3D.ranking import species_id
+
+        smi = tmp_path / "in.smi"
+        # 2-pyridone and 2-hydroxypyridine share a standard InChIKey; this is
+        # exactly the pair smiles2smi renames the second of.
+        smi.write_text("O=c1cccc[nH]1 KEY\nOc1ccccn1 KEY_2\n")
+        engine = _make_engine(str(tmp_path), smi, flipper=False, max_confs=2)
+        engine.run()
+
+        mols = [m for m in Chem.SDMolSupplier(engine.enumerated_sdf) if m is not None]
+        species = {species_id(m.GetProp("_Name")) for m in mols}
+        assert species == {"KEY", "KEY_2"}, (
+            f"the two inputs collapsed into {species}; a conformer of one "
+            "molecule can then be reported under the other's name"
+        )
+
+    def test_the_two_modes_agree_on_shape(self, tmp_path):
+        """Same input, both modes, same number of name components."""
+        smi = tmp_path / "in.smi"
+        smi.write_text("CCO KEY\n")
+
+        shapes = {}
+        for flipper in (True, False):
+            engine = _make_engine(str(tmp_path), smi, flipper=flipper, max_confs=2)
+            engine.run()
+            mols = [
+                m for m in Chem.SDMolSupplier(engine.enumerated_sdf)
+                if m is not None
+            ]
+            assert mols, f"no conformers written with flipper={flipper}"
+            shapes[flipper] = {len(m.GetProp("_Name").split("_")) for m in mols}
+
+        assert shapes[True] == shapes[False] == {3}, (
+            f"name shapes differ between modes: {shapes}"
+        )

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -16,7 +16,7 @@ def _create_mol_with_energy(
     smiles: str,
     energy_ev: float,
     name: str,
-    converged: bool = True,
+    converged: bool | None = True,
 ) -> Chem.Mol:
     """Helper to create a test molecule with properties set.
 
@@ -31,7 +31,10 @@ def _create_mol_with_energy(
     AllChem.EmbedMolecule(mol, randomSeed=42)
     AllChem.MMFFOptimizeMolecule(mol)
     mol.SetProp('_Name', name)
-    mol.SetProp('Converged', 'true' if converged else 'false')
+    # converged=None leaves the property off entirely -- what every SDF that
+    # batchopt did not write looks like.
+    if converged is not None:
+        mol.SetProp('Converged', 'true' if converged else 'false')
     set_e_tot_from_ev(mol, energy_ev)
     return mol
 
@@ -572,42 +575,217 @@ class TestConformerRankerEnergyUnitLabel:
 
 
 class TestConformerRankerMissingConvergedProp:
-    """run() must not abort when a record lacks the 'Converged' property."""
+    """A record that never claimed to be an optimizer output is not a failure.
 
-    def test_run_skips_record_without_converged_prop(self, tmp_path):
-        """A record missing 'Converged' is treated as not-converged and skipped.
+    ``ConformerRanker`` is a documented public class, and any SDF ``batchopt``
+    did not write carries no ``Converged`` property: an ``opt_geometry``
+    output, an ORCA/Gaussian export, a hand-built conformer set. Treating the
+    absent property as "did not converge" dropped **every** record of such a
+    file -- ``[]`` returned, a **0-byte** SDF written, exit 0, and the only
+    message an INFO line on a logger tree with no handler outside ``main()``.
+    """
 
-        Previously the unguarded mol.GetProp('Converged') raised KeyError on
-        the first record lacking the property, producing zero output for the
-        entire run. The valid (Converged=true) record must still be processed.
-        """
+    def test_a_file_with_no_converged_property_is_not_deleted(self, tmp_path):
+        """Three records in, a non-empty file and the same species out."""
         from Auto3D.ranking import ConformerRanker
 
-        # Valid record with Converged=true.
-        good = _create_mol_with_energy("CCO", -10.0, "good_1", converged=True)
+        mols = [
+            _create_mol_with_energy("CCO", -10.0, "ethanol_0_0", converged=None),
+            _create_mol_with_energy("CCCO", -9.0, "propanol_0_0", converged=None),
+            _create_mol_with_energy("CCCCO", -8.0, "butanol_0_0", converged=None),
+        ]
+        for mol in mols:
+            assert not mol.HasProp("Converged"), "test premise"
 
-        # Record lacking the 'Converged' property entirely.
-        bad = Chem.MolFromSmiles("CCCO")
-        bad = Chem.AddHs(bad)
-        AllChem.EmbedMolecule(bad, randomSeed=42)
-        AllChem.MMFFOptimizeMolecule(bad)
-        bad.SetProp('_Name', "bad_1")
-        set_e_tot_from_ev(bad, -9.0)
-        assert not bad.HasProp('Converged')
+        input_path = str(tmp_path / "input.sdf")
+        output_path = str(tmp_path / "output.sdf")
+        _write_mols_to_sdf(mols, input_path)
+
+        results = ConformerRanker(
+            input_path=input_path, out_path=output_path, threshold=0.3, k=1,
+        ).run()
+
+        assert {mol.GetProp("_Name") for mol in results} == {
+            "ethanol", "propanol", "butanol",
+        }
+        assert os.path.getsize(output_path) > 0, (
+            "a non-empty input produced a 0-byte output file"
+        )
+        written = [
+            m for m in Chem.SDMolSupplier(output_path, removeHs=False)
+            if m is not None
+        ]
+        assert len(written) == 3
+
+    def test_an_explicit_false_is_still_dropped(self, tmp_path):
+        """Absence is not failure -- but an explicit failure still is."""
+        from Auto3D.ranking import ConformerRanker
+
+        good = _create_mol_with_energy("CCO", -10.0, "good_0_0", converged=None)
+        bad = _create_mol_with_energy("CCCO", -9.0, "bad_0_0", converged=False)
 
         input_path = str(tmp_path / "input.sdf")
         output_path = str(tmp_path / "output.sdf")
         _write_mols_to_sdf([good, bad], input_path)
 
+        results = ConformerRanker(
+            input_path=input_path, out_path=output_path, threshold=0.3, k=1,
+        ).run()
+
+        names = {mol.GetProp("_Name") for mol in results}
+        assert names == {"good"}
+
+    def test_a_record_without_an_energy_is_refused_not_dropped(self, tmp_path):
+        """Ranking is selection by energy; a record with none cannot be ranked.
+
+        This used to be masked: the record was silently deleted for lacking
+        'Converged' before anything asked it for an energy.
+        """
+        from Auto3D.exceptions import InputValidationError
+        from Auto3D.ranking import ConformerRanker
+
+        mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        mol.SetProp("_Name", "no_energy_0_0")
+        assert not mol.HasProp("E_tot")
+
+        input_path = str(tmp_path / "input.sdf")
+        output_path = str(tmp_path / "output.sdf")
+        _write_mols_to_sdf([mol], input_path)
+
         ranker = ConformerRanker(
-            input_path=input_path,
-            out_path=output_path,
-            threshold=0.3,
-            k=1,
+            input_path=input_path, out_path=output_path, threshold=0.3, k=1,
+        )
+        with pytest.raises(InputValidationError, match="has no 'E_tot' property"):
+            ranker.run()
+
+    def test_selecting_nothing_from_a_non_empty_input_warns(self, tmp_path, caplog):
+        """An empty output must say so at WARNING, which reaches stderr.
+
+        ``logging.lastResort`` prints WARNING and above even for a caller who
+        never ran ``configure_logging`` -- i.e. every direct API caller. The
+        old INFO line reached nobody.
+        """
+        import logging
+
+        from Auto3D.ranking import ConformerRanker
+
+        mols = [
+            _create_mol_with_energy("CCO", -10.0, "a_0_0", converged=False),
+            _create_mol_with_energy("CCCO", -9.0, "b_0_0", converged=False),
+        ]
+        input_path = str(tmp_path / "input.sdf")
+        output_path = str(tmp_path / "output.sdf")
+        _write_mols_to_sdf(mols, input_path)
+
+        with caplog.at_level(logging.WARNING, logger="Auto3D.ranking"):
+            results = ConformerRanker(
+                input_path=input_path, out_path=output_path, threshold=0.3, k=1,
+            ).run()
+
+        assert results == []
+        assert os.path.getsize(output_path) == 0
+        messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("Selected 0 structures from 2 record(s)" in m for m in messages), (
+            f"a 0-byte output was produced with no WARNING; got {messages}"
         )
 
-        # Must not raise KeyError, and must process the valid record.
-        results = ranker.run()
-        names = {mol.GetProp("_Name") for mol in results}
-        assert "good" in names
-        assert "bad" not in names
+
+class TestTwoInputsSharingAnInChIKeyStayTwoMolecules:
+    """Remediation goal #1: no path silently returns a different molecule.
+
+    ``smiles2smi`` renames the second of two inputs that share a standard
+    InChIKey to ``<KEY>_2`` *specifically so it is not dropped*. With
+    ``enumerate_isomer=False`` the SMILES path used to append only the
+    conformer index, so ``species_id`` stripped the ``_2`` along with it and
+    both molecules landed in one ranking group: ``k=1`` then returned ONE
+    conformer for the pair -- and, since selection is by energy across the
+    merged group, it could be the other molecule's geometry carrying this
+    molecule's name.
+
+    This test runs the real embedding path and stands in for the optimizer
+    (no NNP is loaded), then asserts the identity of what comes out.
+    """
+
+    # 2-pyridone / 2-hydroxypyridine: two different molecules the standard
+    # InChIKey conflates.
+    PYRIDONE = "O=c1cccc[nH]1"
+    HYDROXYPYRIDINE = "Oc1ccccn1"
+
+    @staticmethod
+    def _canonical(mol: Chem.Mol) -> str:
+        return Chem.MolToSmiles(Chem.RemoveHs(Chem.Mol(mol)))
+
+    def test_enumerate_isomer_false_returns_both_molecules(self, tmp_path):
+        from Auto3D.isomer_engine import RDKitIsomer
+        from Auto3D.ranking import ConformerRanker, species_id
+        from Auto3D.utils.file_ops import smiles2smi
+
+        smi_path = str(tmp_path / "in.smi")
+        smiles2smi([self.PYRIDONE, self.HYDROXYPYRIDINE], smi_path)
+        ids = [line.split()[1] for line in open(smi_path) if line.strip()]
+        assert ids[1] == f"{ids[0]}_2", (
+            f"test premise: the two inputs must collide on one InChIKey and be "
+            f"disambiguated, got {ids}"
+        )
+        key, key_2 = ids
+
+        job = tmp_path / "job"
+        job.mkdir()
+        engine = RDKitIsomer(
+            smi=smi_path,
+            smiles_enumerated=str(tmp_path / "enum.smi"),
+            smiles_enumerated_reduced=str(tmp_path / "reduced.smi"),
+            smiles_hashed=str(tmp_path / "hashed.smi"),
+            enumerated_sdf=str(tmp_path / "enumerated.sdf"),
+            job_name=str(job),
+            max_confs=2,
+            threshold=0.3,
+            np=1,
+            flipper=False,  # enumerate_isomer=False -- the affected mode
+        )
+        enumerated = engine.run()
+
+        # Stand in for the optimizer: mark everything converged and make the
+        # SECOND input much lower in energy, so a merged group would keep ITS
+        # geometry under the FIRST molecule's name.
+        mols = [
+            m for m in Chem.SDMolSupplier(enumerated, removeHs=False)
+            if m is not None
+        ]
+        assert mols, "the embedding step produced nothing to rank"
+        seen_species = {species_id(m.GetProp("_Name")) for m in mols}
+        assert seen_species == {key, key_2}, (
+            f"both inputs must reach ranking as distinct species, got {seen_species}"
+        )
+        optimized = str(tmp_path / "optimized.sdf")
+        with Chem.SDWriter(optimized) as writer:
+            for mol in mols:
+                mol.SetProp("Converged", "true")
+                energy = -10.0 if species_id(mol.GetProp("_Name")) == key else -20.0
+                set_e_tot_from_ev(mol, energy)
+                writer.write(mol)
+
+        output = str(tmp_path / "ranked.sdf")
+        results = ConformerRanker(
+            input_path=optimized, out_path=output, threshold=0.3, k=1,
+        ).run()
+
+        by_name = {mol.GetProp("_Name"): mol for mol in results}
+        assert set(by_name) == {key, key_2}, (
+            f"expected one conformer per input molecule ({key}, {key_2}), got "
+            f"{sorted(by_name)}"
+        )
+        # Identity, not just count: the record under each name must BE that
+        # molecule, not the other one wearing its name.
+        assert self._canonical(by_name[key]) == Chem.CanonSmiles(self.PYRIDONE)
+        assert self._canonical(by_name[key_2]) == Chem.CanonSmiles(
+            self.HYDROXYPYRIDINE
+        )
+        assert self._canonical(by_name[key]) != self._canonical(by_name[key_2])
+
+        written = [
+            m for m in Chem.SDMolSupplier(output, removeHs=False) if m is not None
+        ]
+        assert {m.GetProp("_Name") for m in written} == {key, key_2}
+        assert os.path.getsize(output) > 0

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -99,7 +99,12 @@ class userNNP2(torch.nn.Module):
         self._calc_device = None
 
         self.coord_pad = 0  # int, the padding value for coordinates
-        self.species_pad = 0  # int, the padding value for species.
+        # -1, NOT 0: atomic number 0 is a real element here (an R-group '*'
+        # atom), and the mask in forward() below is `species !=
+        # self.species_pad`, so a species_pad of 0 silently deletes every
+        # dummy atom from the batch -- a different molecule than the one
+        # submitted. Matches docs/source/howto/custom_nnp.rst.
+        self.species_pad = -1  # int, the padding value for species.
 
     def forward(self,
                 species: torch.Tensor,
@@ -126,7 +131,8 @@ class userNNP2(torch.nn.Module):
             self._calc = AIMNet2Calculator("aimnet2", device=str(species.device))
             self._calc_device = species.device
         # Auto3D feeds padded (B, N) batches; use ragged mol_idx batching to drop
-        # padded atoms (AIMNet2 yields NaN on species-0 padding otherwise).
+        # padded atoms (AIMNet2 has no element for a padding slot and yields
+        # NaN if one reaches it).
         b, n = species.shape
         mask = species != self.species_pad
         coord_flat = coords[mask]

--- a/tests/test_thermo_helpers.py
+++ b/tests/test_thermo_helpers.py
@@ -1112,10 +1112,12 @@ class TestCalculatorChargeInvalidatesCache:
     def _calculator(charge=0):
         """A ``Calculator`` over a stub whose energy/forces depend on charge.
 
-        The stub owns one real ``nn.Parameter`` on the CPU purely so
-        ``Calculator.__init__`` reads device/dtype from it: the param-less
-        branch falls back to ``cuda`` whenever a GPU happens to be visible,
-        which would make this test machine-dependent. No NNP is loaded.
+        The stub owns one real ``nn.Parameter`` on the CPU so
+        ``Calculator.__init__`` reads device/dtype from it, pinning this test
+        to CPU/float32 regardless of what is visible. (The param-less branch
+        is CPU now too -- see
+        ``TestCalculatorDeviceAndDtypeFollowTheCaller`` -- but reading a real
+        parameter is what this class is about.) No NNP is loaded.
         """
         import torch
         from torch import nn
@@ -1207,3 +1209,190 @@ class TestCalculatorChargeInvalidatesCache:
         calc.set_charge(0)
         atoms.get_potential_energy()
         assert model.calls == 1
+
+
+class TestCalculatorDeviceAndDtypeFollowTheCaller:
+    """A ``calc_thermo`` call must run on the one device the user asked for.
+
+    For a **param-less** custom NNP (one that builds its backend lazily, so
+    ``Calculator.__init__`` has no ``nn.Parameter`` to read a device off),
+    the calculator used to choose
+    ``torch.device("cuda" if torch.cuda.is_available() else "cpu")`` and
+    ``torch.double`` on its own. ``use_gpu`` and ``gpu_idx`` never reached it,
+    so ``calc_thermo(..., use_gpu=False)`` relaxed the geometry on **cuda:0 in
+    float64** while the fmax pre-check and the Hessian ran on **cpu in
+    float32** -- one call, two devices, two precisions, nothing logged, and
+    ``gpu_idx`` ignored entirely (always device 0).
+
+    These tests assert the device and dtype of the tensors the model actually
+    receives, not that a branch was taken, and they fake CUDA availability so
+    they mean the same thing on a CI runner with no GPU as on an 8-GPU box.
+    """
+
+    @staticmethod
+    def _paramless_model():
+        """A custom NNP holding no ``nn.Parameter`` -- the H1 input shape.
+
+        Records the device and dtype of every tensor it is handed, which is
+        the only thing that decides whether the run stayed where it was told.
+        """
+        import torch
+        from torch import nn
+
+        class _ParamlessRecordingNNP(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.seen: list[dict] = []
+
+            def forward(self, coords, species, charges, atom_mask=None):
+                self.seen.append({
+                    "device": coords.device,
+                    "dtype": coords.dtype,
+                    "species_device": species.device,
+                    "charge_device": charges.device,
+                })
+                energy = torch.zeros(coords.shape[0], dtype=coords.dtype)
+                # A toy restoring force: non-zero (so the fmax pre-check fails
+                # and the ASE calculator -- the cuda-seizing half of the split
+                # -- is actually exercised) and geometry-dependent (so BFGS's
+                # curvature update does not divide by zero). Detached because
+                # ASE converts forces with .numpy().
+                forces = (-0.5 * coords).detach()
+                return energy, forces
+
+        assert not list(_ParamlessRecordingNNP().parameters()), (
+            "test premise: the model must hold no nn.Parameter"
+        )
+        return _ParamlessRecordingNNP()
+
+    @staticmethod
+    def _pretend_cuda_is_available(monkeypatch, count: int = 8):
+        """Make the CUDA-availability probe say yes without touching a GPU.
+
+        Both ``is_available`` and ``device_count`` are patched: CI runners have
+        no CUDA device at all, and a test that only passes on the 8-GPU
+        development box would not defend anything.
+        """
+        import torch
+
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+        monkeypatch.setattr(torch.cuda, "device_count", lambda: count)
+
+    @staticmethod
+    def _atoms():
+        from ase import Atoms
+
+        return Atoms("H2", [(0.0, 0.0, 0.0), (0.0, 0.0, 0.74)])
+
+    def test_requested_cpu_device_wins_over_visible_cuda(self, monkeypatch):
+        """device=cpu means every tensor is on the CPU, CUDA visible or not."""
+        import torch
+
+        from Auto3D.ASE.thermo import Calculator
+
+        self._pretend_cuda_is_available(monkeypatch)
+        model = self._paramless_model()
+        calc = Calculator(model, 0, model_name="AIMNET", device=torch.device("cpu"))
+
+        assert calc.device == torch.device("cpu")
+        assert calc.dtype is torch.float32
+
+        atoms = self._atoms()
+        atoms.calc = calc
+        atoms.get_potential_energy()
+
+        assert model.seen, "the model was never called"
+        for call in model.seen:
+            assert call["device"].type == "cpu", (
+                f"coordinates were built on {call['device']}, not the "
+                "requested cpu"
+            )
+            assert call["dtype"] is torch.float32, (
+                f"coordinates were built as {call['dtype']}; the rest of the "
+                "call (mol2aimnet_input, the charge tensor) is float32"
+            )
+            assert call["species_device"].type == "cpu"
+            assert call["charge_device"].type == "cpu"
+
+    def test_no_device_argument_never_seizes_a_gpu(self, monkeypatch):
+        """With nothing to infer from, CPU is the only safe answer.
+
+        A calculator that picks cuda because a GPU happens to be visible makes
+        ``use_gpu=False`` untrue for anyone who does not pass a device.
+        """
+        import torch
+
+        from Auto3D.ASE.thermo import Calculator
+
+        self._pretend_cuda_is_available(monkeypatch)
+        calc = Calculator(self._paramless_model(), 0, model_name="AIMNET")
+
+        assert calc.device == torch.device("cpu")
+        assert calc.dtype is torch.float32
+
+    def test_a_models_own_parameter_device_is_still_honored(self):
+        """Nothing changes for a model that does carry parameters."""
+        import torch
+        from torch import nn
+
+        from Auto3D.ASE.thermo import Calculator
+
+        class _WithParam(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.anchor = nn.Parameter(torch.zeros(1, dtype=torch.float64))
+
+            def forward(self, coords, species, charges, atom_mask=None):
+                return torch.zeros(coords.shape[0]), torch.zeros_like(coords)
+
+        calc = Calculator(_WithParam(), 0, model_name="AIMNET")
+        assert calc.device == torch.device("cpu")
+        assert calc.dtype is torch.float64
+
+    def test_calc_thermo_no_gpu_uses_one_device_and_one_dtype(
+        self, monkeypatch, tmp_path
+    ):
+        """The whole call, both stages, on the device ``use_gpu=False`` means.
+
+        The fmax pre-check goes through ``mol2aimnet_input`` (device from
+        ``get_device``) and the relaxation goes through the ASE ``Calculator``.
+        Before this fix those two disagreed for a param-less custom NNP.
+        """
+        import torch
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+
+        import Auto3D.ASE.thermo as thermo_mod
+
+        self._pretend_cuda_is_available(monkeypatch)
+        model = self._paramless_model()
+        monkeypatch.setattr(thermo_mod, "create_model", lambda *a, **k: model)
+        monkeypatch.setattr(
+            thermo_mod, "_load_hessian_model", lambda *a, **k: object()
+        )
+
+        mol = Chem.AddHs(Chem.MolFromSmiles("O"))
+        AllChem.EmbedMolecule(mol, randomSeed=42)
+        mol.SetProp("_Name", "water")
+        sdf = tmp_path / "in.sdf"
+        with Chem.SDWriter(str(sdf)) as writer:
+            writer.write(mol)
+        out = tmp_path / "out.sdf"
+
+        thermo_mod.calc_thermo(
+            str(sdf), "AIMNET", use_gpu=False, opt_steps=2, out_path=str(out)
+        )
+
+        assert len(model.seen) >= 2, (
+            "expected both the fmax pre-check and the ASE relaxation to call "
+            f"the model; got {len(model.seen)} call(s)"
+        )
+        devices = {call["device"].type for call in model.seen}
+        dtypes = {call["dtype"] for call in model.seen}
+        assert devices == {"cpu"}, (
+            f"use_gpu=False, but one calc_thermo call spanned devices {devices}"
+        )
+        assert dtypes == {torch.float32}, (
+            f"one calc_thermo call spanned precisions {dtypes}: the geometry "
+            "would be relaxed at one precision and the Hessian built at another"
+        )

--- a/tests/test_torch_config.py
+++ b/tests/test_torch_config.py
@@ -8,12 +8,20 @@ class TestTorchConfig:
     """Tests for TorchConfig dataclass."""
 
     def test_torch_config_default_values(self):
-        """TorchConfig should have sensible defaults."""
+        """Defaults must name a value only for the flag Auto3D owns.
+
+        ``allow_tf32`` is a documented Auto3D option, so its default (False)
+        is a real request and is applied. ``cudnn_benchmark`` and
+        ``deterministic`` have no Auto3D-level option; their default is None,
+        which ``configure_torch`` reads as "leave the calling process's
+        setting alone".
+        """
         from Auto3D.torch_config import TorchConfig
 
         config = TorchConfig()
         assert config.allow_tf32 is False
-        assert config.cudnn_benchmark is False
+        assert config.cudnn_benchmark is None
+        assert config.deterministic is None
 
     def test_torch_config_custom_values(self):
         """TorchConfig should accept custom values."""
@@ -127,6 +135,117 @@ class TestConfigureTorch:
         finally:
             # Restore the default (non-deterministic) global state.
             configure_torch(TorchConfig(deterministic=False))
+
+
+def _nondeterministic_op_raises() -> bool:
+    """Run an op with no deterministic CPU kernel; True if torch refused it.
+
+    This is the *consequence* of determinism being on with warn_only=False --
+    the signal ``torch.use_deterministic_algorithms(True)`` is set to obtain.
+    Asserting on ``are_deterministic_algorithms_enabled()`` alone would only
+    report the flag; this reports what the flag does.
+    """
+    try:
+        torch.zeros(5).put_(
+            torch.tensor([0, 1]), torch.tensor([1.0, 2.0]), accumulate=False
+        )
+    except RuntimeError:
+        return True
+    return False
+
+
+class TestConfigureTorchLeavesUnrequestedGlobalsAlone:
+    """Process-global state the caller owns must survive an Auto3D call.
+
+    Every Auto3D entry point (``main``, ``smiles2mols``, ``calc_spe``,
+    ``opt_geometry``, ``calc_thermo``) builds ``TorchConfig(allow_tf32=...)``
+    and nothing else, so that exact config is what these tests apply.
+    """
+
+    @staticmethod
+    def _snapshot():
+        return (
+            torch.are_deterministic_algorithms_enabled(),
+            torch.is_deterministic_algorithms_warn_only_enabled(),
+            torch.backends.cudnn.deterministic,
+            torch.backends.cudnn.benchmark,
+        )
+
+    @staticmethod
+    def _restore(state):
+        deterministic, warn_only, cudnn_deterministic, benchmark = state
+        torch.use_deterministic_algorithms(deterministic, warn_only=warn_only)
+        torch.backends.cudnn.deterministic = cudnn_deterministic
+        torch.backends.cudnn.benchmark = benchmark
+
+    def test_a_callers_determinism_survives_an_entry_point_config(self):
+        """The caller set determinism; a nondeterministic op must still raise.
+
+        Auto3D used to write ``use_deterministic_algorithms(False)``
+        unconditionally, so after any entry point the caller's op silently
+        produced a nondeterministic result instead of raising -- with nothing
+        logged and no way to ask for the setting back.
+        """
+        from Auto3D.torch_config import TorchConfig, configure_torch
+
+        saved = self._snapshot()
+        try:
+            torch.use_deterministic_algorithms(True, warn_only=False)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = True
+            assert _nondeterministic_op_raises(), "test premise: op must refuse"
+
+            configure_torch(TorchConfig(allow_tf32=False))
+
+            assert _nondeterministic_op_raises(), (
+                "configure_torch downgraded the caller's determinism: the op "
+                "that must refuse to run now runs and returns a "
+                "nondeterministic result"
+            )
+            assert torch.are_deterministic_algorithms_enabled() is True
+            assert torch.is_deterministic_algorithms_warn_only_enabled() is False
+            assert torch.backends.cudnn.deterministic is True
+            assert torch.backends.cudnn.benchmark is True
+        finally:
+            self._restore(saved)
+
+    def test_an_explicit_request_is_still_applied_in_both_directions(self):
+        """None means "leave alone", not "never write": explicit still wins."""
+        from Auto3D.torch_config import TorchConfig, configure_torch
+
+        saved = self._snapshot()
+        try:
+            torch.use_deterministic_algorithms(False, warn_only=True)
+            torch.backends.cudnn.benchmark = False
+
+            configure_torch(TorchConfig(deterministic=True, cudnn_benchmark=True))
+            assert torch.are_deterministic_algorithms_enabled() is True
+            assert torch.backends.cudnn.deterministic is True
+            assert torch.backends.cudnn.benchmark is True
+
+            configure_torch(TorchConfig(deterministic=False, cudnn_benchmark=False))
+            assert torch.are_deterministic_algorithms_enabled() is False
+            assert torch.backends.cudnn.deterministic is False
+            assert torch.backends.cudnn.benchmark is False
+        finally:
+            self._restore(saved)
+
+    def test_deterministic_warn_only_false_is_honored(self):
+        """A caller asking to be raised at must not be downgraded to a warning."""
+        from Auto3D.torch_config import TorchConfig, configure_torch
+
+        saved = self._snapshot()
+        try:
+            configure_torch(
+                TorchConfig(deterministic=True, deterministic_warn_only=False)
+            )
+            assert torch.is_deterministic_algorithms_warn_only_enabled() is False
+            assert _nondeterministic_op_raises(), (
+                "deterministic_warn_only=False was requested, but the op only "
+                "warned instead of raising"
+            )
+        finally:
+            self._restore(saved)
 
 
 class TestAuto3DOptionsAllowTf32:

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -193,6 +193,35 @@ class TestFilterUnique:
             # Only one should remain
             assert len(result) == 1
 
+    def test_filter_unique_keeps_records_with_no_converged_property(self):
+        """Absence of the property is not a failed optimization.
+
+        Only ``batchopt`` writes ``Converged``; an ``opt_geometry`` output, an
+        ORCA/Gaussian export or a hand-built conformer set carries none.
+        Treating that as "did not converge" deleted every record. The
+        consequence asserted here is that such a file filters exactly the same
+        as one whose records all say Converged=True.
+        """
+        supp = Chem.SDMolSupplier(path_example_sdf, removeHs=False)
+        flagged = [mol for mol in supp if mol is not None]
+        for mol in flagged:
+            mol.SetProp("Converged", "True")
+        expected = len(filter_unique(flagged))
+        assert expected >= 1, "test premise: the flagged file must keep something"
+
+        supp = Chem.SDMolSupplier(path_example_sdf, removeHs=False)
+        unflagged = [mol for mol in supp if mol is not None]
+        for mol in unflagged:
+            mol.ClearProp("Converged")
+            assert not mol.HasProp("Converged")
+
+        result = filter_unique(unflagged)
+        assert len(result) == expected, (
+            f"{len(unflagged)} record(s) with no 'Converged' property kept "
+            f"{len(result)}, but the same records marked Converged=True keep "
+            f"{expected}"
+        )
+
     def test_filter_unique_custom_threshold(self):
         """Test filter_unique with custom RMSD threshold."""
         supp = Chem.SDMolSupplier(path_example_sdf, removeHs=False)


### PR DESCRIPTION
Four fallbacks where Auto3D silently gave the user something other than what they asked for, plus one residual. All four were demonstrated by the error hunt; none was on the original audit's list.

## Two distinct molecules were merged under one name

`ranking.py` derived the species from a conformer name with `rsplit("_", 2)`, which assumes two appended components. The SMILES path with `enumerate_isomer=False` appended only **one**, so `KEY_0` and `KEY_2_0` both reduced to `KEY`.

Demonstrated with 2-pyridone and 2-hydroxypyridine, which share an InChIKey:

- **before** — one species, **1 conformer** returned, `_Name = UBQKCCHYAOITMY-UHFFFAOYSA-N` carrying SMILES `Oc1ccccn1`: *the other molecule's geometry under this molecule's name*
- **after** — two species, 2 conformers, each with its own structure

`species_id`'s own docstring already documented this gap and noted it had no test. It is the remediation's stated goal #1 — "no code path silently produces a molecule of different chemical identity than the user submitted" — and it was still open.

Fixed by making every producer append the same two components in every mode, so the name is unambiguous, rather than by making the parser guess harder.

## `use_gpu=False` ran on the GPU, in a different precision than its own Hessian

For a param-less custom NNP, the ASE calculator could not read a device off a parameter and guessed `cuda if available`, in float64 — never consulting `use_gpu` or `gpu_idx`. So `calc_thermo(..., use_gpu=False)` relaxed on **cuda:0 in float64** while the Hessian ran on **CPU in float32**: one call, two devices, two precisions, nothing logged.

- **before** — `get_device(0, use_gpu=False) = cpu`, but `calculator.device = cuda`, `dtype = float64`, allocations requested on `cuda`
- **after** — `calculator.device = cpu`, `dtype = float32`, allocations on `cpu`

This contradicted the policy an earlier phase unified, in which `check_gpu_requested` makes `use_gpu` mean one thing at every entry point. The caller's device and dtype are now threaded through instead of guessed.

## A caller's determinism was switched off behind their back

`configure_torch` unconditionally wrote `use_deterministic_algorithms(False)` and both `cudnn` flags — process-global state — so a caller who had set determinism before importing Auto3D lost it for the rest of the process, with no way to ask for it back. It now sets only what was requested.

## A 0-byte output at exit 0

Records without a `Converged` property were dropped by three separate filters. `batchopt` always writes it, so the pipeline was fine — but the **public** `ConformerRanker` on any other SDF dropped every record, returned `[]`, wrote a 0-byte file and exited 0. Absence of the property no longer means failure, and a genuinely empty result now warns on stderr with input, output and counts.

## Residual: `species_pad = 0` in the example models users copy

Three `userNNP2` examples in test files paired `species_pad = 0` with `mask = species != self.species_pad` — the C13 collision, since atomic number 0 is a real R-group atom. Now `-1`, matching the docs.

The new guard is a **fast** test that drives each example's own `forward` with the calculator replaced by a recorder, so this is no longer covered only by the un-runnable slow tier. Reverting to 0 fails it with `passed [8, 5] atoms per molecule but was given [9, 5]`.

## Testing

**1166 passed, 10 skipped, 0 xfailed** — identical across plain, `CUDA_VISIBLE_DEVICES=""` and `FORCE_COLOR=1`. Slow collection unchanged at 67.

Every fix mutation-verified, each failing for its own reason — including the GPU fix, which under `CUDA_VISIBLE_DEVICES=""` fails with `RuntimeError: No CUDA GPUs are available` when reverted, because the old code reaches for a device `use_gpu=False` had already resolved away.

Static slow-tier audit found no impact: no slow test uses `enumerate_isomer=False`, final `_Name` is unchanged in every mode, and the slow molecules carry no Z=0 atom.

## Known limits

- `oe_isomer` with `flipper=False` has the same two-component naming shape. Untouched: OpenEye is unavailable here, and its wart naming cannot be verified without a license. Reachable only via `isomer_engine="omega"` with `enumerate_isomer=False`.
- A param-less custom NNP's thermochemistry changes numerically — that *is* the fix, since relaxation and Hessian now agree. Documented in the migration guide.
