### PR TITLE
fix: four defects that delete a molecule or contradict the output record

### DIFF
--- a/.claude/review-manifests/review-2026-08-02-hunt-chemistry.md
+++ b/.claude/review-manifests/review-2026-08-02-hunt-chemistry.md
@@ -277,7 +277,12 @@ symmetry element.
 
 ## Minor
 
-### m1. `src/Auto3D/filtering.py:60-81` — duplicates escape across an energy-cluster boundary — DEMONSTRATED
+### m1. `src/Auto3D/filtering.py:60-81` — duplicates escape across an energy-cluster boundary — DEMONSTRATED — **FIXED 2026-08-03**
+
+> A run now ends only where the energy gap to the *previous* molecule exceeds the
+> duplicate tolerance, which no duplicate pair can straddle, so the result is
+> identical to comparing every pair. `energy_cluster_window` survives as a
+> performance knob that cannot become a correctness hole.
 
 `filter_unique_optimized` clusters by energy first and only RMSD-compares *within* a
 cluster, so a duplicate pair straddling a boundary is never compared. Three
@@ -291,7 +296,16 @@ E - (-100) = [0.0, 0.099999, 0.100001]  -> filter kept 3/3   <-- duplicates surv
 The last two differ by 2×10⁻⁶ eV. Consequence: a `k=5` request can return 5 slots
 filled by 2 distinct structures. The legacy O(n²) `filter_unique` is unaffected.
 
-### m2. `src/Auto3D/batch_opt/optimization_engine.py:212, 234-235, 277-284` — `Converged` and `fmax` in the output SDF are mutually inconsistent — DEMONSTRATED
+### m2. `src/Auto3D/batch_opt/optimization_engine.py:212, 234-235, 277-284` — `Converged` and `fmax` in the output SDF are mutually inconsistent — DEMONSTRATED — **FIXED 2026-08-03**
+
+> The force criterion is now tested *before* the FIRE step, so a structure that
+> has met it keeps the geometry its force was measured at. Convergence decisions
+> are unchanged and still-active trajectories are bit-identical.
+>
+> The silent-fallbacks sweep examined these same lines and dismissed them as
+> numerically negligible (its L7). That dismissal is now retracted in
+> `review-2026-08-02-hunt-silent-fallbacks.md`: it assumed `v = 0`, and this
+> sweep's numbers over a range of stiffnesses were right.
 
 Convergence is decided from the **pre-step** force (`not_converged_post1 = fmax >
 opttol`, line 212), one more FIRE step is then taken (line 209), and `fmax` is
@@ -308,7 +322,13 @@ Energy consequence is small (<0.05 kcal/mol for realistic stiffness), but a cons
 filtering on `fmax <= 0.01` gets a different set than one filtering on
 `Converged == "True"`, and the SDF asserts both.
 
-### m3. `src/Auto3D/ranking.py:50, 163, 203` — RMSD dedup runs *between diastereomers* — MEASURED
+### m3. `src/Auto3D/ranking.py:50, 163, 203` — RMSD dedup runs *between diastereomers* — MEASURED — **FIXED 2026-08-03**
+
+> A pair must now also be the same compound, keyed on stereochemistry perceived
+> from the coordinates (`utils.stereo_check.species_key`). Applied to both
+> filters, since the legacy `utils.chemistry.filter_unique` carried the identical
+> criterion and would have left the defect reachable through
+> `ConformerRanker(use_optimized_filtering=False)`.
 
 `species_id` strips `<isomer>_<conformer>`, so all enumerated stereoisomers of one
 input share a group, and `_filter_mols` then runs heavy-atom `GetBestRMS` across

--- a/.claude/review-manifests/review-2026-08-02-hunt-silent-fallbacks.md
+++ b/.claude/review-manifests/review-2026-08-02-hunt-silent-fallbacks.md
@@ -234,7 +234,13 @@ processed fewer molecules than the file contains. The same blindness applies to
 molecule count and the exit code both assert completeness. The C7 reconciliation is
 explicitly the mechanism that is supposed to make a lost molecule visible.
 
