### PR TITLE
fix: report input records the pipeline could not read, instead of exiting 0

### DIFF
--- a/docs/superpowers/follow-ups-after-4.0.0-remediation.md
+++ b/docs/superpowers/follow-ups-after-4.0.0-remediation.md
@@ -10,6 +10,54 @@ scratch and will not survive a `git clean`. This file is the durable record.
 Source of the finding IDs: `.claude/review-manifests/review-2026-07-30-package-audit.md`.
 Design and rationale: `docs/superpowers/specs/2026-07-30-audit-remediation-design.md` §1.
 
+## Plan of record, as of 2026-08-03
+
+Everything in this file plus the deferred clusters below is now scheduled rather
+than merely recorded. Design detail lives in
+`docs/superpowers/specs/2026-08-03-debt-closure-design.md` (git-ignored, like every
+spec in this repo); the decisions and the order are here because this file is the
+durable record.
+
+**Three decisions, settled so they are not re-litigated per phase:**
+
+1. **Fix everything, then ship one release.** No release until every cluster is
+   closed. One version absorbs every breaking change so users migrate once.
+2. **Clean sweep on the public surface, no shims and no separate migration
+   guide.** The CHANGELOG's Breaking Changes section carries the import changes.
+   Defensible because **PyPI's latest Auto3D is 2.3.1** — `v3.0.0` and `v3.5.0`
+   are git tags only, since `publish.yml` fires on *GitHub release published* and
+   no release was ever cut for either. Shims would protect only source installs
+   off a tag.
+3. **No speedup claimed without measurement.** The GPU work lands behind
+   correctness tests that assert unchanged results; the number comes from a
+   maintainer-run benchmark.
+
+**Version:** 4.0.0, not 3.5.0. `pyproject.toml` still reads `3.5.0` and must
+move; the `v3.5.0` tag points at `0d21094`, many merges behind, and is retired
+rather than moved.
+
+**Order:** correctness leftovers -> the *subset* of test-quality findings covering
+files the architecture work will move -> dead-code deletion -> one model contract
+-> barrels and public surface -> configuration -> file splits -> the items in this
+file -> cleanup and duplication -> performance -> release.
+
+Two positions in that order are deliberate. Dead-code deletion (M53, ~450 lines
+of `src/` whose only callers are its own tests) runs early because it deletes
+those tests too, shrinking the test-quality cluster before any effort goes into
+it. And the test hardening step is not all ~105 vacuous-test findings but a
+rule-selected subset — only those naming a test that covers a `src/` file the
+architecture work moves; the rest are fixed when their module is visited.
+
+Estimated 15–20 phases.
+
+**Correction found while scoping this:** M46 (`use_ensemble`) and M47 (discarded
+`**kwargs`) are closed — verified against source. The "What the remediation
+closed" list below is right about them and
+`.claude/review-manifests/review-2026-07-30-package-audit.md` is not. More
+generally, the manifests' line numbers are stale (`ASE/thermo.py` has shifted
+~500 lines), so every finding is re-verified against source before being worked,
+not read out of a ledger. Chemistry M4 was already fixed and no ledger knew.
+
 ## What the remediation closed
 
 All 14 Criticals (C1–C14), plus M1, M2 (moot), M8–M17, M19, M21–M23,

--- a/src/Auto3D/utils/file_ops.py
+++ b/src/Auto3D/utils/file_ops.py
@@ -922,7 +922,11 @@ def find_ids_not_in_sdf(source_sdf: str, sdf: str) -> list[str]:
         sdf: Path to the output SDF file (decoded IDs).
 
     Returns:
-        List of input molecule IDs with no corresponding structure in ``sdf``.
+        Input molecule IDs with no corresponding structure in ``sdf``. A source
+        record RDKit could not parse has no ``_Name`` to return, so it appears as
+        ``UNPARSEABLE_RECORD_ID`` filled in with its position -- it is a molecule
+        the user supplied and did not get back, and omitting it is what let a run
+        exit 0 having processed fewer molecules than its input contained.
 
     Example:
         >>> missing = find_ids_not_in_sdf("input.sdf", "output.sdf")
