### PR TITLE
test: make the suite's result independent of the order its tests run in

### DIFF
--- a/.claude/review-manifests/review-2026-08-02-test-order-dependence.md
+++ b/.claude/review-manifests/review-2026-08-02-test-order-dependence.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-02
 **Scope:** `tests/` (fast tier), `tests/conftest.py`
-**Trigger:** every CI verdict in this repository was carrying an unknown amount of luck.
+**Trigger:** the suite's result depended on the order its tests ran in.
 
 ## The observation that started it
 
@@ -12,15 +12,42 @@ CI runs, verbatim:
 pytest tests/ -q -m "not slow" --continue-on-collection-errors
 ```
 
-Note what is *absent*: `-p no:randomly`. `pytest-randomly` is installed and
-enabled by default, so **CI shuffles test order on every run** while the local
-habit in this repo (`-p no:randomly`) does not. Three runs of that exact command
-on the same commit produced **0, 1, and 13 failures**, differing only by seed.
-`git archive` of `main` failed the identical 13 at seed `1351916419`, so this
-predated the remediation branches — it was not introduced by them.
+Note what is *absent*: `-p no:randomly`. Running that same command locally, where
+`pytest-randomly` is installed and enabled by default, produced **0, 1, and 13
+failures across three runs of one commit**, differing only by seed. `git archive`
+of `main` failed the identical 13 at seed `1351916419`, so this predated the
+remediation branches — it was not introduced by them.
 
-A suite whose result depends on the seed cannot answer the only question CI is
-asked: *did this change break anything?*
+### Correction: CI itself was never shuffling
+
+An early draft of this write-up claimed CI was flaky for the same reason. It was
+not, and the check is one line of any CI log:
+
+```
+plugins: cov-7.1.0, anyio-4.14.2
+```
+
+`pytest-randomly` is **not installed on CI** — it is not in the `dev` extra, so
+it arrives only in a developer's environment. CI's order is therefore fixed
+collection order, and it happens to be an order in which causes 1 and 2 below do
+not fire. So the accurate statement is narrower than "every CI verdict was
+luck", and worth stating precisely:
+
+| | locally, shuffled | on CI, fixed order |
+|---|---|---|
+| cause 1 (captured stub) | 13 failures on unlucky seeds | latent, not firing |
+| cause 2 (split module) | 1 failure on seed `12345` | latent, not firing |
+| cause 3 (leaked start method) | test skipped on most seeds | **test skipped every run** |
+
+Two things follow. First, cause 3 *was* costing CI real coverage every single
+run, and the CI skip count falling from **2 to 1** is the receipt. Second,
+causes 1 and 2 are latent on CI rather than fixed: CI's order is stable only
+until a test module is added or renamed, at which point the same 13 failures can
+appear with no code change to blame them on.
+
+A suite whose result depends on collection order cannot reliably answer the only
+question CI is asked — *did this change break anything?* — even when today's
+particular order is a lucky one.
 
 ## Three independent defects, three different mechanisms
 
@@ -92,12 +119,14 @@ test that calls `main()` converts the rest of the session to spawn.
 `test_parallel_embed.py::test_parallel_embed_reraises_broken_pool` gates itself
 on `mp.get_start_method() != "fork"`. It therefore ran or skipped depending on
 whether a `main()`-calling test was scheduled ahead of it: **skipped under most
-seeds, ran under 999983.** A test that quietly stops testing anything on most
-orderings is worse than one that fails, because the summary still reads green.
+seeds locally, ran under 999983 — and skipped on every CI run.** A test that
+quietly stops testing anything is worse than one that fails, because the summary
+still reads green.
 
 This one produced no failure — which is exactly why it had gone unnoticed. It
 showed up only as a pass/skip count that moved between seeds
-(`1227 passed, 10 skipped` vs `1228 passed, 9 skipped`).
+(`1227 passed, 10 skipped` vs `1228 passed, 9 skipped`), and on CI as a `2` in
+the skip column that nobody had reason to look at.
 
 ## The fixes
 
@@ -154,6 +183,25 @@ the guard exists to catch.
   flake; it passes three times out of three in isolation.
 - The suite also got ~15% faster (78s → 66s), because tests that had been
   inheriting `spawn` from an earlier `main()` call now fork.
+- On CI, against the `main` baseline at `02fba12` (`1234 passed, 2 skipped`):
+  **`1236 passed, 1 skipped`** — the two added passes are the new guard test and
+  the revived broken-pool test, and the lost skip is that same test no longer
+  opting out.
+
+## Open recommendation: let CI shuffle
+
+The guard added here works in any order, so it earns its keep on CI today: it
+fails a test that leaks even when the leak is not currently causing a failure.
+What CI still cannot see is *order sensitivity itself*, because it runs one fixed
+order.
+
+Adding `pytest-randomly` to the `dev` extra would close that. The argument for:
+12 seeds are now demonstrably stable, and when a shuffle does break something the
+guard names the guilty test instead of leaving 13 unexplained failures. The
+argument against: it introduces a source of CI variation that can turn a build
+red for reasons unrelated to the change under review, and the seed must then be
+read out of the log to reproduce. Left as the maintainer's call rather than
+bundled into this change, whose premise had already needed one correction.
 
 ## What generalizes
 
@@ -176,3 +224,9 @@ were all invisible under `-p no:randomly`, which is what this repo's own notes
 recommend running. When local and CI invocations differ, the difference is a
 place for defects to live — this session found three others the same way (GPU
 visibility, `FORCE_COLOR`, and random ordering itself).
+
+**Check which plugins are actually loaded before reasoning about what a test run
+did.** The `plugins:` line is in every pytest header, local and CI. Assuming the
+two environments load the same set is what produced the wrong claim corrected
+above: the local suite had six plugins, CI had two, and the one that mattered was
+in the difference.

--- a/.claude/review-manifests/review-2026-08-02-test-order-dependence.md
+++ b/.claude/review-manifests/review-2026-08-02-test-order-dependence.md
@@ -1,0 +1,178 @@
+# Test-suite order dependence — root cause and closure
+
+**Date:** 2026-08-02
+**Scope:** `tests/` (fast tier), `tests/conftest.py`
+**Trigger:** every CI verdict in this repository was carrying an unknown amount of luck.
+
+## The observation that started it
+
+CI runs, verbatim:
+
+```
+pytest tests/ -q -m "not slow" --continue-on-collection-errors
+```
+
+Note what is *absent*: `-p no:randomly`. `pytest-randomly` is installed and
+enabled by default, so **CI shuffles test order on every run** while the local
+habit in this repo (`-p no:randomly`) does not. Three runs of that exact command
+on the same commit produced **0, 1, and 13 failures**, differing only by seed.
+`git archive` of `main` failed the identical 13 at seed `1351916419`, so this
+predated the remediation branches — it was not introduced by them.
+
+A suite whose result depends on the seed cannot answer the only question CI is
+asked: *did this change break anything?*
+
+## Three independent defects, three different mechanisms
+
+### 1. A stub captured permanently by a lazy import — 13 failures
+
+`tests/test_config_parity.py` patches the module that *defines* a function:
+
+```python
+monkeypatch.setattr("Auto3D.cli.errors.handle_error", _capture)
+```
+
+`src/Auto3D/cli/commands/run.py:16` copies that function into its own namespace
+at import time:
+
+```python
+from Auto3D.cli.errors import handle_error, handle_interrupt, job_directory_hint
+```
+
+and the CLI imports `run` **lazily**, inside a function, to keep `auto3d --help`
+fast. So the outcome depends on who gets there first:
+
+| ordering | result |
+|---|---|
+| some earlier test already imported `run` | `run` holds the real function; `monkeypatch` restores cleanly |
+| this test is the first to reach the lazy import | `run` binds the **stub**, permanently |
+
+`monkeypatch` restores `Auto3D.cli.errors`, which is what it patched. It cannot
+know that `run` copied the value meanwhile. The leaked stub swallows the
+exception it is handed, so **every later test expecting a non-zero exit code saw
+exit 0** — 13 tests across six CLI modules, none of them near the cause.
+
+Proven directly, not inferred:
+
+```
+run in sys.modules AFTER: True
+run.handle_error is the stub: True
+```
+
+Note the earlier fix attempt on this same test — widening the stub signature to
+`(error, *args, **kwargs)` — was a real bug fix (the stub raised `TypeError` on
+the `json_output` kwarg) but **not this bug**, and the 13 failures survived it.
+
+### 2. A module split in two by `sys.modules` surgery — 1 failure
+
+`tests/test_lazy_torchani_import.py` evicted `Auto3D.ASE.thermo` from
+`sys.modules` and re-imported it under an import block, without putting the
+original back. A re-import does not refresh a module; it constructs a **second
+module object with its own globals**, while every
+`from Auto3D.ASE.thermo import helper` elsewhere still points into the first.
+
+The consequence, 182 tests downstream at seed `12345`:
+`test_thermo_helpers.py::TestSymmetryNumber::test_defaulting_warns_prominently`
+patched `thermo._symmetry_default_warned` on the *new* module and then called a
+helper bound to the *old* one, which read the old module's already-tripped flag
+— so no warning was emitted and the assertion failed. The test even carried a
+comment explaining that it isolates itself from that flag. It does; the flag it
+isolates is just not the flag being read.
+
+Found by bisecting the seed-`12345` ordering down to the single triggering
+predecessor (smallest failing tail: 182).
+
+### 3. A process-global start method leaking between tests — a silent skip
+
+`main()` calls `set_start_method("spawn", force=True)` — correct production
+behavior, since forking a worker from a process holding a CUDA context gives the
+child a broken one. But it is **process-wide and outlives the test**, so every
+test that calls `main()` converts the rest of the session to spawn.
+
+`test_parallel_embed.py::test_parallel_embed_reraises_broken_pool` gates itself
+on `mp.get_start_method() != "fork"`. It therefore ran or skipped depending on
+whether a `main()`-calling test was scheduled ahead of it: **skipped under most
+seeds, ran under 999983.** A test that quietly stops testing anything on most
+orderings is worse than one that fails, because the summary still reads green.
+
+This one produced no failure — which is exactly why it had gone unnoticed. It
+showed up only as a pass/skip count that moved between seeds
+(`1227 passed, 10 skipped` vs `1228 passed, 9 skipped`).
+
+## The fixes
+
+`tests/conftest.py`:
+
+1. **`_import_every_auto3d_module_before_any_test`** (session, autouse) —
+   imports all 62 Auto3D modules up front (~1s), so module identity is stable
+   before any test can patch anything. Closes class 1 wholesale rather than the
+   one instance. Tolerates `ImportError` per module, since the optional extras
+   (ani / ase / openeye) are genuinely absent in some environments.
+
+2. **`_fail_on_auto3d_state_a_test_leaves_behind`** (function, autouse) —
+   asserts each test leaves Auto3D's modules as it found them, checking both
+   mechanisms above: a module object replaced in `sys.modules`, and a
+   test-tree-defined object left on a module attribute. Findings are **reported
+   against the guilty test and repaired**, because a detector that only reported
+   would reproduce the very cascade it exists to prevent.
+
+   Ordering is load-bearing: autouse means pytest sets it up before the test's
+   own `monkeypatch`, and finalizers run in reverse — so the check runs *after*
+   `monkeypatch` has undone everything it recorded. What survives to be seen is
+   exactly what `monkeypatch` could not restore.
+
+3. **`_restore_the_multiprocessing_start_method`** (function, autouse) — puts
+   the start method back after each test. Repairs rather than reports: unlike 1
+   and 2, the mutation here is the behavior under test, not a test's mistake.
+
+`tests/test_lazy_torchani_import.py` — restores both the evicted `sys.modules`
+entries and the leaf attributes the re-import rebinds on the parent packages.
+
+`tests/test_conftest_isolation_guards.py` (new) — the guard is now the thing
+keeping this suite's verdict meaningful, so it gets its own test rather than
+being trusted. It drives a real nested pytest session (a temp dir holding a
+copy of `conftest.py`, read at runtime so it cannot drift) against a file of
+deliberately misbehaving tests, and asserts the guard names each of the three
+leak shapes and repairs each one. A guard nobody checks is the same defect class
+the guard exists to catch.
+
+## Verification
+
+- Seed `1351916419`, which failed 13: **1227 → 1228 passed, 0 failed.**
+- Seed `12345`, which failed 1: **0 failed.**
+- **12 seeds swept, one distinct outcome:** `1228 passed, 9 skipped, 67
+  deselected` — every seed, including the two that used to fail.
+- The guard's own test mutation-verified three ways, each naming the right thing:
+  - remove instance detection → *"did not name
+    test_c_leaks_an_instance_of_a_test_defined_class"*
+  - remove module-swap detection → *"did not name
+    test_d_swaps_a_module_in_sys_modules"*
+  - remove the repair → the observer tests fail, so the nested session no longer
+    reports 6 passed
+- The `test_parallel_embed` broken-pool test now runs under every seed instead
+  of skipping under most, so this closed a live coverage hole as well as a
+  flake; it passes three times out of three in isolation.
+- The suite also got ~15% faster (78s → 66s), because tests that had been
+  inheriting `spawn` from an earlier `main()` call now fork.
+
+## What generalizes
+
+**Patch the module that *reads* a name, not the one that defines it.** Patching
+the definition site is correct only if every reader resolves the attribute at
+call time. `from X import y` readers resolve at *import* time, so a lazily
+imported reader can capture a stub and keep it forever, and `monkeypatch` will
+report success.
+
+**Global state that a test mutates must be restored by that test, even when the
+mutation is the production behavior under test.** Class 3 was nobody's bug and
+still cost real coverage.
+
+**A pass/skip count that moves between seeds is a defect report.** It was the
+only visible symptom of class 3, and it is invisible if you compare failure
+counts alone.
+
+**Order-dependence hides behind the local invocation.** The three classes here
+were all invisible under `-p no:randomly`, which is what this repo's own notes
+recommend running. When local and CI invocations differ, the difference is a
+place for defects to live — this session found three others the same way (GPU
+visibility, `FORCE_COLOR`, and random ordering itself).

--- a/.claude/review-manifests/review-2026-08-02-test-order-dependence.md
+++ b/.claude/review-manifests/review-2026-08-02-test-order-dependence.md
@@ -188,20 +188,33 @@ the guard exists to catch.
   the revived broken-pool test, and the lost skip is that same test no longer
   opting out.
 
-## Open recommendation: let CI shuffle
+## Decided: CI stays on a fixed order
 
-The guard added here works in any order, so it earns its keep on CI today: it
-fails a test that leaks even when the leak is not currently causing a failure.
-What CI still cannot see is *order sensitivity itself*, because it runs one fixed
-order.
+`pytest-randomly` was considered for the `dev` extra so CI would exercise order
+variation, and **declined** (maintainer decision, 2026-08-03). CI keeps running
+one fixed collection order.
 
-Adding `pytest-randomly` to the `dev` extra would close that. The argument for:
-12 seeds are now demonstrably stable, and when a shuffle does break something the
-guard names the guilty test instead of leaving 13 unexplained failures. The
-argument against: it introduces a source of CI variation that can turn a build
-red for reasons unrelated to the change under review, and the seed must then be
-read out of the log to reproduce. Left as the maintainer's call rather than
-bundled into this change, whose premise had already needed one correction.
+That decision is worth understanding rather than just recording, because it
+changes what protects this suite. The rejected upside was CI detecting *order
+sensitivity itself*; the cost was a source of CI variation that can redden a
+build for reasons unrelated to the change under review, with the seed to be dug
+out of a log before anything can be reproduced.
+
+What still holds without it:
+
+- `_fail_on_auto3d_state_a_test_leaves_behind` is **order-independent**. It fails
+  a test that leaves state behind even when nothing downstream currently trips
+  over it, so it catches a new leak on CI's fixed order, on the first run, and
+  names the test that caused it. This is the load-bearing guard, not the shuffle.
+- `_import_every_auto3d_module_before_any_test` removes the lazy-import race
+  outright rather than detecting it.
+
+What is genuinely given up: if a *future* defect is order-sensitive in a way that
+leaves no state behind on an `Auto3D.` module — ordering coupled through a
+temp directory, an env var, a logging handler, an RDKit global — CI will not see
+it, and it will surface only when someone runs the suite locally with the plugin
+installed. Worth knowing where the blind spot is: the guard covers Auto3D module
+state, and nothing wider.
 
 ## What generalizes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1238,6 +1238,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into every CLI command (`run`, `energy`, `optimize`, `thermo`, `tautomers`,
   `models test`, and the legacy YAML path).
 
+- **The test suite no longer depends on the order its tests run in.** No
+  shipped behavior changes here, but every CI verdict on this release was
+  carrying an unknown amount of luck, so it is recorded. CI runs `pytest tests/
+  -q -m "not slow"` *without* `-p no:randomly`, so `pytest-randomly` shuffles
+  the order on every run; three runs of that command on one commit produced 0,
+  1 and 13 failures, and `main` failed the same 13 at seed `1351916419`. Three
+  independent causes, all pre-existing:
+
+  - A test patched `Auto3D.cli.errors.handle_error`, but
+    `cli/commands/run.py` copies that function into its own namespace with
+    `from ... import handle_error` at import time, and the CLI imports `run`
+    lazily. Whenever that test was the first to reach the lazy import, `run`
+    captured the stub permanently -- `monkeypatch` restored the module it had
+    patched and could not know a second module had copied the value meanwhile.
+    The leaked stub swallows the exception it is handed, so 13 later tests
+    across six CLI modules saw exit 0 where they expected a non-zero code.
+  - A test evicted `Auto3D.ASE.thermo` from `sys.modules` and re-imported it
+    without restoring the original, which does not refresh a module but builds
+    a second one with its own globals. 182 tests downstream, a thermo test
+    patched a flag on one copy and called a helper bound to the other.
+  - `main()` sets the multiprocessing start method to `spawn` process-wide (a
+    deliberate fix: forking from a CUDA-initialized process breaks the child),
+    which outlived the test that called it. A `parallel_embed` test gates on
+    `get_start_method() != "fork"`, so it *skipped* whenever any
+    `main()`-calling test was scheduled ahead of it -- silently, on most seeds.
+
+  `tests/conftest.py` now imports Auto3D's modules eagerly so module identity
+  is fixed before any test can patch anything, restores the start method after
+  each test, and asserts per test that Auto3D's modules come out as they went
+  in -- naming the guilty test and repairing the damage, rather than letting it
+  surface as unrelated failures later. Twelve seeds now give identical pass and
+  skip counts.
+
 ## [3.5.0] - 2026-06-13
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1239,12 +1239,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `models test`, and the legacy YAML path).
 
 - **The test suite no longer depends on the order its tests run in.** No
-  shipped behavior changes here, but every CI verdict on this release was
-  carrying an unknown amount of luck, so it is recorded. CI runs `pytest tests/
-  -q -m "not slow"` *without* `-p no:randomly`, so `pytest-randomly` shuffles
-  the order on every run; three runs of that command on one commit produced 0,
-  1 and 13 failures, and `main` failed the same 13 at seed `1351916419`. Three
-  independent causes, all pre-existing:
+  shipped behavior changes here, but the suite is how this release is verified,
+  so it is recorded. With `pytest-randomly` installed -- as it is in a typical
+  dev environment, though the repo does not declare it -- `pytest tests/`
+  shuffles the order by default, and three runs of the same commit produced 0,
+  1 and 13 failures. CI does *not* install it, so CI's order is fixed and only
+  one of the three causes below was costing it anything; the other two were
+  latent there, and would surface on CI the first time a test module is added
+  or renamed, with no code change to blame. Three independent causes, all
+  pre-existing:
 
   - A test patched `Auto3D.cli.errors.handle_error`, but
     `cli/commands/run.py` copies that function into its own namespace with
@@ -1262,7 +1265,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     deliberate fix: forking from a CUDA-initialized process breaks the child),
     which outlived the test that called it. A `parallel_embed` test gates on
     `get_start_method() != "fork"`, so it *skipped* whenever any
-    `main()`-calling test was scheduled ahead of it -- silently, on most seeds.
+    `main()`-calling test was scheduled ahead of it -- which in CI's fixed order
+    was every run. This is the one cause that was costing CI real coverage, and
+    the CI skip count dropping from 2 to 1 is the evidence.
 
   `tests/conftest.py` now imports Auto3D's modules eagerly so module identity
   is fixed before any test can patch anything, restores the start method after

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ neural network models, avoiding redundant loading across tests.
 """
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -62,6 +63,214 @@ def smiles10_path():
 def cyclooctane_path():
     """Path to cyclooctane.sdf test file."""
     return str(FILES_DIR / "cyclooctane.sdf")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _import_every_auto3d_module_before_any_test():
+    """Import all of Auto3D up front so no module is first imported while a
+    test has a source module patched.
+
+    ``from Auto3D.cli.errors import handle_error`` copies the function object
+    into the importing module's namespace at *import* time. Auto3D's CLI
+    imports many of its own modules lazily (inside functions, to keep
+    ``auto3d --help`` fast). Put those two facts together with a test that does
+    ``monkeypatch.setattr("Auto3D.cli.errors.handle_error", stub)`` and the
+    result depends on which test ran first:
+
+    * if some earlier test already imported ``Auto3D.cli.commands.run``, that
+      module holds the real ``handle_error`` and the patch is undone cleanly;
+    * if this test is the first to reach the lazy import, ``run`` binds the
+      *stub* permanently. ``monkeypatch`` restores ``Auto3D.cli.errors``, which
+      it patched, and cannot know that ``run`` copied the value meanwhile.
+
+    A leaked ``handle_error`` stub swallows the exception it is handed, so
+    every later test that expects a non-zero exit code sees exit 0. That is
+    what made this suite order-dependent: three runs of CI's own command
+    (``pytest tests/ -q -m "not slow" --continue-on-collection-errors``, which
+    unlike the local habit does *not* pass ``-p no:randomly``) produced 0, 1
+    and 13 failures purely by ``pytest-randomly`` seed, and seed 1351916419
+    failed 13 tests across six CLI modules on ``main``.
+
+    Importing everything first makes module identity stable before any test can
+    patch anything, which closes the whole class rather than the one instance.
+    Companion to :func:`_fail_on_auto3d_state_a_test_leaves_behind`, which
+    catches any future instance instead of letting it resurface as N unrelated
+    failures on an unlucky seed.
+
+    ``ImportError`` is tolerated per module because the optional extras (ani /
+    ase / openeye) are genuinely absent in some environments; anything else is
+    a real defect and propagates. The dedicated ``pytest tests/ --collect-only``
+    CI step remains the check that no *test* module fails to import.
+    """
+    import importlib
+    import pkgutil
+
+    import Auto3D
+
+    for module in pkgutil.walk_packages(Auto3D.__path__, prefix="Auto3D."):
+        try:
+            importlib.import_module(module.name)
+        except ImportError:
+            continue
+
+
+def _defining_file(obj) -> str | None:
+    """Best-effort path of the file that defined ``obj``, or None.
+
+    Instances resolve to the file that defined their *class*, so a stub object
+    (``_StubAdapter()``, the shape these tests reach for most often) is
+    attributed to the test module that declared the class, not left unattributed
+    for having no ``__code__`` of its own.
+    """
+    code = getattr(obj, "__code__", None)
+    if code is not None:  # plain function, lambda, or unbound method
+        return code.co_filename
+    func = getattr(obj, "__func__", None)  # bound method
+    if func is not None and getattr(func, "__code__", None) is not None:
+        return func.__code__.co_filename
+    cls = obj if isinstance(obj, type) else type(obj)
+    return getattr(sys.modules.get(cls.__module__, None), "__file__", None)
+
+
+def _is_defined_in_the_test_tree(obj) -> bool:
+    origin = _defining_file(obj)
+    if origin is None:
+        return False
+    try:
+        Path(origin).relative_to(TEST_DIR)
+    except ValueError:
+        return False
+    return True
+
+
+def _auto3d_modules():
+    for name, module in list(sys.modules.items()):
+        if module is not None and (name == "Auto3D" or name.startswith("Auto3D.")):
+            yield name, module
+
+
+@pytest.fixture(autouse=True)
+def _fail_on_auto3d_state_a_test_leaves_behind(request):
+    """Fail a test that does not leave Auto3D's modules as it found them.
+
+    The failure mode this exists for is invisible at the scene of the crime:
+    the leaking test passes, and the damage lands on whichever tests happen to
+    run afterwards -- as an exit code of 0 where 2 was expected, with nothing in
+    the output pointing at the cause. Six modules' worth of CLI tests failed
+    that way (see :func:`_import_every_auto3d_module_before_any_test`) and the
+    cause took a seeded bisect to find.
+
+    So rather than trust the eager import to hold forever, check the invariant
+    directly, in the two forms it has been broken:
+
+    1. a module object under ``Auto3D.`` replaced in ``sys.modules`` -- which
+       splits it in two, since a re-import builds a second module with its own
+       globals while existing ``from Auto3D.x import y`` references keep
+       pointing into the first;
+    2. an object defined in this repository's ``tests/`` tree left on an
+       ``Auto3D.`` module attribute.
+
+    Anything found is both **reported against the test that left it** and
+    **put back**, because a detector that only reports would reproduce the
+    very cascade it exists to prevent -- one leak, then a failure in every
+    test that follows. Repair is limited to what is flagged here: module state
+    a test legitimately mutates (caches, lazily built globals) is left alone,
+    since this fixture cannot tell a deliberate change from an accidental one
+    and guessing would break tests that rely on it.
+
+    Ordering is load-bearing. This fixture is autouse, so pytest sets it up
+    before the test's own ``monkeypatch``, and finalizers run in reverse -- the
+    check therefore runs *after* ``monkeypatch`` has undone everything it
+    recorded. What survives to be seen here is exactly what ``monkeypatch``
+    could not restore.
+    """
+    before_modules = dict(_auto3d_modules())
+    before_attrs = {name: dict(vars(module)) for name, module in before_modules.items()}
+
+    yield
+
+    leaked = []
+
+    # (1) A module object swapped for a different one. Evicting a module from
+    #     sys.modules and re-importing it does not refresh it -- it builds a
+    #     second module object with its own globals, while every
+    #     `from Auto3D.x import helper` elsewhere still points into the first.
+    #     Patching a global on one copy then has no effect on the other, which
+    #     is a defect no amount of attribute checking below can see, because
+    #     both copies' attributes come from src/.
+    for name, original in before_modules.items():
+        current = sys.modules.get(name)
+        if current is original:
+            continue
+        leaked.append(
+            f"sys.modules[{name!r}] is a different module object than before "
+            f"this test ({'removed' if current is None else 'replaced'})"
+        )
+        sys.modules[name] = original
+        parent_name, _, leaf = name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None and getattr(parent, leaf, None) is not original:
+            setattr(parent, leaf, original)
+
+    # (2) A test-local object left on a module Auto3D still uses.
+    for name, module in _auto3d_modules():
+        original_attrs = before_attrs.get(name, {})
+        for attr, value in list(vars(module).items()):
+            if attr.startswith("__") or original_attrs.get(attr) is value:
+                continue
+            if not _is_defined_in_the_test_tree(value):
+                continue
+            leaked.append(
+                f"{name}.{attr} = {value!r}\n      defined in {_defining_file(value)}"
+            )
+            if attr in original_attrs:
+                setattr(module, attr, original_attrs[attr])
+            else:
+                delattr(module, attr)
+
+    assert not leaked, (
+        f"{request.node.nodeid} did not leave Auto3D's modules as it found "
+        "them (repaired, so the tests after this one are unaffected). What a "
+        "test leaves behind is inherited by whatever runs next, so without "
+        "this check the failure surfaces somewhere else entirely. Patch the "
+        "module that *reads* a name rather than the one that defines it, and "
+        "restore anything removed from sys.modules:\n    "
+        + "\n    ".join(leaked)
+    )
+
+
+@pytest.fixture(autouse=True)
+def _restore_the_multiprocessing_start_method():
+    """Put the process-wide multiprocessing start method back after each test.
+
+    ``main()`` deliberately calls ``set_start_method("spawn", force=True)`` --
+    forking a worker from a process that already holds a CUDA context gives the
+    child a broken one. That is correct production behavior, but it is
+    *process-wide* and outlives the test that triggered it, so every test which
+    calls ``main()`` (even with a stubbed orchestrator) silently converts the
+    rest of the session to spawn.
+
+    What that cost: ``test_parallel_embed_reraises_broken_pool`` gates itself on
+    ``mp.get_start_method() != "fork"``, so it ran or skipped depending on
+    whether any ``main()``-calling test happened to be scheduled ahead of it --
+    skipped under most ``pytest-randomly`` seeds, ran under seed 999983. A test
+    that quietly stops testing anything on most orderings is worse than one that
+    fails, because the summary still says green.
+
+    Restoring rather than reporting, because unlike the leaks
+    :func:`_fail_on_auto3d_state_a_test_leaves_behind` catches, the mutation here
+    is the behavior under test, not a mistake in the test.
+    """
+    import multiprocessing as mp
+
+    previous = mp.get_start_method(allow_none=True)
+    yield
+    if mp.get_start_method(allow_none=True) == previous:
+        return
+    # allow_none=True returns None only before anything has fixed the method;
+    # there is no way to put that "unset" state back, so restore the platform
+    # default, which is what an unset method would have resolved to anyway.
+    mp.set_start_method(previous or mp.get_all_start_methods()[0], force=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_conftest_isolation_guards.py
+++ b/tests/test_conftest_isolation_guards.py
@@ -1,0 +1,124 @@
+"""The isolation guards in conftest.py are load-bearing; test them.
+
+``_fail_on_auto3d_state_a_test_leaves_behind`` is what keeps this suite's result
+independent of the order its tests run in. If it silently stopped detecting
+anything -- an edit to ``_defining_file``, a change in fixture ordering that put
+the check before ``monkeypatch``'s undo -- the suite would go straight back to
+producing 0, 1 or 13 failures by ``pytest-randomly`` seed with nothing to say
+why, and no test would fail to tell us. A guard nobody checks is the same defect
+class the guard exists to catch.
+
+So it is exercised against a real nested pytest session: a temporary directory
+holding a *copy of this repo's conftest.py* (read at runtime, so it cannot drift
+from the real one) plus a file of deliberately misbehaving tests. One
+subprocess covers every case, because each nested session pays for importing
+torch and eagerly importing Auto3D.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+CONFTEST = Path(__file__).with_name("conftest.py")
+
+# Each leaking test below *passes*; the guard reports at teardown, which pytest
+# renders as an error against that test. The observers after each leak prove the
+# guard repaired what it found, so the cascade stops at the guilty test.
+_MISBEHAVING_TESTS = '''\
+import sys
+
+
+def _leaked_function(*a, **k):
+    pass
+
+
+class _LeakedStubClass:
+    pass
+
+
+def test_a_leaks_a_function():
+    import Auto3D.cli.errors as errors_mod
+    errors_mod.handle_error = _leaked_function
+
+
+def test_b_sees_the_function_leak_repaired():
+    import Auto3D.cli.errors as errors_mod
+    assert errors_mod.handle_error is not _leaked_function
+
+
+def test_c_leaks_an_instance_of_a_test_defined_class():
+    import Auto3D.model_factory as factory
+    factory.create_model = _LeakedStubClass()
+
+
+def test_d_swaps_a_module_in_sys_modules():
+    del sys.modules["Auto3D.ASE.thermo"]
+    import Auto3D.ASE.thermo  # noqa: F401
+
+
+def test_e_sees_the_module_swap_repaired():
+    import Auto3D.ASE.thermo as thermo
+    from Auto3D.ASE.thermo import _symmetry_number
+    assert _symmetry_number.__globals__ is vars(thermo), (
+        "the module is still split in two: a helper's globals are not the "
+        "globals of the module object in sys.modules"
+    )
+
+
+def test_f_leaves_auto3d_alone():
+    import Auto3D.cli.errors  # noqa: F401
+    assert True
+'''
+
+_GUILTY = (
+    "test_a_leaks_a_function",
+    "test_c_leaks_an_instance_of_a_test_defined_class",
+    "test_d_swaps_a_module_in_sys_modules",
+)
+
+
+def test_the_guard_names_every_test_that_leaves_state_behind(tmp_path):
+    """Three leak shapes are each reported against the test that caused it, and
+    each is repaired so the test after it sees clean state.
+
+    Mutation-checked: dropping either branch of the guard's teardown, or the
+    repair, turns specific lines below red -- removing the repair makes the
+    observers (``test_b``/``test_e``) fail, and removing a detection branch
+    drops its name from the error list.
+    """
+    (tmp_path / "conftest.py").write_text(CONFTEST.read_text())
+    (tmp_path / "test_misbehaving.py").write_text(_MISBEHAVING_TESTS)
+
+    proc = subprocess.run(
+        [
+            sys.executable, "-m", "pytest", "test_misbehaving.py",
+            # The nested session asserts on ordering (leak first, observer
+            # second), so it must not be shuffled. addopts is cleared because
+            # this repo's -v/--tb=short/-m markers do not apply here, and
+            # -p no:cacheprovider keeps a .pytest_cache out of tmp_path.
+            "-p", "no:randomly", "-p", "no:cacheprovider", "-o", "addopts=", "-q",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    out = proc.stdout + proc.stderr
+
+    # Every test body passes, including the leaking ones -- the observers among
+    # them (test_b, test_e) pass only because the guard repaired what it found,
+    # so this is also the assertion that fails if the repair is dropped.
+    assert "6 passed" in out, f"the nested session did not run as expected:\n{out}"
+    # Named individually before the total, so a shape the guard stops detecting
+    # is identified by name rather than reported as an off-by-one in a count.
+    for name in _GUILTY:
+        assert f"ERROR at teardown of {name}" in out, (
+            f"the guard did not name {name} as the test that leaked:\n{out}"
+        )
+    assert "ERROR at teardown of test_f_leaves_auto3d_alone" not in out, (
+        f"the guard fired on a test that only imported a module:\n{out}"
+    )
+    assert "3 errors" in out, (
+        f"expected exactly one teardown error per leaking test, and no others:\n{out}"
+    )

--- a/tests/test_lazy_torchani_import.py
+++ b/tests/test_lazy_torchani_import.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 import builtins
 import sys
 
+# Module names this test evicts from sys.modules so their module-level code
+# re-runs under the import block.
+_RELOADED = ("Auto3D.ASE.thermo", "Auto3D.batch_opt.ANI2xt_no_rep")
+
 
 def test_thermo_imports_with_torchani_blocked(monkeypatch):
     """Importing Auto3D.ASE.thermo (and using its pure-Python helpers) must work
@@ -17,18 +21,42 @@ def test_thermo_imports_with_torchani_blocked(monkeypatch):
             raise ImportError("torchani blocked for this test")
         return real_import(name, *args, **kwargs)
 
-    # Drop cached copies so the re-import re-runs module-level code under the block.
-    for mod in list(sys.modules):
-        if mod.startswith("Auto3D.ASE.thermo") or mod.startswith(
-            "Auto3D.batch_opt.ANI2xt_no_rep"
-        ):
-            sys.modules.pop(mod, None)
+    # Drop cached copies so the re-import re-runs module-level code under the
+    # block -- then put the originals back, because a re-import does not just
+    # refresh a module, it creates a *second* module object with its own
+    # globals. Other test modules hold `from Auto3D.ASE.thermo import helper`
+    # references bound to the first object, so leaving the second one in
+    # sys.modules splits the module in two: a later test that patches
+    # `thermo._symmetry_default_warned` patches the new module's global while
+    # the helper it then calls reads the old module's. That is invisible here
+    # and fails somewhere else -- it cost seed 12345 a failure in
+    # test_thermo_helpers.py, 182 tests downstream of this one, with nothing in
+    # the output pointing back here.
+    saved_modules = {name: sys.modules[name] for name in _RELOADED if name in sys.modules}
+    # A re-import also rebinds the leaf attribute on the parent package
+    # (`Auto3D.ASE.thermo`), which is how `import Auto3D.ASE; Auto3D.ASE.thermo`
+    # resolves, so that needs restoring too.
+    saved_parent_attrs = {}
+    for name in saved_modules:
+        parent_name, _, leaf = name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None and hasattr(parent, leaf):
+            saved_parent_attrs[(parent, leaf)] = getattr(parent, leaf)
+
+    for name in saved_modules:
+        del sys.modules[name]
 
     monkeypatch.setattr(builtins, "__import__", blocked_import)
 
-    import Auto3D.ASE.thermo as thermo  # must NOT raise ModuleNotFoundError  # noqa: I001
+    try:
+        import Auto3D.ASE.thermo as thermo  # must NOT raise ModuleNotFoundError  # noqa: I001
 
-    from rdkit import Chem
+        from rdkit import Chem
 
-    # A pure-Python helper that does not touch torchani must work.
-    assert thermo._symmetry_number(Chem.MolFromSmiles("CCO")) == 1
+        # A pure-Python helper that does not touch torchani must work.
+        assert thermo._symmetry_number(Chem.MolFromSmiles("CCO")) == 1
+    finally:
+        for name, module in saved_modules.items():
+            sys.modules[name] = module
+        for (parent, leaf), module in saved_parent_attrs.items():
+            setattr(parent, leaf, module)


### PR DESCRIPTION
Three genuine test-isolation defects, found by running CI's argument list locally under a shuffled order. **No shipped behavior changes — `src/` is untouched.**

> **Correction to an earlier draft of this description.** It claimed CI runs the suite under `pytest-randomly` and was therefore producing verdicts by luck. That is wrong, and the check is one line of any CI log: `plugins: cov-7.1.0, anyio-4.14.2`. `pytest-randomly` is not in the `dev` extra, so it reaches a developer's environment and not the runner. The 0/1/13-failure spread came from running CI's argument list **locally**. What each cause actually did:
>
> | | locally, shuffled | on CI, fixed order |
> |---|---|---|
> | cause 1 (captured stub) | 13 failures on unlucky seeds | latent, not firing |
> | cause 2 (split module) | 1 failure on seed `12345` | latent, not firing |
> | cause 3 (leaked start method) | skipped on most seeds | **skipped every run** |
>
> Causes 1 and 2 are latent on CI rather than fixed: its order is stable only until a test module is added or renamed, at which point the same 13 failures appear with nothing in the diff to blame. Cause 3 was costing CI coverage every run, and the numbers below are the receipt.

### 1. A stub captured permanently by a lazy import — 13 failures locally

`tests/test_config_parity.py` patches the module that *defines* a function:

```python
monkeypatch.setattr("Auto3D.cli.errors.handle_error", _capture)
```

`src/Auto3D/cli/commands/run.py:16` copies that function into its own namespace at import time, and the CLI imports `run` **lazily**:

```python
from Auto3D.cli.errors import handle_error, handle_interrupt, job_directory_hint
```

So the outcome depended on who got there first. If an earlier test had already imported `run`, it held the real function and `monkeypatch` restored cleanly. If this test was first to reach the lazy import, `run` bound the **stub permanently** — `monkeypatch` restores the module it patched and cannot know a second module copied the value meanwhile. The leaked stub swallows the exception it is handed, so **13 later tests across six CLI modules saw exit 0 where they expected a non-zero code**, none of them near the cause.

Proven directly rather than inferred:

```
run in sys.modules AFTER: True
run.handle_error is the stub: True
```

Note: the fix made earlier to this same stub — widening its signature to accept `json_output` — was a real bug, but **not this one**. The 13 failures survived it.

### 2. A module split in two by `sys.modules` surgery — 1 failure locally

`tests/test_lazy_torchani_import.py` evicted `Auto3D.ASE.thermo` and re-imported it under an import block without restoring the original. A re-import does not refresh a module; it builds a **second module object with its own globals**, while every `from Auto3D.ASE.thermo import helper` elsewhere still points into the first.

182 tests downstream at seed `12345`, `test_thermo_helpers.py::TestSymmetryNumber::test_defaulting_warns_prominently` patched `_symmetry_default_warned` on the *new* copy and then called a helper bound to the *old* one, which read the old module's already-tripped flag. The test carries a comment explaining that it isolates itself from that flag — it does; the flag it isolates just is not the one being read.

### 3. A process-global start method leaking between tests — a silent skip on every CI run

`main()` sets the multiprocessing start method to `spawn` process-wide, which is correct (forking from a CUDA-initialized process gives the child a broken context) but **outlives the test that called it**. `test_parallel_embed_reraises_broken_pool` gates on `get_start_method() != "fork"`, so it ran or skipped depending on whether any `main()`-calling test was scheduled ahead of it.

This produced no failure, which is why it went unnoticed. Its only symptoms were a pass/skip count that moved between seeds locally, and a `2` in CI's skip column that nobody had reason to look at.

## The fixes

`tests/conftest.py` gains three fixtures:

1. **`_import_every_auto3d_module_before_any_test`** (session) — imports all 62 Auto3D modules up front (~1s), fixing module identity before any test can patch anything. Closes class 1 wholesale rather than the one instance. Tolerates `ImportError` per module, since the optional extras are genuinely absent in some environments.
2. **`_fail_on_auto3d_state_a_test_leaves_behind`** — asserts each test leaves Auto3D's modules as it found them, checking both a module object replaced in `sys.modules` and a test-tree-defined object left on a module attribute. Findings are **reported against the guilty test and repaired**, because a detector that only reported would reproduce the very cascade it exists to prevent. Its autouse ordering is load-bearing: pytest sets it up before the test's own `monkeypatch`, and finalizers run in reverse, so the check sees exactly what `monkeypatch` could not restore. This one earns its keep on CI today regardless of ordering — it fails a test that leaks even when the leak is not currently causing a failure.
3. **`_restore_the_multiprocessing_start_method`** — repairs rather than reports, because unlike 1 and 2 the mutation is the behavior under test, not a test's mistake.

`tests/test_conftest_isolation_guards.py` (new) — that guard is now what keeps this suite's verdict meaningful, so it gets its own test rather than being trusted. It drives a real nested pytest session against a runtime copy of `conftest.py` and a file of deliberately misbehaving tests. A guard nobody checks is the same defect class the guard exists to catch.

## Verification

- **On CI, against the `main` baseline at `02fba12`** (`1234 passed, 2 skipped`): **`1236 passed, 1 skipped`**. The two added passes are the new guard test and the revived broken-pool test; the lost skip is that same test no longer opting out.
- Seed `1351916419`, which failed 13: **0 failed.** Seed `12345`, which failed 1: **0 failed.**
- **12 seeds swept locally, one distinct outcome:** `1228 passed, 9 skipped, 67 deselected` on every one.
- Green under `FORCE_COLOR=1` (as GitHub Actions sets it) and with GPUs visible.
- The guard's own test mutation-verified three ways, each naming the right thing: removing instance detection → *"did not name test_c_leaks_an_instance_of_a_test_defined_class"*; removing module-swap detection → *"did not name test_d_swaps_a_module_in_sys_modules"*; removing the repair → the observer tests fail.
- The broken-pool test passes 3/3 in isolation.
- The suite is ~15% faster (78s → 66s), because tests that had been inheriting `spawn` now fork.

## Open recommendation, deliberately not bundled here

Adding `pytest-randomly` to the `dev` extra would let CI see order sensitivity at all, instead of running one fixed order. **For:** 12 seeds are now demonstrably stable, and when a shuffle does break something the guard names the guilty test rather than leaving 13 unexplained failures. **Against:** it adds a source of CI variation that can turn a build red for reasons unrelated to the change under review, and the seed then has to be read out of the log to reproduce. Left as a maintainer call.

## What generalizes

**Patch the module that *reads* a name, not the one that defines it.** Patching the definition site is correct only if every reader resolves the attribute at call time; `from X import y` readers resolve at *import* time, so a lazily imported reader can capture a stub and keep it forever while `monkeypatch` reports success.

**A pass/skip count that moves is a defect report.** It was the only visible symptom of cause 3, and it is invisible if you compare failure counts alone.

**Read the `plugins:` line before reasoning about what a test run did.** It is in every pytest header. Assuming local and CI load the same set is what produced the claim corrected at the top of this description — the local suite loaded six plugins, CI loaded two, and the one that mattered was in the difference.