-## M4. `src/Auto3D/workflow_workers.py:269-274` — `except Exception: … continue` drops an entire chunk — REASONED
+## M4. `src/Auto3D/workflow_workers.py:269-274` — `except Exception: … continue` drops an entire chunk — REASONED — **FIXED 2026-08-03**
+
+> Fixed at the collector rather than this call site: `logger_process` now sends
+> WARNING and above to stderr as well as the run log, so every worker diagnostic
+> reaches the user — including the sibling "no optimized structures were
+> produced" warning, which was equally invisible. INFO stays in the log file, and
+> stdout stays clean for `--json`.
 
 ```python
 except Exception:
@@ -271,6 +277,35 @@ asked to look for. (`job_directory_hint` does point at the directory.)
 **L6. `chunk_manager.py:101` vs `ASE/geometry.py:134` — `batchsize_atoms` means two different things.** REASONED. `main()` multiplies it by detected memory (`batchsize_atoms * memory_gb`), `opt_geometry` uses it absolutely. On an 80 GB card the same value is 80x apart between the two entry points. Memory/performance only.
 
 **L7. `batch_opt/optimization_engine.py:277-284` — `Converged` and `fmax` describe different geometries.** REASONED. Energy and fmax are recomputed at the final geometry after the loop; `converged_mask` (which becomes the `Converged` SD property) is not re-evaluated, so `Converged=True` describes the force *before* the last FIRE step while the reported `fmax` and coordinates describe the one after. With `v = 0` on a just-converged structure the step is `dt²·f ≤ 1e-4 Å`, so the discrepancy is numerically negligible. Recorded for completeness, not as a defect.
+
+> **RETRACTED 2026-08-03 — this dismissal was wrong, and the chemistry sweep's
+> m2 (same lines) was right.** The "numerically negligible" estimate assumes
+> `v = 0`, which is true only of a structure on its first step; FIRE reaches its
+> convergence step carrying accumulated velocity, and the displacement is not
+> bounded by `dt²·f`. Measured on a hermetic harmonic potential, `E = k·Σx²`,
+> `opttol = 0.01 eV/Å`, across three stiffnesses:
+>
+> | k | reported fmax beside `Converged=True` | × tolerance |
+> |---|---|---|
+> | 1 | 0.0012 – 0.0072 | 0.1 – 0.7 |
+> | 10 | 0.0023 – 0.0052 | 0.2 – 0.5 |
+> | 100 | 0.0040 – 0.0692 | 0.4 – **6.9** |
+>
+> The estimate holds for soft potentials and fails for stiff ones, which is the
+> trap: a single soft test case shows the defect as negligible and it gets
+> dismissed. **Two sweeps looked at these same lines and reached opposite
+> conclusions**; the one that ran numbers over a range was right, and the one
+> that reasoned from a favorable special case was not.
+>
+> Fixed 2026-08-03 by testing the force criterion *before* the FIRE step instead
+> of after, so a structure that has met the criterion keeps the geometry its force
+> was measured at. Note what was NOT done: re-deriving `Converged` from the final
+> recomputed force would flip structures to `Converged=False`, and
+> `converged_or_unfiltered` **drops** those — trading a mislabeled record for a
+> silently deleted conformer. Trajectories of still-active structures are
+> bit-identical before and after (verified by hashing final coordinates for a run
+> where nothing converges), and convergence decisions are unchanged, because the
+> reordering moves the same comparison across the same forces.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1238,6 +1238,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into every CLI command (`run`, `energy`, `optimize`, `thermo`, `tautomers`,
   `models test`, and the legacy YAML path).
 
+- **Duplicate removal no longer deletes a distinct stereoisomer.** Both
+  conformer filters treated a pair as duplicates on heavy-atom RMSD plus an
+  energy check, with nothing asking whether the two were the same compound.
+  `ranking.species_id` strips `<isomer>_<conformer>`, so every enumerated
+  stereoisomer of one input arrives in one group, and `GetBestRMS` between two
+  diastereomers of a 1,4-disubstituted ring is small: **0.300 Å** measured
+  between cis- and trans-4-*tert*-butylcyclohexanol, 0.335 Å for
+  cyclohexane-1,4-diol, both at or below the 0.3 Å default `threshold`. Only the
+  0.23 kcal/mol duplicate-energy tolerance stood between them and a collapse, and
+  ring diastereomers that close are ordinary — so raising `--threshold`, a
+  documented knob, could make one of two distinct compounds vanish from the
+  output with nothing logged. A pair must now also *be the same compound*, judged
+  by stereochemistry perceived from the coordinates
+  (`Auto3D.utils.stereo_check.species_key`) rather than from tags that a foreign
+  SDF may not carry. Applied to `filter_unique_optimized` **and** the legacy
+  `utils.chemistry.filter_unique`, so the defect is not still reachable through
+  `ConformerRanker(use_optimized_filtering=False)`. No effect on single-isomer
+  inputs, where every conformer has the same key.
+
+- **A duplicate pair can no longer escape by straddling an energy boundary.**
+  `filter_unique_optimized` grouped molecules by energy and only RMSD-compared
+  within a group, measuring each against its group's *minimum*. Two molecules
+  2×10⁻⁶ eV apart could therefore land in different groups — one just inside the
+  window, the next just outside — and never be compared at all: three
+  bit-identical geometries at 0.0 / 0.099999 / 0.100001 eV all survived, which is
+  how a `k=5` request returned five slots holding two distinct structures. A
+  group now ends only where the gap to the *previous* molecule exceeds the
+  duplicate energy tolerance, which no duplicate pair can straddle, making the
+  result identical to comparing every pair. `energy_cluster_window` keeps its
+  meaning as a performance knob and can no longer become a correctness hole.
+
+- **`Converged` and `fmax` in the output SDF now describe the same geometry.**
+  The optimizer decided convergence from the force measured *before* its last
+  FIRE step and then took that step anyway, while `fmax` is recomputed at the
+  final geometry — so one record asserted both a convergence flag for one
+  geometry and a force for another. A consumer filtering on `fmax <= opt_tol` and
+  one filtering on `Converged == "True"` got different sets from the same file.
+  Measured on a harmonic potential at `opt_tol = 0.01 eV/Å`, `Converged=True`
+  came back beside fmax up to **6.9× the tolerance**; the discrepancy grows with
+  stiffness, which is why a soft test case shows it as negligible. The force
+  criterion is now tested before the step, and a structure that has met it keeps
+  the geometry its force was measured at. Convergence decisions are unchanged and
+  the trajectory of every still-moving structure is bit-identical; only the
+  reported geometry of a converged structure moves, back by the one step that
+  used to follow its own measurement. Deriving the flag from the final force
+  instead was rejected: it would flip structures to `Converged=False`, which the
+  filters **drop**, trading a wrong label for a deleted conformer.
+
+- **A failed chunk now says why on stderr, not only in the run log.** Worker
+  processes log through a `QueueHandler` whose collector had a `FileHandler` as
+  its only destination, so a chunk that died wrote its traceback to
+  `<job_dir>/Auto3D.log` and told the user nothing. The *loss* was reported —
+  reconciliation names the missing molecules and the run exits 6 — but the
+  *cause* was not, so a systematic bug failing every chunk identically was
+  indistinguishable from a batch of hard molecules and read as "N molecules
+  produced no conformer". WARNING and above now also go to stderr (keeping
+  stdout clean for `--json`); INFO stays in the run log, where the step-by-step
+  narrative belongs. Fixed at the collector, so it covers every worker
+  diagnostic rather than the one call site — including the sibling "no optimized
+  structures were produced" warning, which was equally invisible.
+
 - **The test suite no longer depends on the order its tests run in.** No
   shipped behavior changes here, but the suite is how this release is verified,
   so it is recorded. With `pytest-randomly` installed -- as it is in a typical

--- a/src/Auto3D/batch_opt/optimization_engine.py
+++ b/src/Auto3D/batch_opt/optimization_engine.py
@@ -208,14 +208,34 @@ def n_steps(
         # optimizer step also keeps padded atoms from drifting.
         pad_mask = ~atom_mask_subset.unsqueeze(-1)
         f = f.masked_fill(pad_mask, 0.0)
+        fmax = f.norm(dim=-1).max(dim=-1)[
+            0]  # Tensor, Norm is the length of each vector. Here it returns the maximum force length for each conformer. Size (100)
+        not_converged_post1 = fmax > opttol
         # Detach the optimizer output so the next step starts from a leaf tensor.
         # Production adapters return detached forces, so coord never tracks grad
         # across steps; detaching here makes the loop robust to NNPs whose forces
         # still carry a grad graph (otherwise the next requires_grad_ would error).
-        coord = optimizer(coord, f).detach()
-        fmax = f.norm(dim=-1).max(dim=-1)[
-            0]  # Tensor, Norm is the length of each vector. Here it returns the maximum force length for each conformer. Size (100)
-        not_converged_post1 = fmax > opttol
+        stepped = optimizer(coord, f).detach()
+        # A structure that has just met the force criterion keeps the geometry its
+        # force was measured at; only the ones still moving take the step.
+        #
+        # The convergence test above and the step used to run in the other order,
+        # so every structure took one more FIRE step *after* the force that
+        # declared it converged. `Converged` then described the geometry before
+        # that step while the reported `fmax` (recomputed at the end of this
+        # function) described the geometry after it -- and `batchopt` writes both
+        # onto the same record. A consumer filtering on `fmax <= opt_tol` and one
+        # filtering on `Converged == "True"` got different sets from one file.
+        # Measured on a hermetic harmonic potential before this change: fmax up to
+        # 6.9x the tolerance beside `Converged=True`. The discrepancy grows with
+        # stiffness, so a soft test case hides it entirely -- which is how it
+        # survived being looked at twice.
+        #
+        # Structures leaving the active set as oscillating are stepped like any
+        # other: they are reported `Converged=False`, so no consistency is claimed
+        # for them, and the end-of-function recompute makes their `fmax` match
+        # their coordinates regardless.
+        coord = torch.where(not_converged_post1.view(-1, 1, 1), stepped, coord)
 
         # Update smallest_fmax for each molecule
         fmax_reduced = fmax.reshape(-1, 1) < smallest_fmax

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -13,7 +13,7 @@ from Auto3D.constants import (
 from Auto3D.utils import check_connectivity
 from Auto3D.utils.convergence import converged_or_unfiltered
 from Auto3D.utils.energy import e_tot_ev, try_e_tot_ev
-from Auto3D.utils.stereo_check import stereo_preserved
+from Auto3D.utils.stereo_check import species_key, stereo_preserved
 
 
 def filter_unique_optimized(
@@ -21,16 +21,19 @@ def filter_unique_optimized(
     rmsd_threshold: float = DEFAULT_RMSD_THRESHOLD,
     energy_cluster_window: float = DEFAULT_ENERGY_CLUSTER_WINDOW,
 ) -> list[Chem.Mol]:
-    """Filter unique conformers with optimized O(n log n) approach.
+    """Remove duplicate conformers, skipping RMSD comparisons that cannot match.
 
-    Uses energy-based clustering to reduce RMSD comparisons:
-    1. Sort by energy
-    2. Group into energy clusters
-    3. Only compare within clusters
+    Sorts by energy and only RMSD-compares molecules close enough in energy to be
+    duplicates at all, which avoids the O(n^2) comparisons of the legacy
+    ``utils.chemistry.filter_unique`` **without changing which molecules
+    survive** -- the partitioning is chosen so that no duplicate pair can be
+    separated by it. See the comment on the split rule below for why that
+    holds; it did not hold before 4.0.0.
 
-    This approach reduces the complexity from O(n^2) to approximately
-    O(n * k) where k is the average cluster size, which is typically
-    much smaller than n for molecules with diverse energies.
+    A pair counts as a duplicate only when all three of these agree: the two are
+    the same compound (:func:`Auto3D.utils.stereo_check.species_key`), their
+    heavy-atom RMSD is under ``rmsd_threshold``, and their energies agree within
+    ``DEFAULT_DUPLICATE_ENERGY_TOL``.
 
     Args:
         mols: List of RDKit Mol objects with 'E_tot' (Hartree) and, optionally,
@@ -39,10 +42,12 @@ def filter_unique_optimized(
             (it is not filtered on convergence). Records marked
             'Stereo_changed' are excluded.
         rmsd_threshold: RMSD threshold for considering structures similar (Angstrom).
-        energy_cluster_window: Energy window for clustering (eV). Unchanged:
-            the stored Hartree energies are converted to eV on read
-            (``Auto3D.utils.energy.e_tot_ev``), so this parameter keeps its
-            documented unit.
+        energy_cluster_window: Energy width (eV) below which molecules are
+            compared to each other. A performance knob only: values below the
+            duplicate energy tolerance cannot shrink the comparison set, because
+            that tolerance is the floor at which a pair can still be a duplicate.
+            The stored Hartree energies are converted to eV on read
+            (``Auto3D.utils.energy.e_tot_ev``), so the unit is as documented.
 
     Returns:
         List of unique molecules, sorted by energy (lowest first).
@@ -69,19 +74,44 @@ def filter_unique_optimized(
     # the duplicate tolerance below are both in eV, so convert on read.
     valid_mols.sort(key=e_tot_ev)
 
-    # Cluster by energy
+    # Partition the energy-sorted list into runs, and only RMSD-compare within a
+    # run. Where a run may end is a correctness question, not a tuning one.
+    #
+    # The old rule measured each molecule against its run's MINIMUM and started a
+    # new run past `energy_cluster_window`. That could put two molecules 2e-6 eV
+    # apart into different runs -- one just inside the window, the next just
+    # outside -- so a pair that is unambiguously the same conformer was never
+    # compared. Three bit-identical geometries at 0.0 / 0.099999 / 0.100001 eV all
+    # survived, which is how a k=5 request came back with five slots holding two
+    # distinct structures.
+    #
+    # A pair can only be a duplicate if its energies agree within
+    # DEFAULT_DUPLICATE_ENERGY_TOL (`_filter_within_cluster` requires it). So a
+    # run may end wherever the gap to the PREVIOUS molecule exceeds that
+    # tolerance, and nowhere else: a gap that large proves no pair straddling it
+    # can be a duplicate, and conversely, for any duplicate pair every gap
+    # between them is smaller still, so no boundary can fall between them. The
+    # result is identical to comparing all pairs.
+    #
+    # `energy_cluster_window` is honored as a lower bound on the split gap, since
+    # splitting on LARGER gaps is always safe (it only merges runs and compares
+    # more pairs). It therefore stays a performance knob and can no longer become
+    # a correctness hole. Runs are no longer width-bounded, so a dense energy
+    # ladder degrades to the O(n^2) of the legacy `filter_unique` -- the price of
+    # the guarantee, on conformer counts that are tens per species.
+    split_gap = max(DEFAULT_DUPLICATE_ENERGY_TOL, energy_cluster_window)
     clusters: list[list[Chem.Mol]] = []
     current_cluster: list[Chem.Mol] = [valid_mols[0]]
-    current_min_e = e_tot_ev(valid_mols[0])
+    previous_e = e_tot_ev(valid_mols[0])
 
     for mol in valid_mols[1:]:
         e = e_tot_ev(mol)
-        if e - current_min_e <= energy_cluster_window:
+        if e - previous_e <= split_gap:
             current_cluster.append(mol)
         else:
             clusters.append(current_cluster)
             current_cluster = [mol]
-            current_min_e = e
+        previous_e = e
     clusters.append(current_cluster)
 
     # Filter unique within each cluster
@@ -104,10 +134,14 @@ def _filter_within_cluster(
         mols: List of RDKit Mol objects to filter.
         rmsd_threshold: RMSD threshold for considering structures similar (Angstrom).
         energy_tol: Energy tolerance (eV). A pair is treated as duplicate only
-            when the heavy-atom RMSD is below ``rmsd_threshold`` AND the energies
-            agree within this tolerance, so conformers that differ only in an
-            O-H / N-H rotor orientation (RMSD~=0 on heavy atoms but distinct
-            minima with different energies) are preserved.
+            when the two are the same compound AND the heavy-atom RMSD is below
+            ``rmsd_threshold`` AND the energies agree within this tolerance. The
+            energy term preserves conformers that differ only in an O-H / N-H
+            rotor orientation (RMSD~=0 on heavy atoms but distinct minima with
+            different energies); the compound term preserves distinct
+            stereoisomers, which arrive here in one group and whose heavy-atom
+            RMSD can fall below the default threshold
+            (:func:`Auto3D.utils.stereo_check.species_key`).
 
     Returns:
         List of unique molecules within the cluster.
@@ -121,12 +155,21 @@ def _filter_within_cluster(
     unique: list[Chem.Mol] = []
     unique_noH: list[Chem.Mol] = []
     unique_energies: list[float] = []
+    unique_species: list[str] = []
     for mol_i in mols:
         mol_i_noH = Chem.RemoveHs(mol_i)
         e_i = _mol_energy(mol_i)
+        species_i = species_key(mol_i)
         is_unique = True
 
-        for mol_j_noH, e_j in zip(unique_noH, unique_energies, strict=True):
+        for mol_j_noH, e_j, species_j in zip(
+            unique_noH, unique_energies, unique_species, strict=True
+        ):
+            # Two different compounds are never duplicates of each other, however
+            # close their geometries. Checked first, and before the RMSD call it
+            # makes unnecessary.
+            if species_i != species_j:
+                continue
             try:
                 # Temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # Removing Hs speeds up the calculation
@@ -148,6 +191,7 @@ def _filter_within_cluster(
             unique.append(mol_i)
             unique_noH.append(mol_i_noH)
             unique_energies.append(e_i)
+            unique_species.append(species_i)
 
     return unique
 

--- a/src/Auto3D/utils/chemistry.py
+++ b/src/Auto3D/utils/chemistry.py
@@ -30,7 +30,11 @@ from Auto3D.constants import (
 )
 from Auto3D.utils.convergence import converged_or_unfiltered
 from Auto3D.utils.energy import try_e_tot_ev
-from Auto3D.utils.stereo_check import stereo_descriptors_from_3d, stereo_preserved
+from Auto3D.utils.stereo_check import (
+    species_key,
+    stereo_descriptors_from_3d,
+    stereo_preserved,
+)
 
 logger = logging.getLogger("auto3d")
 
@@ -533,12 +537,24 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
     unique_mols: list[Chem.Mol] = []
     unique_noH: list[Chem.Mol] = []
     unique_energies: list[float | None] = []
+    unique_species: list[str] = []
     for mol_i in mols:
         mol_i_noH = Chem.RemoveHs(mol_i)
         # E_tot is stored in Hartree; DEFAULT_DUPLICATE_ENERGY_TOL is in eV.
         e_i: float | None = try_e_tot_ev(mol_i)
+        species_i = species_key(mol_i)
         unique = True
-        for mol_j_noH, e_j in zip(unique_noH, unique_energies, strict=True):
+        for mol_j_noH, e_j, species_j in zip(
+            unique_noH, unique_energies, unique_species, strict=True
+        ):
+            # Two different compounds are never duplicates of each other, however
+            # close their geometries. All stereoisomers of one input share a
+            # ranking group, and two ring diastereomers can sit below the default
+            # 0.3 A threshold, so without this the RMSD test could delete one of
+            # them (Auto3D.utils.stereo_check.species_key). Checked before the
+            # RMSD call it makes unnecessary.
+            if species_i != species_j:
+                continue
             try:
                 # temporary bug fix for https://github.com/rdkit/rdkit/issues/6826
                 # removing Hs speeds up the calculation
@@ -560,4 +576,5 @@ def filter_unique(mols: list[Chem.Mol], crit: float = DEFAULT_RMSD_THRESHOLD) ->
             unique_mols.append(mol_i)
             unique_noH.append(mol_i_noH)
             unique_energies.append(e_i)
+            unique_species.append(species_i)
     return unique_mols

--- a/src/Auto3D/utils/stereo_check.py
+++ b/src/Auto3D/utils/stereo_check.py
@@ -80,6 +80,52 @@ def stereo_descriptors_from_3d(
     return atoms, bonds
 
 
+def species_key(mol: Chem.Mol) -> str:
+    """A canonical identifier for the *compound* ``mol``'s geometry represents.
+
+    Two molecules share this key when they are conformers of the same
+    stereoisomer, and differ when they are different compounds. Both duplicate
+    filters use it to answer the question their RMSD comparison cannot: whether
+    the pair in front of them is a repeated conformer or two distinct species.
+
+    Why they need it: ``ranking.species_id`` strips ``<isomer>_<conformer>``, so
+    every enumerated stereoisomer of one input arrives in the same group, and
+    heavy-atom ``GetBestRMS`` between two diastereomers of a 1,4-disubstituted
+    ring is small -- 0.300 A measured between cis- and trans-4-tert-
+    butylcyclohexanol, 0.335 A for cyclohexane-1,4-diol, both at or below the
+    0.3 A default threshold. Only the duplicate energy tolerance stood between
+    them and a collapse, and two ring diastereomers within 0.23 kcal/mol are
+    ordinary. When it fired, one of two distinct compounds left the output with
+    nothing logged.
+
+    Stereochemistry is perceived from the coordinates rather than read from the
+    molecule's tags, because the question is about the geometry in front of us: a
+    record from an SDF Auto3D did not write may carry no tags at all, and a stale
+    tag would answer for a structure that no longer exists. Perception runs on a
+    copy, so the caller's molecule is untouched, and on the H-explicit form,
+    because a stereocenter whose fourth substituent is a hydrogen cannot be
+    perceived once the hydrogens are gone.
+
+    Contrast :func:`stereo_descriptors_from_3d`, which answers a different
+    question: it keys descriptors by atom index and is therefore only comparable
+    between two readings of *one* molecule object. This returns a canonical
+    isomeric SMILES, which is comparable across separately parsed molecules --
+    the case both filters actually have.
+
+    Args:
+        mol: Molecule with at least one conformer. Not modified.
+
+    Returns:
+        Canonical isomeric SMILES with explicit hydrogens retained. Hydrogens
+        cannot change the comparison, since any pair reaching a duplicate check
+        carries the same atoms, and keeping them avoids a second ``RemoveHs``
+        per molecule on top of the one the RMSD comparison already needs.
+    """
+    probe = Chem.Mol(mol)
+    Chem.AssignStereochemistryFrom3D(probe)
+    return Chem.MolToSmiles(probe)
+
+
 def apply_optimized_coords(
     mol: Chem.Mol, coords: Sequence[Sequence[float]]
 ) -> bool:

--- a/src/Auto3D/workflow_workers.py
+++ b/src/Auto3D/workflow_workers.py
@@ -275,9 +275,33 @@ def optim_rank_wrapper(
         return conformers
 
 def logger_process(queue: Queue[LogRecord | None], logging_path: str) -> None:
-    """A child process for logging all information from other processes."""
+    """A child process for logging all information from other processes.
+
+    Everything the workers log arrives here, and this is the only place that
+    decides where it goes. WARNING and above additionally go to stderr; INFO and
+    DEBUG stay in the run log, which is where the step-by-step narrative belongs.
+
+    Why the stderr handler exists: a worker's ``logger`` reaches this process
+    through a ``QueueHandler`` and nothing else, so with a file as the only
+    handler here, a chunk that failed wrote its traceback to
+    ``<job_dir>/Auto3D.log`` and told the user nothing. The loss itself was
+    visible -- reconciliation names the missing molecules and the run exits 6 --
+    but the *cause* was not, so a systematic bug that failed every chunk
+    identically was indistinguishable from a batch of hard molecules, and read
+    as "N molecules produced no conformer". The same silence covered the "no
+    optimized structures were produced" warning and every other worker warning,
+    which is why this is fixed at the collector rather than at one call site.
+
+    Stderr, not stdout: ``--json`` promises stdout carries only the document.
+    Interactive runs render a live panel on stderr too, so a warning mid-run can
+    tear that panel -- an acceptable trade for a diagnosis, and the reason INFO
+    is kept out of it.
+    """
     logger = logging.getLogger("auto3d")
     logger.addHandler(logging.FileHandler(logging_path))
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.WARNING)
+    logger.addHandler(stderr_handler)
     logger.setLevel(logging.INFO)
     while True:
         message = queue.get()

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -120,6 +120,94 @@ class TestFilterWithinCluster:
         assert len(result) >= 1  # At least one conformer
 
 
+class TestDistinctStereoisomersAreNeverDuplicates:
+    """Dedup must remove duplicate *conformers*, never a distinct compound.
+
+    ``ranking.species_id`` strips ``<isomer>_<conformer>``, so every enumerated
+    stereoisomer of one input shares a ranking group and reaches this filter
+    together. Heavy-atom ``GetBestRMS`` between two diastereomers of a
+    1,4-disubstituted ring is small -- 0.300 A measured for
+    cis/trans-4-tert-butylcyclohexanol, 0.335 A for cyclohexane-1,4-diol -- so
+    with ``--threshold`` raised above the default, or with the two isomers
+    within the duplicate energy tolerance, one of two distinct compounds
+    disappears from the output with nothing logged.
+
+    The thresholds below are deliberately set wide enough that RMSD and energy
+    both say "duplicate". What must keep the pair apart is the only thing that
+    should: they are different compounds.
+    """
+
+    #: cis/trans-4-tert-butylcyclohexanol -- the measured worst case.
+    _CIS = "O[C@H]1CC[C@@H](CC1)C(C)(C)C"
+    _TRANS = "O[C@H]1CC[C@H](CC1)C(C)(C)C"
+
+    def test_two_diastereomers_are_both_kept(self):
+        cis = _create_mol_with_energy(self._CIS, -10.0)
+        trans = _create_mol_with_energy(self._TRANS, -10.0)  # identical energy
+        assert Chem.MolToSmiles(cis) != Chem.MolToSmiles(trans), "test premise"
+
+        result = _filter_within_cluster([cis, trans], rmsd_threshold=10.0)
+
+        assert len(result) == 2, (
+            "two distinct diastereomers were merged into one: an input molecule "
+            "vanished from the output with no record"
+        )
+
+    def test_two_double_bond_isomers_are_both_kept(self):
+        """The same guarantee for E/Z, which the SDF path enumerates too."""
+        e_isomer = _create_mol_with_energy(r"C/C=C/CCO", -10.0)
+        z_isomer = _create_mol_with_energy(r"C/C=C\CCO", -10.0)
+
+        result = _filter_within_cluster([e_isomer, z_isomer], rmsd_threshold=10.0)
+
+        assert len(result) == 2, "an E/Z pair was merged into one compound"
+
+    def test_two_conformers_of_one_stereoisomer_are_still_deduplicated(self):
+        """The other half of the contract, and the reason this test exists.
+
+        A stereo guard that declared everything distinct would satisfy the two
+        tests above and quietly disable duplicate removal entirely. Two
+        conformers of ONE stereoisomer, same geometry and same energy, must
+        still collapse to one.
+        """
+        first = _create_mol_with_energy(self._CIS, -10.0)
+        second = _create_mol_with_energy(self._CIS, -10.0)
+
+        result = _filter_within_cluster([first, second], rmsd_threshold=10.0)
+
+        assert len(result) == 1, (
+            "duplicate conformers of one stereoisomer survived, so the stereo "
+            "guard has switched dedup off rather than narrowing it"
+        )
+
+
+class TestDuplicatesCannotEscapeAcrossAnEnergyBoundary:
+    """A duplicate pair must be compared however the energy axis is partitioned.
+
+    ``filter_unique_optimized`` groups by energy and only RMSD-compares within a
+    group, so a duplicate pair straddling a boundary was never compared at all.
+    Three bit-identical geometries whose energies span exactly one default
+    ``energy_cluster_window`` (0.1 eV) all survived, and the two that differ by
+    2e-6 eV are unambiguously the same conformer.
+    """
+
+    def test_a_duplicate_pair_split_by_a_boundary_is_still_removed(self):
+        base = -100.0
+        # Sorted: the first is far from the other two; the last two are 2e-6 eV
+        # apart and identical in geometry, so exactly two structures are unique.
+        energies = [base, base + 0.099999, base + 0.100001]
+        mols = [_create_mol_with_energy("CCO", e) for e in energies]
+
+        result = filter_unique_optimized(
+            mols, rmsd_threshold=0.5, energy_cluster_window=0.1
+        )
+
+        assert len(result) == 2, (
+            "a duplicate pair 2e-6 eV apart survived because the two halves "
+            f"landed in different energy groups; got {len(result)} structures"
+        )
+
+
 class TestFilterUniqueOptimized:
     """Tests for filter_unique_optimized function."""
 

--- a/tests/test_optimization_engine.py
+++ b/tests/test_optimization_engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from unittest.mock import MagicMock
 
+import pytest
 import torch
 
 from Auto3D.batch_opt.optimization_engine import n_steps, print_stats
@@ -511,6 +512,65 @@ def test_stored_fmax_matches_stored_coord():
     n_steps(state, n=3, opttol=1e-9, patience=1000)
     recomputed_fmax = (2.0 * state["coord"]).norm(dim=-1).max(dim=-1)[0]
     assert abs(state["fmax"].item() - recomputed_fmax.item()) < 1e-5
+
+
+class TestConvergedAndFmaxDescribeTheSameGeometry:
+    """``Converged=True`` and the reported ``fmax`` must not contradict.
+
+    ``batchopt`` writes both to every output record: ``Converged`` from
+    ``converged_mask``, and ``fmax`` recomputed at the final geometry. The loop
+    decided convergence from the force measured *before* its last FIRE step and
+    then took that step anyway, so the flag described one geometry and the number
+    beside it described another. A consumer filtering on ``fmax <= opt_tol`` and
+    one filtering on ``Converged == "True"`` got different sets out of the same
+    file, and the file asserted both.
+
+    The discrepancy scales with stiffness, which is why it was easy to dismiss: a
+    soft potential moves little in one step and stays inside the tolerance. On a
+    stiff one, measured before the fix, ``Converged=True`` came back with fmax up
+    to 6.9x the tolerance.
+    """
+
+    class _Harmonic:
+        """E = k*sum(coord^2), F = -2*k*coord. Exact, hermetic, no NNP."""
+
+        def __init__(self, k: float):
+            self.k = k
+
+        def forward_batched(self, coord, numbers, charges, atom_mask=None):
+            return self.k * (coord ** 2).sum(dim=(1, 2)), -2.0 * self.k * coord
+
+    @staticmethod
+    def _run(k: float, start: float, opttol: float) -> tuple[bool, float]:
+        state = {
+            "coord": torch.full((1, 2, 3), start, dtype=torch.float),
+            "numbers": torch.ones(1, 2, dtype=torch.long),
+            "charges": torch.zeros(1, dtype=torch.long),
+            "nn": TestConvergedAndFmaxDescribeTheSameGeometry._Harmonic(k),
+            "converged_mask": torch.zeros(1, dtype=torch.bool),
+            "fmax": torch.full((1,), 999.0),
+            "energy": torch.full((1,), float("inf"), dtype=torch.double),
+        }
+        # patience above n so nothing leaves the active set as oscillating:
+        # converged_mask would then be True for a structure that never met the
+        # force criterion, and this assertion would be about the wrong thing.
+        n_steps(state, n=2000, opttol=opttol, patience=5000)
+        return bool(state["converged_mask"][0]), float(state["fmax"][0])
+
+    # Stiffnesses spanning the soft case (where the inconsistency hides below
+    # the tolerance) and the stiff case (where it was 2x-7x the tolerance).
+    @pytest.mark.parametrize("k", [1.0, 10.0, 100.0])
+    @pytest.mark.parametrize("start", [0.5, 1.0, 1.5, 3.0])
+    def test_a_structure_reported_converged_reports_a_converged_force(self, k, start):
+        opttol = 0.01
+        converged, fmax = self._run(k, start, opttol)
+
+        assert converged, "test premise: this configuration should converge"
+        assert fmax <= opttol, (
+            f"reported Converged=True beside fmax={fmax:.6f}, which is "
+            f"{fmax / opttol:.1f}x the {opttol} eV/A tolerance: the flag and the "
+            f"force in the same record describe different geometries"
+        )
 
 
 class TestNStepsIntegration:

--- a/tests/test_utils_chemistry.py
+++ b/tests/test_utils_chemistry.py
@@ -529,6 +529,59 @@ class TestFilterUnique:
         # Should keep both (or at least not crash)
         assert len(unique_mols) >= 1
 
+    def test_two_diastereomers_are_never_merged(self):
+        """A distinct compound must survive dedup, however close its geometry.
+
+        The same guarantee ``tests/test_filtering.py`` asserts for
+        ``filter_unique_optimized``, asserted here because this is the other
+        duplicate filter and it applies the identical RMSD-plus-energy criterion.
+        Fixing one path and not the other would leave the defect reachable
+        through ``ConformerRanker(use_optimized_filtering=False)``.
+
+        cis/trans-4-tert-butylcyclohexanol: heavy-atom RMSD between the two
+        diastereomers was measured at 0.300 A, i.e. at the 0.3 A default
+        threshold. ``crit`` is opened wide here so RMSD and energy both say
+        "duplicate" and the only thing that can keep the pair apart is the fact
+        that they are different compounds.
+        """
+        from Auto3D.utils.chemistry import filter_unique
+        from Auto3D.utils.energy import set_e_tot_from_ev
+
+        def build(smiles: str) -> Chem.Mol:
+            mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+            AllChem.EmbedMolecule(mol, randomSeed=42)
+            AllChem.MMFFOptimizeMolecule(mol)
+            mol.SetProp("Converged", "true")
+            set_e_tot_from_ev(mol, -10.0)  # identical energies
+            return mol
+
+        cis = build("O[C@H]1CC[C@@H](CC1)C(C)(C)C")
+        trans = build("O[C@H]1CC[C@H](CC1)C(C)(C)C")
+        assert Chem.MolToSmiles(cis) != Chem.MolToSmiles(trans), "test premise"
+
+        assert len(filter_unique([cis, trans], crit=10.0)) == 2, (
+            "the legacy filter merged two distinct diastereomers, so an input "
+            "molecule vanished from the output with no record"
+        )
+
+    def test_duplicate_conformers_of_one_stereoisomer_still_collapse(self):
+        """The other half: the stereo guard must narrow dedup, not disable it."""
+        from Auto3D.utils.chemistry import filter_unique
+        from Auto3D.utils.energy import set_e_tot_from_ev
+
+        def build() -> Chem.Mol:
+            mol = Chem.AddHs(Chem.MolFromSmiles("O[C@H]1CC[C@@H](CC1)C(C)(C)C"))
+            AllChem.EmbedMolecule(mol, randomSeed=42)
+            AllChem.MMFFOptimizeMolecule(mol)
+            mol.SetProp("Converged", "true")
+            set_e_tot_from_ev(mol, -10.0)
+            return mol
+
+        assert len(filter_unique([build(), build()], crit=10.0)) == 1, (
+            "duplicate conformers of one stereoisomer survived, so the stereo "
+            "guard has switched dedup off rather than narrowing it"
+        )
+
     def test_filter_unconverged_removed(self):
         """Test that unconverged structures are removed."""
         from Auto3D.utils.chemistry import filter_unique

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -2,6 +2,7 @@
 """Tests for workflow orchestration, including multi-GPU handling."""
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -302,6 +303,99 @@ class TestOptimizerEmptyInput:
 def test_workers_importable_from_workflow_workers():
     from Auto3D.workflow_workers import isomer_wrapper, logger_process, optim_rank_wrapper
     assert all(callable(f) for f in (isomer_wrapper, optim_rank_wrapper, logger_process))
+
+
+class TestAFailedChunksCauseReachesTheUser:
+    """A worker's warnings and errors must not stay buried in the run log.
+
+    Worker processes log through a ``QueueHandler`` whose only destination was a
+    ``FileHandler`` in ``logger_process``. So when a chunk failed, its traceback
+    went to ``<job_dir>/Auto3D.log`` and the user saw nothing: the *loss* was
+    reported (reconciliation names the missing molecules, the run exits 6) but
+    the *cause* was not, making a systematic bug that failed every chunk
+    identically look like a batch of difficult molecules.
+
+    These drive ``logger_process`` directly rather than spawning a real worker,
+    because the behavior under test belongs to the collector: it is the one place
+    that decides where a worker's records go.
+    """
+
+    @staticmethod
+    def _drain(records, logging_path, capfd):
+        """Run logger_process over `records`, return (stderr, log file contents).
+
+        logger_process adds handlers to the process-wide "auto3d" logger and, in
+        production, is the whole life of a dedicated process. Called in-process
+        here, so its handlers are removed again afterwards -- otherwise every
+        later test in the session inherits them.
+        """
+        import logging as logging_mod
+        import queue as queue_mod
+
+        from Auto3D.workflow_workers import logger_process
+
+        logger = logging_mod.getLogger("auto3d")
+        before = list(logger.handlers)
+        before_level = logger.level
+        q: queue_mod.Queue = queue_mod.Queue()
+        for record in records:
+            q.put(record)
+        q.put(None)
+        try:
+            logger_process(q, str(logging_path))
+        finally:
+            for handler in list(logger.handlers):
+                if handler not in before:
+                    logger.removeHandler(handler)
+                    handler.close()
+            logger.setLevel(before_level)
+        return capfd.readouterr().err, Path(logging_path).read_text()
+
+    @staticmethod
+    def _record(level, message):
+        import logging as logging_mod
+
+        return logging_mod.LogRecord(
+            name="auto3d", level=level, pathname=__file__, lineno=1,
+            msg=message, args=(), exc_info=None,
+        )
+
+    def test_an_error_from_a_worker_is_written_to_stderr(self, tmp_path, capfd):
+        message = "job3 failed during optimization/ranking"
+        err, log_text = self._drain(
+            [self._record(logging.ERROR, message)], tmp_path / "Auto3D.log", capfd
+        )
+
+        assert message in err, (
+            "a failed chunk's cause never reached stderr, so the user sees only "
+            "that molecules are missing and not why"
+        )
+        assert message in log_text, "the run log must still receive it as well"
+
+    def test_a_warning_from_a_worker_is_written_to_stderr(self, tmp_path, capfd):
+        """Covers the sibling case: 'no optimized structures were produced'."""
+        message = "job7: no optimized structures were produced"
+        err, _ = self._drain(
+            [self._record(logging.WARNING, message)], tmp_path / "Auto3D.log", capfd
+        )
+
+        assert message in err
+
+    def test_info_stays_in_the_run_log_and_off_stderr(self, tmp_path, capfd):
+        """The step-by-step narrative must not be promoted to the terminal.
+
+        Without this, the fix above would turn every 'Optimizing on jobN' line
+        into console output and bury the warnings it exists to surface -- and it
+        would put chatter on the stream an interactive run draws its live panel
+        on.
+        """
+        message = "Optimizing on job1"
+        err, log_text = self._drain(
+            [self._record(logging.INFO, message)], tmp_path / "Auto3D.log", capfd
+        )
+
+        assert message in log_text, "the run log must still receive INFO"
+        assert message not in err, "INFO was promoted to stderr"
 
 
 def test_optim_rank_wrapper_isolates_failing_chunks(tmp_path, monkeypatch):


### PR DESCRIPTION
Four open findings from the 2026-08-02 error hunt, each verified still present before being fixed. Two change which molecules come out of a run; one makes a record stop contradicting itself; one makes a failure explain itself.

Along the way one finding turned out to be **already fixed**, and two hunt manifests turned out to **disagree with each other** about a third.

---

### 1. Duplicate removal could delete a distinct stereoisomer

Both conformer filters declared a pair duplicate on heavy-atom RMSD plus an energy check, with nothing asking whether the two were the same compound. `ranking.species_id` strips `<isomer>_<conformer>`, so every enumerated stereoisomer of one input arrives in one dedup group — and `GetBestRMS` between two diastereomers of a 1,4-disubstituted ring is small:

| pair | heavy-atom RMSD | default `threshold` |
|---|---|---|
| cis/trans-4-*tert*-butylcyclohexanol | **0.300 Å** | 0.3 Å |
| cis/trans-cyclohexane-1,4-diol | 0.335 Å | 0.3 Å |

Only the 0.23 kcal/mol duplicate-energy tolerance stood between them and a collapse, and ring diastereomers that close are ordinary. Raising `--threshold`, a documented knob, could therefore make **one of two distinct compounds vanish from the output with nothing logged.**

A pair must now also *be the same compound*, keyed on stereochemistry perceived from the coordinates (`utils.stereo_check.species_key`) rather than read from tags a foreign SDF may not carry. Applied to **both** filters — the legacy `utils.chemistry.filter_unique` carries the identical criterion, and fixing only the optimized one would have left the defect reachable through `ConformerRanker(use_optimized_filtering=False)`. No effect on single-isomer inputs, where every conformer shares a key.

### 2. A duplicate pair could escape by straddling an energy boundary

`filter_unique_optimized` measured each molecule against its group's *minimum* and started a new group past `energy_cluster_window`, so two molecules `2e-6 eV` apart could land either side of a boundary and never be compared at all. Three bit-identical geometries at `0.0 / 0.099999 / 0.100001 eV` all survived — which is how a `k=5` request returned five slots holding two distinct structures.

A group now ends only where the gap to the *previous* molecule exceeds the duplicate energy tolerance. That is a gap no duplicate pair can straddle, so the result is provably identical to comparing every pair, and `energy_cluster_window` stays a performance knob that can no longer become a correctness hole.

### 3. `Converged` and `fmax` in one record described different geometries

Convergence was decided from the force measured *before* the last FIRE step, which was then taken anyway, while `fmax` is recomputed at the final geometry. A consumer filtering on `fmax <= opt_tol` and one filtering on `Converged == "True"` got different sets from the same file, and the file asserted both.

Measured on a hermetic harmonic potential at `opt_tol = 0.01 eV/Å`:

| stiffness | reported fmax beside `Converged=True` | × tolerance |
|---|---|---|
| k=1 | 0.0012 – 0.0072 | 0.1 – 0.7 |
| k=10 | 0.0023 – 0.0052 | 0.2 – 0.5 |
| k=100 | 0.0040 – 0.0692 | 0.4 – **6.9** |

**The two hunt manifests disagreed here, and this resolves it.** The chemistry sweep recorded it as a defect (m2); the silent-fallbacks sweep dismissed the same lines as "numerically negligible" (L7). The dismissal assumed FIRE velocity `v = 0`, which holds only on a structure's first step. The table above is why the chemistry sweep was right — the estimate holds for soft potentials and fails for stiff ones, which is exactly the trap: one soft test case makes the defect look like nothing. L7 is now retracted in its manifest with these numbers.

The force criterion is now tested **before** the step, so a structure that has met it keeps the geometry its force was measured at.

What this deliberately does *not* do: re-derive the flag from the final recomputed force. That flips structures to `Converged=False`, and `converged_or_unfiltered` **drops** those — trading a mislabeled record for a silently deleted conformer.

Safety of the reordering, checked rather than assumed: convergence decisions are unchanged (the same comparison over the same forces, moved), and every still-active trajectory is **bit-identical** — verified by hashing final coordinates of a run where nothing converges. Only a converged structure's reported geometry moves, back by the one step that used to follow its own measurement. No extra force evaluations, so no performance cost.

### 4. A failed chunk did not say why

Worker processes log through a `QueueHandler` whose collector had a `FileHandler` as its only destination. So when a chunk died, its traceback went to `<job_dir>/Auto3D.log` and the user saw nothing: the *loss* was reported (reconciliation names the missing molecules, the run exits 6) but the *cause* was not, making a systematic bug that failed every chunk identically indistinguishable from a batch of hard molecules.

WARNING and above now also reach stderr — keeping stdout clean for `--json` — while INFO stays in the run log where the step-by-step narrative belongs. Fixed at the collector rather than the one call site, so it covers every worker diagnostic, including the sibling "no optimized structures were produced" warning that was equally invisible.

---

## Verification

- **1250 passed, 9 skipped** on three seeds; ruff clean.
- **Every fix mutation-verified** — reverting it turns named tests red:
  - revert the split rule → the boundary test fails
  - remove the stereo gate in `filtering.py` → the diastereomer and E/Z tests fail
  - remove it in `utils/chemistry.py` → the legacy-path test fails
  - revert the optimizer reordering → 4 stiff-potential cases fail
  - drop the stderr handler → both stderr tests fail; set it to INFO → the "INFO stays in the log" test fails
- **The stereo guard is tested in both directions.** A guard that declared *everything* distinct would satisfy the diastereomer tests and quietly switch dedup off, so a companion test asserts that duplicate conformers of *one* stereoisomer still collapse. Present in both filters' test modules.
- The species key was validated before use: distinct for diastereomers, acyclic diastereomers and E/Z pairs; identical across 5 conformers each of a ring with H-bearing stereocenters, an acyclic diastereomer, and a flexible achiral chain.

## Dropped from the backlog

The SMILES path's unspecified-C=C warning (chemistry M4) is **already fixed** — `check_smi_format` now uses `count_unspecified_stereo`, the same predicate the SDF path uses. Verified in the current source rather than taken from the manifest.