@@ -949,7 +953,14 @@ def find_ids_not_in_sdf(source_sdf: str, sdf: str) -> list[str]:
     source_ids: list[str] = []
     for i, mol in enumerate(Chem.SDMolSupplier(source_sdf, removeHs=False)):
         if mol is None:
-            logger.warning("Skipping molecule at index %d: failed to parse", i)
+            # Not "Skipping ...", which is what this said while it was in fact
+            # skipping: the record is now counted as a failure, and a message
+            # claiming otherwise would be the same defect one layer up.
+            logger.warning(
+                "Input record at index %d could not be parsed; reporting it as a "
+                "molecule that produced no output.",
+                i,
+            )
             source_ids.append(UNPARSEABLE_RECORD_ID.format(index=i))
             continue
         source_ids.append(mol.GetProp("_Name").strip())

--- a/src/Auto3D/utils/file_ops.py
+++ b/src/Auto3D/utils/file_ops.py
@@ -28,6 +28,13 @@ from Auto3D.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+#: Stand-in ID for an input record Auto3D could not parse, used by the
+#: input-vs-output reconciliation. Such a record has no ``_Name`` to report, so it
+#: is identified by its position in the source file. The angle brackets make it
+#: unmistakable as a placeholder rather than a molecule name a user chose -- an ID
+#: read from a file can be anything, including ``record 3``, but not with these.
+UNPARSEABLE_RECORD_ID = "<unparseable input record at index {index}>"
+
 
 def iter_smi_records(path, *, on_malformed="skip"):
     """Yield (line_no, smiles, mol_id) for each non-blank, non-comment line of
@@ -922,12 +929,28 @@ def find_ids_not_in_sdf(source_sdf: str, sdf: str) -> list[str]:
         >>> for mol_id in missing:
         ...     print(f"Failed: {mol_id}")
     """
-    # Find all input molecule IDs
+    # Find all input molecule IDs.
+    #
+    # A record RDKit cannot parse is reported, not skipped. `encode_ids` drops
+    # such a record with a warning so it never enters the run; this function then
+    # built its expected-ID list from the SAME file and skipped the SAME record,
+    # so the record was in neither `source_ids` nor the output, could not appear
+    # in `failures`, and `_exit_if_incomplete` saw `failed_count == 0`. The run
+    # printed a success summary and exited 0 having processed fewer molecules than
+    # the file contained -- exactly what this reconciliation exists to prevent
+    # (audit C7). It has no `_Name` to report, so it is named by position.
+    #
+    # Only the SDF path needed this. `encode_ids` reads `.smi` input with
+    # `on_malformed="raise"`, so a malformed SMILES line aborts the run with
+    # InputValidationError long before reconciliation. That the two input formats
+    # disagree on strictness -- `.smi` refuses the file, `.sdf` processes the rest
+    # -- is a real divergence, but unifying it changes behavior for large files
+    # and belongs with the other validation-consistency work, not here.
     source_ids: list[str] = []
-    suppl = Chem.SDMolSupplier(source_sdf, removeHs=False)
-    for i, mol in enumerate(suppl):
+    for i, mol in enumerate(Chem.SDMolSupplier(source_sdf, removeHs=False)):
         if mol is None:
             logger.warning("Skipping molecule at index %d: failed to parse", i)
+            source_ids.append(UNPARSEABLE_RECORD_ID.format(index=i))
             continue
         source_ids.append(mol.GetProp("_Name").strip())
 

--- a/tests/test_utils_file_ops.py
+++ b/tests/test_utils_file_ops.py
@@ -1257,18 +1257,34 @@ class TestFindIdsNotInSdf:
 
         assert find_ids_not_in_sdf(str(source), str(out)) == []
 
-    def test_skips_none_records_on_both_sides(self, tmp_path, monkeypatch):
-        """A None record (unparseable) in either SDF must not crash or miscount."""
+    def test_an_unreadable_record_is_reported_on_the_input_side_only(
+        self, tmp_path, monkeypatch
+    ):
+        """The two sides of the comparison are not symmetric, and must not be.
+
+        This test used to assert ``== []`` for a source file containing an
+        unreadable record, under the heading "must not crash or miscount". The
+        empty list *was* the miscount: an input molecule the pipeline never saw
+        was reported by nothing, and the run exited 0 claiming completeness.
+
+        The asymmetry is the point:
+
+        * **input side** -- a record that cannot be read is a molecule the user
+          supplied and did not get back. It is reported, by position, since it has
+          no ``_Name`` to report by.
+        * **output side** -- a record that cannot be read yields no name to match
+          against, and there is nothing better to do than skip it. Reporting it
+          would invent a *missing input* out of an unreadable output.
+        """
         import Auto3D.utils.file_ops as file_ops
 
-        valid_source = _make_mol("mol_a")
         calls = {"n": 0}
 
         def fake_supplier(*a, **k):
             calls["n"] += 1
             if calls["n"] == 1:
-                return [valid_source, None]  # source SDF
-            return [None, _make_mol("mol_a")]  # output SDF
+                return [_make_mol("mol_a"), None]  # source: one good, one unreadable
+            return [None, _make_mol("mol_a")]      # output: mol_a made it
 
         monkeypatch.setattr(file_ops.Chem, "SDMolSupplier", fake_supplier)
 
@@ -1276,6 +1292,80 @@ class TestFindIdsNotInSdf:
         source.write_text("placeholder")
         out = tmp_path / "out.sdf"
         out.write_text("placeholder")
+
+        assert find_ids_not_in_sdf(str(source), str(out)) == [
+            file_ops.UNPARSEABLE_RECORD_ID.format(index=1)
+        ]
+
+
+class TestReconciliationSeesUnparseableInputRecords:
+    """A record Auto3D could not read must not vanish from the accounting.
+
+    ``encode_ids`` skips an unparseable SDF record with a warning, so it never
+    enters the run. ``find_ids_not_in_sdf`` then built its expected-ID list by
+    reading **the same source SDF** and skipping the same record -- so it was in
+    neither ``source_ids`` nor the output, could not appear in ``failures``, and
+    ``_exit_if_incomplete`` saw ``failed_count == 0``. The run printed a success
+    summary and exited **0** having processed fewer molecules than the file
+    contained, which is precisely what the C7 reconciliation exists to prevent.
+
+    Only the SDF path is affected. ``encode_ids`` reads ``.smi`` input with
+    ``on_malformed="raise"``, so a malformed SMILES line aborts the run with
+    ``InputValidationError`` long before reconciliation -- the same blindness
+    cannot be reached through that door.
+    """
+
+    @staticmethod
+    def _unparseable_record(name: str) -> str:
+        """A molblock RDKit rejects: the counts line is corrupted.
+
+        Built from a real molblock so only the one line under test is invalid;
+        a wholly invented block could fail for an unrelated reason.
+        """
+        mol = _make_mol(name)
+        lines = Chem.MolToMolBlock(mol).splitlines()
+        lines[3] = "!! corrupted counts line !!"
+        return "\n".join(lines)
+
+    def test_an_unparseable_source_record_is_reported_as_a_failure(self, tmp_path):
+        source = tmp_path / "source.sdf"
+        good = Chem.MolToMolBlock(_make_mol("mol_a"))
+        source.write_text(
+            good + "$$$$\n" + self._unparseable_record("mol_b") + "\n$$$$\n"
+        )
+        # Confirm the premise: RDKit reads one molecule and one None.
+        parsed = list(Chem.SDMolSupplier(str(source), removeHs=False))
+        assert [m is None for m in parsed] == [False, True], "test premise"
+
+        out = tmp_path / "out.sdf"
+        writer = Chem.SDWriter(str(out))
+        writer.write(_make_mol("mol_a"))  # the parseable one succeeded
+        writer.close()
+
+        missing = find_ids_not_in_sdf(str(source), str(out))
+
+        assert len(missing) == 1, (
+            f"a source record the pipeline could not read was left out of the "
+            f"accounting entirely, so the run would exit 0 claiming every input "
+            f"was processed; got {missing}"
+        )
+        assert "1" in missing[0], (
+            f"the report must say which record could not be read, got {missing[0]!r}"
+        )
+
+    def test_a_clean_source_file_still_reports_nothing(self, tmp_path):
+        """The new branch must not manufacture failures for a healthy file."""
+        source = tmp_path / "source.sdf"
+        writer = Chem.SDWriter(str(source))
+        for name in ("mol_a", "mol_b"):
+            writer.write(_make_mol(name))
+        writer.close()
+
+        out = tmp_path / "out.sdf"
+        writer = Chem.SDWriter(str(out))
+        for name in ("mol_a", "mol_b"):
+            writer.write(_make_mol(name))
+        writer.close()
 
         assert find_ids_not_in_sdf(str(source), str(out)) == []
 


### PR DESCRIPTION
First fix of cluster A from the debt plan (#130), and the most serious item in it.

## The defect

`encode_ids` skips an SDF record RDKit cannot parse, with a warning, so it never enters the run. `find_ids_not_in_sdf` then built its expected-ID list by reading **the same source file** and skipping **the same record**:

```python
for i, mol in enumerate(Chem.SDMolSupplier(source_sdf, removeHs=False)):
    if mol is None:
        logger.warning("Skipping molecule at index %d: failed to parse", i)
        continue          # <-- and now it is in neither list
    source_ids.append(mol.GetProp("_Name").strip())
```

So the record was in neither `source_ids` nor the output, could not appear in `failures`, and `_exit_if_incomplete` saw `failed_count == 0`. **The run printed a success summary and exited 0 having processed fewer molecules than the file contained** — the exact failure C7's reconciliation exists to prevent, defeated by reading the input twice the same way.

## The fix

An unreadable record has no `_Name`, so it is reported by position via `UNPARSEABLE_RECORD_ID`. The angle brackets keep it unmistakable as a placeholder: an ID read from a file can be any string, including `record 3`, but not one wrapped in brackets.

**The two sides of the comparison are deliberately asymmetric**, and the rewritten test asserts that rather than assuming it:

| side | unreadable record | why |
|---|---|---|
| input | **reported** | a molecule the user supplied and did not get back |
| output | skipped | no name to match against; reporting it would invent a *missing input* out of an unreadable *output* |

## Scope correction to the finding

The manifest claims the same blindness reaches `find_smiles_not_in_sdf` for `.smi` input via `iter_smi_records(on_malformed="skip")`. **It does not.** `encode_ids` reads `.smi` with `on_malformed="raise"`, so a malformed SMILES line aborts the run with `InputValidationError` long before reconciliation. Verified in source — only the SDF path was live.

That does leave a real divergence: **`.smi` refuses the whole file, `.sdf` processes the rest.** Noted in the code rather than fixed here, because unifying it changes behavior for large files and belongs with the other validation-consistency work (B4 in the plan).

## An existing test was enshrining the defect

`test_skips_none_records_on_both_sides` asserted `find_ids_not_in_sdf(...) == []` for a source containing an unreadable record, under the heading *"A None record (unparseable) in either SDF must not crash or miscount."* The empty list **was** the miscount. Rewritten to assert the asymmetry above, with the history in its docstring so it cannot be quietly reverted to the old claim.

## Verification

- Tripwire first, on a real corrupted molblock (counts line broken so only the line under test is invalid), with the premise asserted: RDKit reads one molecule and one `None`.
- **Mutation-verified** — restoring the `continue` turns both the new test and the rewritten one red.
- A companion test asserts a clean source file still reports nothing, so the new branch cannot manufacture failures.
- 1281 passed, 9 skipped locally; ruff clean.