### PR TITLE
refactor!: delete the utils barrel and make utils a leaf package

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,6 +3,19 @@ API Reference
 
 This section documents the public API of Auto3D.
 
+A name is public if and only if it appears below, at the dotted path given here.
+Anything absent is internal: import it from the module that defines it and expect
+it to move. ``Auto3D.__all__`` is a narrower thing again -- the top-level
+convenience barrel, and the only re-export barrel in the package. Every name it
+exports is listed here; the reverse does not hold, and is not meant to. Most of
+what follows (the exception classes, ``get_device``, ``CustomNNP``) is public at
+its module path and deliberately has no top-level alias, so there is exactly one
+supported way to import it.
+
+Both directions are enforced by ``tests/test_import_boundaries.py``: every path
+listed here must resolve, and nothing may be exported from ``Auto3D.__all__``
+without appearing here.
+
 Core Functions
 --------------
 
@@ -13,6 +26,15 @@ The main entry points for Auto3D:
 
    Auto3D.auto3D.main
    Auto3D.auto3D.smiles2mols
+
+``generate_conformers`` is the canonical, self-describing name for ``main()``.
+It exists only as a top-level alias -- ``main`` remains the function's name in
+``Auto3D.auto3D`` -- so it is documented at the path it is importable from:
+
+.. autosummary::
+   :toctree: generated
+
+   Auto3D.generate_conformers
 
 Configuration
 -------------

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -23,7 +23,7 @@ from rdkit import Chem
 from rdkit.Chem import rdmolops
 from tqdm import tqdm
 
-from Auto3D.batch_opt.batchopt import EnForce_ANI
+from Auto3D.batch_opt.model_wrapper import EnForce_ANI
 from Auto3D.constants import (
     DEFAULT_OPT_STEPS,
     DEFAULT_THERMO_CONVERGENCE_THRESHOLD,
@@ -39,7 +39,7 @@ from Auto3D.model_factory import create_model, get_device
 from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.models.species import to_model_species
 from Auto3D.torch_config import TorchConfig, configure_torch
-from Auto3D.utils import hartree2ev
+from Auto3D.utils.chemistry import hartree2ev
 from Auto3D.utils.logging_config import get_logger
 from Auto3D.utils.validation import (
     check_engine_supports_molecules,

--- a/src/Auto3D/SPE.py
+++ b/src/Auto3D/SPE.py
@@ -6,12 +6,12 @@ from pathlib import Path
 
 from rdkit import Chem
 
-from Auto3D.batch_opt.batchopt import EnForce_ANI
+from Auto3D.batch_opt.model_wrapper import EnForce_ANI
 from Auto3D.batch_opt.padding import pad_from_mols
 from Auto3D.model_factory import create_model, get_device
 from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.torch_config import TorchConfig, configure_torch
-from Auto3D.utils import hartree2ev
+from Auto3D.utils.chemistry import hartree2ev
 from Auto3D.utils.logging_config import get_logger
 from Auto3D.utils.validation import (
     check_engine_supports_molecules,

--- a/src/Auto3D/auto3D.py
+++ b/src/Auto3D/auto3D.py
@@ -25,14 +25,14 @@ from Auto3D.isomers import IsomerEngineFactory
 from Auto3D.model_factory import create_model
 from Auto3D.models.preflight import preflight_model
 from Auto3D.ranking import ranking
-from Auto3D.utils import (
-    check_input,
-    check_valid_configuration,
+from Auto3D.utils.file_ops import (
     create_chunk_meta_names,
+    find_smiles_not_in_sdf,
     reorder_sdf,
+    smiles2smi,
 )
-from Auto3D.utils.file_ops import find_smiles_not_in_sdf, smiles2smi
 from Auto3D.utils.logging_config import configure_logging, get_logger
+from Auto3D.utils.validation import check_input, check_valid_configuration
 
 # Pipeline workers live in workflow_workers to break the auto3D<->workflow import
 # cycle. Re-exported here for backward compatibility with code/tests that import

--- a/src/Auto3D/batch_opt/ANI2xt_no_rep.py
+++ b/src/Auto3D/batch_opt/ANI2xt_no_rep.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 
 from Auto3D.models.species import ANI2XT_INDEX
-from Auto3D.utils import hartree2ev
+from Auto3D.utils.chemistry import hartree2ev
 
 # Note: Do NOT set torch.manual_seed() at module level.
 # Random seed should be controlled by the caller, not by importing a module.

--- a/src/Auto3D/batch_opt/batchopt.py
+++ b/src/Auto3D/batch_opt/batchopt.py
@@ -22,14 +22,15 @@ from rdkit import Chem
 # Note: TF32 settings are now configured via Auto3D.torch_config.configure_torch()
 # and the allow_tf32 option in Auto3DOptions. The hardcoded settings have been
 # removed to allow user configuration.
-# EnForce_ANI extracted to separate module for better modularity
-# Re-export for backward compatibility - modules like SPE.py and ASE/thermo.py
-# import EnForce_ANI from this module
+#
+# `EnForce_ANI` and `n_steps` are imported because this module uses them
+# (`ensemble_opt`'s annotation and `optimizing.run`'s construction; the step
+# loop), NOT as re-exports. Their homes are `batch_opt.model_wrapper` and
+# `batch_opt.optimization_engine`; import them from there. `print_stats` used to
+# be imported here purely to re-export -- nothing in this file called it -- and
+# is gone.
 from Auto3D.batch_opt.model_wrapper import EnForce_ANI
-
-# Optimization loop functions extracted to separate module for better modularity
-# Re-export for backward compatibility (print_stats kept as public re-export)
-from Auto3D.batch_opt.optimization_engine import n_steps, print_stats  # noqa: F401
+from Auto3D.batch_opt.optimization_engine import n_steps
 from Auto3D.constants import INITIAL_ENERGY_SENTINEL, INITIAL_FMAX_SENTINEL
 
 # Deliberately NOT `from Auto3D.model_factory import create_model`. This module

--- a/src/Auto3D/filtering.py
+++ b/src/Auto3D/filtering.py
@@ -10,7 +10,7 @@ from Auto3D.constants import (
     DEFAULT_ENERGY_CLUSTER_WINDOW,
     DEFAULT_RMSD_THRESHOLD,
 )
-from Auto3D.utils import check_connectivity
+from Auto3D.utils.chemistry import check_connectivity
 from Auto3D.utils.convergence import converged_or_unfiltered
 from Auto3D.utils.energy import e_tot_ev, try_e_tot_ev
 from Auto3D.utils.stereo_check import species_key, stereo_preserved

--- a/src/Auto3D/isomer_engine.py
+++ b/src/Auto3D/isomer_engine.py
@@ -20,18 +20,20 @@ from rdkit.Chem.MolStandardize import rdMolStandardize
 from tqdm import tqdm
 
 from Auto3D.constants import CONFORMER_RANDOM_SEED, MAX_STEREOISOMERS
-from Auto3D.utils import (
-    amend_configuration_w,
+from Auto3D.utils.chemistry import calculate_conformer_count, relieve_clash
+from Auto3D.utils.file_ops import (
+    combine_smi,
     hash_enumerated_smi_IDs,
-    relieve_clash,
+    iter_smi_records,
+)
+from Auto3D.utils.stereochemistry import (
+    amend_configuration_w,
+    enantiomer_key,
     remove_enantiomers,
 )
-from Auto3D.utils.chemistry import calculate_conformer_count
-from Auto3D.utils.file_ops import combine_smi, iter_smi_records
 from Auto3D.utils.stereochemistry import (
     count_unspecified_stereo as _count_unspecified_stereo,
 )
-from Auto3D.utils.stereochemistry import enantiomer_key
 
 try:
     from openeye import oechem, oeomega, oequacpac

--- a/src/Auto3D/isomers/parallel_embed.py
+++ b/src/Auto3D/isomers/parallel_embed.py
@@ -10,8 +10,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 from Auto3D.constants import CONFORMER_RANDOM_SEED
-from Auto3D.utils import relieve_clash
-from Auto3D.utils.chemistry import calculate_conformer_count
+from Auto3D.utils.chemistry import calculate_conformer_count, relieve_clash
 from Auto3D.utils.logging_config import get_logger
 
 logger = get_logger(__name__)

--- a/src/Auto3D/models/preflight.py
+++ b/src/Auto3D/models/preflight.py
@@ -165,10 +165,12 @@ def preflight_model(engine: str) -> None:
     # (pure, offline) functions importable without pulling in the model stack.
     # `requests` is now also declared directly in pyproject.toml (previously
     # it arrived only transitively, via aimnet's own `requests>=2.32.3`), but
-    # deferring the import here still matters on its own: `import Auto3D.utils`
-    # (which reaches this module through utils/validation.py) stays free of a
-    # dependency it does not otherwise need, regardless of how `requests`
-    # is declared.
+    # deferring the import here still matters on its own: `resolve_engine_name`
+    # is a pure offline dict read that config validation calls on every run, and
+    # it must not require a network library to be importable. (The original
+    # reason was narrower and no longer applies: `import Auto3D.utils` used to
+    # reach this module through a module-scope import in utils/validation.py,
+    # which audit M43 deferred into the two functions that use it.)
     import requests
     from aimnet.calculators.model_registry import get_registry_model_path
 

--- a/src/Auto3D/models/species.py
+++ b/src/Auto3D/models/species.py
@@ -15,9 +15,12 @@ also supplies ``species_pad``, so the remap and the padding sentinel cannot come
 from two sources and disagree (audit findings C3/C4).
 
 Layering note: rdkit is imported lazily, inside the error branch that needs it
-for an element symbol. ``models/`` is reached from ``utils/validation.py`` and
-therefore from ``import Auto3D.utils``; a module-scope rdkit import here would
-make that import pay for rdkit (audit M44).
+for an element symbol. This module is a pure lookup table plus a remap; it is
+imported by the padder, by ``ASE/`` and by ``cli/``, none of which otherwise
+need rdkit, and only the error path does. (The original reason was narrower and
+no longer applies: ``models/`` used to be reachable from ``import Auto3D.utils``
+via a module-scope import in ``utils/validation.py``, which audit M43 deferred
+into the two functions that use it.)
 """
 from __future__ import annotations
 

--- a/src/Auto3D/processors.py
+++ b/src/Auto3D/processors.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from Auto3D.config import Auto3DOptions
 from Auto3D.isomers import create_tautomer_engine
-from Auto3D.utils import hash_taut_smi
+from Auto3D.utils.file_ops import hash_taut_smi
 from Auto3D.utils.logging_config import get_logger
 
 logger = get_logger(__name__)

--- a/src/Auto3D/ranking.py
+++ b/src/Auto3D/ranking.py
@@ -8,8 +8,7 @@ from rdkit import Chem
 from Auto3D.config import SELECTOR_FIELDS, check_selectors_mutually_exclusive
 from Auto3D.exceptions import ConfigurationError, InputValidationError
 from Auto3D.filtering import filter_unique_optimized
-from Auto3D.utils import ev2kcalpermol, filter_unique
-from Auto3D.utils.chemistry import check_connectivity
+from Auto3D.utils.chemistry import check_connectivity, ev2kcalpermol, filter_unique
 from Auto3D.utils.convergence import converged_or_unfiltered, has_convergence_flag
 from Auto3D.utils.energy import E_TOT_HARTREE_PROP, E_TOT_PROP, e_tot_ev
 from Auto3D.utils.logging_config import get_logger

--- a/src/Auto3D/tautomer.py
+++ b/src/Auto3D/tautomer.py
@@ -8,7 +8,7 @@ from rdkit import Chem
 from Auto3D.auto3D import main
 from Auto3D.config import Auto3DOptions
 from Auto3D.exceptions import ConfigurationError
-from Auto3D.utils import hartree2kcalpermol
+from Auto3D.utils.chemistry import hartree2kcalpermol
 from Auto3D.utils.energy import e_tot_hartree
 from Auto3D.utils.logging_config import get_logger
 

--- a/src/Auto3D/utils/__init__.py
+++ b/src/Auto3D/utils/__init__.py
@@ -1,108 +1,43 @@
-"""Auto3D utility modules.
+"""Generic helpers shared by every Auto3D layer.
 
-This package contains utility functions split into focused modules:
-- chemistry: Energy conversions, molecular properties, geometry utilities
-- convergence: The single owner of the 'Converged' SDF property
-- stereochemistry: Functions for stereochemistry detection and manipulation
-- validation: Functions for input validation and filtering
-- file_ops: File I/O operations (SMILES files, SDF chunking, ID encoding)
-- logging_config: Logging configuration and logger factory
+This package is a **namespace, not a barrel**: it re-exports nothing, and
+``__init__.py`` deliberately contains no code at all. Import each name from the
+module that defines it -- ``from Auto3D.utils.chemistry import hartree2ev``, not
+``from Auto3D.utils import hartree2ev``. The barrel that used to live here
+listed 41 names drawn from five of the eight modules below, so the three it
+omitted (``energy``, ``convergence``, ``stereo_check``) had no way in, and the
+same function was reached by two different paths in sibling modules. See
+``docs/source/api.rst`` for the rule and the CHANGELOG for the full old-to-new
+mapping.
+
+Nothing here is public API. ``api.rst`` documents no ``Auto3D.utils`` name;
+these modules exist for Auto3D's own use and may move.
+
+What each module owns:
+
+``chemistry``
+    Energy-unit conversions and their constants, molecular properties (charge,
+    connectivity), RMSD, clash relief, conformer-count heuristics.
+``convergence``
+    The single owner of the ``Converged`` SDF property -- reading it, writing
+    it, and deciding what counts as converged.
+``energy``
+    The single owner of the ``E_tot`` SDF properties, in both eV and hartree.
+``file_ops``
+    File I/O: SMILES/SDF reading and writing, SDF chunking, ID encode/decode,
+    housekeeping, output reordering.
+``logging_config``
+    Logging setup and the logger factory every module calls.
+``stereo_check``
+    Species keys and the stereochemistry-preserved check applied after
+    optimization.
+``stereochemistry``
+    Stereocenter detection, enantiomer enumeration and removal, configuration
+    amendment.
+``validation``
+    Input and configuration validation. The one module here that is not a
+    pure leaf by nature: it needs ``Auto3D.models`` to resolve an engine name
+    and to load a custom NNP, so both imports are function-scope, keeping
+    ``utils`` free of a dependency on a domain package
+    (``tests/test_import_boundaries.py`` enforces this).
 """
-
-from Auto3D.utils.chemistry import (
-    EV_TO_KCAL_PER_MOL,
-    HARTREE_TO_EV,
-    HARTREE_TO_KCAL_PER_MOL,
-    amend_mol,
-    check_connectivity,
-    ev2kcalpermol,
-    filter_unique,
-    get_mol_charge,
-    get_mol_connectivity,
-    get_rmsd,
-    hartree2ev,
-    hartree2kcalpermol,
-    min_pairwise_distance,
-    relieve_clash,
-)
-from Auto3D.utils.file_ops import (
-    SDF2chunks,
-    combine_smi,
-    create_chunk_meta_names,
-    decode_ids,
-    encode_ids,
-    guess_file_type,
-    hash_enumerated_smi_IDs,
-    hash_taut_smi,
-    housekeeping,
-    reorder_sdf,
-)
-from Auto3D.utils.logging_config import configure_logging, get_logger
-from Auto3D.utils.stereochemistry import (
-    amend_configuration,
-    amend_configuration_w,
-    check_value,
-    count_unspecified_stereo,
-    create_enantiomer,
-    enantiomer,
-    enantiomer_helper,
-    get_stereo_info,
-    no_enantiomer,
-    no_enantiomer_helper,
-    remove_enantiomers,
-)
-from Auto3D.utils.validation import (
-    check_input,
-    check_sdf_format,
-    check_smi_format,
-    check_valid_configuration,
-)
-
-__all__ = [
-    # Logging configuration
-    "get_logger",
-    "configure_logging",
-    # Chemistry module exports
-    "HARTREE_TO_EV",
-    "HARTREE_TO_KCAL_PER_MOL",
-    "EV_TO_KCAL_PER_MOL",
-    "hartree2ev",
-    "hartree2kcalpermol",
-    "ev2kcalpermol",
-    "get_mol_charge",
-    "min_pairwise_distance",
-    "relieve_clash",
-    "get_rmsd",
-    "check_connectivity",
-    "amend_mol",
-    "get_mol_connectivity",
-    "filter_unique",
-    # Stereochemistry functions
-    "count_unspecified_stereo",
-    "enantiomer",
-    "enantiomer_helper",
-    "remove_enantiomers",
-    "no_enantiomer_helper",
-    "get_stereo_info",
-    "no_enantiomer",
-    "create_enantiomer",
-    "check_value",
-    "amend_configuration",
-    "amend_configuration_w",
-    # Validation functions
-    "check_input",
-    "check_smi_format",
-    "check_sdf_format",
-    "check_valid_configuration",
-    # File operations
-    "guess_file_type",
-    "hash_enumerated_smi_IDs",
-    "hash_taut_smi",
-    "housekeeping",
-    "create_chunk_meta_names",
-    "combine_smi",
-    "SDF2chunks",
-    "encode_ids",
-    "decode_ids",
-    "reorder_sdf",
-]

--- a/src/Auto3D/utils/validation.py
+++ b/src/Auto3D/utils/validation.py
@@ -21,8 +21,6 @@ from Auto3D.exceptions import (
     InputValidationError,
     ModelLoadError,
 )
-from Auto3D.models.loading import load_custom_nnp
-from Auto3D.models.preflight import resolve_engine_name
 from Auto3D.utils.logging_config import get_logger
 from Auto3D.utils.stereochemistry import count_unspecified_stereo
 
@@ -346,6 +344,12 @@ def check_input(args: Any) -> None:
     if Path(args.optimizing_engine).exists():
         # Validate that a custom NNP path loads (TorchScript archive or eager
         # nn.Module); shared load contract -- see Auto3D.models.loading.
+        #
+        # Function-scope on purpose: `utils` is the bottom of the stack and must
+        # not import the `models` domain package at module level. Reached only
+        # when the engine really is a path on disk.
+        from Auto3D.models.loading import load_custom_nnp
+
         try:
             load_custom_nnp(args.optimizing_engine, torch.device("cpu"))
         except ModelLoadError as e:
@@ -615,6 +619,11 @@ def check_valid_configuration(options: Auto3DOptions) -> list[str]:
     # optim_rank_wrapper's per-chunk handler swallowed it. The registry lookup
     # is a pure offline dict read against a bundled YAML, so validating costs
     # nothing.
+    #
+    # Function-scope for the same reason as load_custom_nnp above: it keeps
+    # `utils` from importing the `models` domain package at module level.
+    from Auto3D.models.preflight import resolve_engine_name
+
     try:
         resolve_engine_name(options.optimizing_engine)
     except ConfigurationError as exc:

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -18,14 +18,15 @@ from Auto3D.exceptions import ConfigurationError, FileFormatError, OptimizationE
 from Auto3D.model_factory import ModelFactory
 from Auto3D.models.preflight import preflight_model
 from Auto3D.torch_config import TorchConfig, configure_torch
-from Auto3D.utils import check_input, check_valid_configuration, reorder_sdf
 from Auto3D.utils.file_ops import (
     decode_ids,
     encode_ids,
     find_ids_not_in_sdf,
     find_smiles_not_in_sdf,
+    reorder_sdf,
 )
 from Auto3D.utils.logging_config import get_logger
+from Auto3D.utils.validation import check_input, check_valid_configuration
 from Auto3D.workflow_workers import (
     isomer_wrapper,
     logger_process,

--- a/src/Auto3D/workflow_workers.py
+++ b/src/Auto3D/workflow_workers.py
@@ -27,7 +27,7 @@ from Auto3D.isomers import IsomerEngineFactory
 from Auto3D.model_factory import create_model
 from Auto3D.processors import TautomerProcessor
 from Auto3D.ranking import ranking
-from Auto3D.utils import create_chunk_meta_names, housekeeping
+from Auto3D.utils.file_ops import create_chunk_meta_names, housekeeping
 
 if TYPE_CHECKING:
     from logging import LogRecord

--- a/tests/test_batchopt.py
+++ b/tests/test_batchopt.py
@@ -7,7 +7,8 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from Auto3D.batch_opt.batchopt import optimizing, EnForce_ANI
+from Auto3D.batch_opt.batchopt import optimizing
+from Auto3D.batch_opt.model_wrapper import EnForce_ANI
 from tests.helpers_adapter import FakeAdapter
 
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -391,7 +391,7 @@ class TestFilterUniqueBehavior:
         real Auto3D contract). Use genuinely distinct conformers of one molecule
         so RMSD is well-defined and comparable across both implementations.
         """
-        from Auto3D.utils import filter_unique
+        from Auto3D.utils.chemistry import filter_unique
 
         def conformer(seed: float, energy_ev: float) -> Chem.Mol:
             m = Chem.AddHs(Chem.MolFromSmiles("CCCCCCO"))  # flexible chain

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -1,7 +1,9 @@
-"""Import boundaries for the ``Auto3D`` package root: what ``import Auto3D``
-is allowed to cost, and what the package root is allowed to expose.
+"""Import boundaries: what ``import Auto3D`` is allowed to cost, what is public,
+and which packages are allowed to re-export.
 
-Two properties are locked here.
+Four properties are locked here. The last three are static (AST) checks over
+``src/Auto3D/**`` plus one subprocess probe; only the first needs the package
+imported.
 
 **Import cost.** ``import Auto3D`` must reach nothing but the standard library.
 The package root is the entry point every consumer pays for -- ``auto3d
@@ -21,6 +23,22 @@ was False) while the module namespace still exposes whatever the module body
 happened to import. Both halves are asserted -- the public names are visible,
 and the import-machinery names are not.
 
+**The public-surface rule.** ``docs/source/api.rst`` is the definition of what
+is public, at the dotted paths it lists; ``Auto3D.__all__`` is the top-level
+convenience barrel and may export only what api.rst documents. Both directions
+are checked, so the rule is mechanical rather than a preference. See the section
+comment above ``test_api_rst_entries_resolve_at_their_documented_path`` for why
+the implication runs one way only.
+
+**No package re-exports anything.** ``Auto3D/utils/__init__.py`` was a 41-name
+barrel assembled from five of its eight submodules, so three of them had no way
+in, and the same function was imported through the barrel in one module and
+through its defining module in a sibling. ``batch_opt/batchopt.py`` was a
+narrower version of the same thing. Deleting a barrel needs both halves asserted
+-- the names are gone, *and* nobody imports through it -- because removing only
+the consumers leaves a live barrel for the next contributor, and removing only
+the barrel is caught by the type checker at best.
+
 Every cost measurement runs in a **subprocess**. It cannot be done in-process:
 ``conftest.py`` deliberately imports every ``Auto3D`` submodule before the first
 test runs (see ``_import_every_auto3d_module_before_any_test``), so by the time
@@ -29,8 +47,10 @@ of Auto3D. An in-process version of these tests would pass unconditionally.
 """
 from __future__ import annotations
 
+import ast
 import importlib
 import json
+import pathlib
 import subprocess
 import sys
 
@@ -250,3 +270,371 @@ def test_unknown_attribute_raises_attribute_error():
 
     with pytest.raises(AttributeError, match="no attribute 'nope'"):
         getattr(Auto3D, "nope")  # noqa: B009  (the lookup is the assertion)
+
+
+# --------------------------------------------------------------------------- #
+# The public-surface rule
+# --------------------------------------------------------------------------- #
+#
+# A name is public iff ``docs/source/api.rst`` documents it, at the dotted path
+# api.rst gives, and that path resolves. ``Auto3D.__all__`` is a *second*,
+# narrower thing: the top-level convenience barrel, and the only barrel in the
+# package. Every name in it must also be documented in api.rst, so nothing is
+# exported that is not documented.
+#
+# The rule is deliberately **not** "api.rst and ``__all__`` hold the same
+# names". api.rst documents 24 entries, ten of which are the exception classes
+# (``Auto3D.exceptions.*``); none of those is in ``__all__`` and none should be.
+# api.rst documents *dotted paths*, and the rest of the docs consistently
+# reference these names that way -- ``Auto3D.model_factory.get_device``,
+# ``Auto3D.models.contract.CustomNNP`` (migration-4.0.rst calls that "the
+# surviving one", against the removed ``from Auto3D.models import CustomNNP``),
+# ``Auto3D.isomers.IsomerEngineFactory``. Promoting those into ``__all__`` would
+# mint a *second* supported path for each and contradict the migration guide, so
+# the implication runs one way only: exported implies documented.
+#
+# Corollary, checked by ``test_only_documented_subpackages_define_all``: no
+# subpackage ``__init__.py`` re-exports anything, unless its api.rst-documented
+# dotted path *is* the package path.
+
+API_RST = pathlib.Path(__file__).resolve().parents[1] / "docs" / "source" / "api.rst"
+
+# ``__version__`` is a string produced by the package itself, not an API object
+# autosummary can document.
+UNDOCUMENTED_BY_DESIGN = frozenset({"__version__"})
+
+
+def _api_rst_entries() -> list[str]:
+    """Dotted paths listed under api.rst's ``autosummary`` directives."""
+    entries = []
+    in_block = False
+    for raw in API_RST.read_text().splitlines():
+        line = raw.strip()
+        if line.startswith(".. autosummary::"):
+            in_block = True
+            continue
+        if not in_block:
+            continue
+        if not line:
+            continue
+        if line.startswith(":"):  # directive option, e.g. :toctree:
+            continue
+        if line.startswith("Auto3D."):
+            entries.append(line)
+        else:  # any other non-blank, non-indented content ends the block
+            in_block = False
+    return entries
+
+
+def _resolve_dotted_path(path: str):
+    """Import the longest importable prefix of ``path``, then getattr the rest.
+
+    Written this way so a package-path entry (``Auto3D.isomers.IsomerEngineFactory``,
+    ``Auto3D.generate_conformers``) resolves by the same rule as a module-path
+    entry (``Auto3D.auto3D.main``), instead of the test hard-coding which is which.
+    """
+    parts = path.split(".")
+    for split in range(len(parts) - 1, 0, -1):
+        module_name = ".".join(parts[:split])
+        try:
+            obj = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        for attr in parts[split:]:
+            obj = getattr(obj, attr)
+        return obj
+    raise AssertionError(f"no importable module prefix in {path!r}")
+
+
+def test_api_rst_entries_resolve_at_their_documented_path():
+    """Every documented dotted path is real.
+
+    This is what makes the rule checkable rather than aspirational: api.rst is
+    the definition of the public surface, so a documented path that no longer
+    resolves is a broken promise, and a sphinx build is too slow to be the only
+    place that notices.
+    """
+    entries = _api_rst_entries()
+    assert len(entries) > 20, f"api.rst parse looks wrong: {entries}"
+    broken = []
+    for path in entries:
+        try:
+            _resolve_dotted_path(path)
+        except (AssertionError, AttributeError, ImportError) as exc:
+            broken.append(f"{path}: {type(exc).__name__}: {exc}")
+    assert not broken, "api.rst documents paths that do not resolve:\n" + "\n".join(broken)
+
+
+def test_every_exported_name_is_documented_in_api_rst():
+    """``Auto3D.__all__`` may not export an undocumented name.
+
+    The top-level barrel is the one place a name can be reached without knowing
+    which module defines it, so it is the one place an undocumented export is
+    invisible. Note the implication is one-way -- api.rst documents plenty that
+    ``__all__`` does not export (see the section comment above).
+    """
+    import Auto3D
+
+    documented_leaves = {path.rsplit(".", 1)[1] for path in _api_rst_entries()}
+    undocumented = sorted(
+        set(Auto3D.__all__) - documented_leaves - UNDOCUMENTED_BY_DESIGN
+    )
+    assert not undocumented, (
+        "names exported from Auto3D.__all__ but absent from docs/source/api.rst: "
+        f"{undocumented}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Package barrels: static (AST) enforcement
+# --------------------------------------------------------------------------- #
+#
+# Static, and specifically AST rather than a regex over the text. A regex
+# matches the historical ``from Auto3D.utils import ...`` snippets that live on
+# purpose in ``docs/plans/**`` and in ``docs/source/migration-4.0.rst`` (where
+# the barrel import is the deliberate *before* half of a before/after pair), so
+# a regex-based check could be "satisfied" by falsifying the migration guide.
+# Everything below is scoped to ``src/Auto3D/**`` only.
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src" / "Auto3D"
+
+# ``from Auto3D.utils import chemistry`` -- naming a submodule -- stays legal;
+# it is a module reference, not a re-export. ``from Auto3D.utils import
+# hartree2ev`` does not.
+UTILS_SUBMODULES = frozenset(
+    p.stem for p in (SRC_ROOT / "utils").glob("*.py") if p.stem != "__init__"
+)
+
+# Names ``batch_opt/batchopt.py`` re-exported for backward compatibility. Two
+# of them (``EnForce_ANI``, ``n_steps``) the module genuinely uses, so they
+# still resolve there; ``batchopt`` is nonetheless not their home and no
+# first-party module may reach them through it.
+BATCHOPT_REEXPORTS = frozenset({"EnForce_ANI", "n_steps", "print_stats"})
+
+# The only subpackage whose api.rst-documented dotted path *is* the package
+# path, and therefore the only one allowed to re-export. ``cli`` and ``models``
+# still carry an ``__all__`` and are known remaining barrels: neither is
+# documented at its package path (api.rst documents
+# ``Auto3D.models.contract.CustomNNP``, and no ``Auto3D.cli`` name at all), so
+# both are debt this set records rather than blesses. Removing one means
+# deleting it from here, not adding it.
+SUBPACKAGES_WITH_ALL = frozenset({"isomers", "cli", "models"})
+
+
+def _source_files() -> list[pathlib.Path]:
+    return sorted(p for p in SRC_ROOT.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _absolute_module(node: ast.ImportFrom, path: pathlib.Path) -> str | None:
+    """Absolute module name an ``ImportFrom`` names, resolving relative levels."""
+    if not node.level:
+        return node.module
+    package = path.parent.relative_to(SRC_ROOT.parent).parts
+    if node.level > 1:
+        package = package[: -(node.level - 1)]
+    return ".".join((*package, node.module)) if node.module else ".".join(package)
+
+
+def test_no_src_module_imports_through_the_utils_barrel():
+    """No first-party module pulls a *name* out of ``Auto3D.utils``.
+
+    The barrel was never a coherent surface -- three of its eight submodules
+    (``energy``, ``convergence``, ``stereo_check``) had no presence in it at all
+    -- and ``check_connectivity`` was reached through the barrel in
+    ``filtering.py`` and through ``utils.chemistry`` in ``ranking.py``, two
+    sibling modules disagreeing about the same function with nothing saying
+    which was right.
+    """
+    offenders = []
+    for path in _source_files():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if _absolute_module(node, path) != "Auto3D.utils":
+                continue
+            names = [a.name for a in node.names if a.name not in UTILS_SUBMODULES]
+            if names:
+                offenders.append(f"{path.relative_to(SRC_ROOT.parent)}:{node.lineno}: {names}")
+    assert not offenders, (
+        "imports through the Auto3D.utils barrel (import from the defining "
+        "module instead):\n" + "\n".join(offenders)
+    )
+
+
+def test_utils_init_imports_nothing():
+    """``utils/__init__.py`` is docstring-only.
+
+    Frozen deliberately, and not merely as the tail of the demolition: a later
+    cluster splits ``utils/file_ops.py`` and moves modules underneath this
+    package. Its own proposal was to "keep ``file_ops.py`` as a re-export shim
+    so ``utils/__init__.py`` is untouched", which would rebuild the barrel one
+    directory down. This test makes that fail here instead of being noticed
+    later, or not at all.
+    """
+    path = SRC_ROOT / "utils" / "__init__.py"
+    tree = ast.parse(path.read_text(), filename=str(path))
+    imports = [
+        f"line {node.lineno}"
+        for node in tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+    assert not imports, f"utils/__init__.py imports something: {imports}"
+    non_docstring = [
+        type(node).__name__ for node in tree.body if not _is_docstring(node)
+    ]
+    assert not non_docstring, (
+        f"utils/__init__.py has statements beyond its docstring: {non_docstring}"
+    )
+
+
+def _is_docstring(node: ast.stmt) -> bool:
+    return isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) \
+        and isinstance(node.value.value, str)
+
+
+def test_utils_package_exposes_no_names():
+    """The demolition's other half: the names are actually gone at runtime.
+
+    The AST test proves nobody in ``src/`` reaches through the barrel; this
+    proves the barrel is not there to reach through. Both halves are needed --
+    deleting only the consumers leaves a live barrel for the next contributor
+    to use.
+    """
+    utils = importlib.import_module("Auto3D.utils")
+    assert not hasattr(utils, "__all__"), (
+        f"Auto3D.utils still declares __all__: {getattr(utils, '__all__', None)}"
+    )
+    # The ``from ... import name`` form, because that is what consumers wrote
+    # and it is the form that raises ImportError (a bare getattr would raise
+    # AttributeError, a weaker and differently-worded failure).
+    for name in ("check_input", "check_connectivity", "hartree2ev", "reorder_sdf"):
+        with pytest.raises(ImportError):
+            exec(f"from Auto3D.utils import {name}", {})  # noqa: S102
+
+
+def test_utils_submodule_imports_still_work():
+    """Emptying the barrel must not break ``from Auto3D.utils import chemistry``.
+
+    A submodule reference is not a re-export, several tests use this form, and
+    ``__init__.py`` importing nothing is exactly the condition under which it is
+    easy to assume otherwise.
+    """
+    from Auto3D.utils import chemistry, validation
+
+    assert chemistry.hartree2ev > 0  # a float constant, not a function
+    assert callable(validation.check_input)
+
+
+def test_only_documented_subpackages_define_all():
+    """A subpackage may re-export only if api.rst documents it at that path."""
+    offenders = {}
+    for path in _source_files():
+        if path.name != "__init__.py" or path.parent == SRC_ROOT:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        declares_all = any(
+            isinstance(node, ast.Assign)
+            and any(getattr(t, "id", None) == "__all__" for t in node.targets)
+            for node in tree.body
+        )
+        if declares_all:
+            offenders[path.parent.name] = str(path.relative_to(SRC_ROOT.parent))
+    assert set(offenders) == SUBPACKAGES_WITH_ALL, (
+        "subpackages declaring __all__ changed; expected "
+        f"{sorted(SUBPACKAGES_WITH_ALL)}, found {sorted(offenders)}"
+    )
+
+
+def test_no_src_module_imports_batchopt_reexports():
+    """``batchopt`` is not the home of ``EnForce_ANI``/``n_steps``/``print_stats``.
+
+    ``batchopt.py`` itself still *uses* the first two, so they resolve there and
+    third-party code does not break today -- but a first-party import through
+    that path is what kept the compat barrel alive and made the module look like
+    the owner of a class defined in ``model_wrapper``.
+    """
+    offenders = []
+    for path in _source_files():
+        if path == SRC_ROOT / "batch_opt" / "batchopt.py":
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if _absolute_module(node, path) != "Auto3D.batch_opt.batchopt":
+                continue
+            names = [a.name for a in node.names if a.name in BATCHOPT_REEXPORTS]
+            if names:
+                offenders.append(f"{path.relative_to(SRC_ROOT.parent)}:{node.lineno}: {names}")
+    assert not offenders, (
+        "imports of batchopt's compat re-exports:\n" + "\n".join(offenders)
+    )
+
+
+def test_batchopt_does_not_re_export_print_stats():
+    """The one name ``batchopt`` re-exported without using it is gone."""
+    batchopt = importlib.import_module("Auto3D.batch_opt.batchopt")
+    assert not hasattr(batchopt, "print_stats"), (
+        "batchopt still re-exports print_stats; its home is "
+        "Auto3D.batch_opt.optimization_engine"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# utils/ is a leaf
+# --------------------------------------------------------------------------- #
+
+# Subprocess, for the same reason as the cost tests above: conftest imports
+# every Auto3D module before any test runs, so in-process this would pass
+# unconditionally.
+_LEAF_PROBE_SOURCE = """
+import json, sys
+import Auto3D.utils.validation  # noqa: F401
+print(json.dumps(sorted(
+    m for m in sys.modules if m == "Auto3D.models" or m.startswith("Auto3D.models.")
+)))
+"""
+
+
+def test_importing_utils_validation_does_not_load_models():
+    """``utils/`` must not depend on the ``models/`` domain package.
+
+    ``utils`` is a leaf by intent -- generic helpers every layer may use -- and
+    ``validation.py`` was the single module breaking that, with two module-level
+    imports of ``Auto3D.models.*`` whose only consumers are function-scope. A
+    domain package reached from the bottom of the stack is what let one probe in
+    ``Auto3D/__init__.py`` drag in the entire model layer.
+
+    Scoped to ``Auto3D.models`` on purpose: ``validation.py`` legitimately
+    imports torch and rdkit at module scope, and must keep doing so -- twenty-two
+    test sites patch ``Auto3D.utils.validation.torch.cuda.is_available``, which
+    requires ``torch`` to be a real attribute of this module's namespace.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _LEAF_PROBE_SOURCE],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"probe failed:\n{proc.stdout}\n{proc.stderr}"
+    loaded = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert not loaded, (
+        f"importing Auto3D.utils.validation pulled in the models package: {loaded}"
+    )
+
+
+def test_validation_imports_torch_at_module_scope():
+    """The companion constraint, pinned so the leaf fix cannot overreach.
+
+    ``torch`` is a third-party leaf, not a domain package, and twenty-two test
+    sites patch ``Auto3D.utils.validation.torch.cuda.is_available``. Deferring
+    this import would break every one of them at once, and the leaf test above
+    would still pass -- so the prohibition is stated here rather than left to be
+    inferred.
+    """
+    validation = importlib.import_module("Auto3D.utils.validation")
+    assert hasattr(validation, "torch"), (
+        "utils/validation.py no longer imports torch at module scope; "
+        "monkeypatches targeting Auto3D.utils.validation.torch.* will silently "
+        "target nothing"
+    )

--- a/tests/test_model_preflight.py
+++ b/tests/test_model_preflight.py
@@ -376,13 +376,18 @@ class TestNamedEngineNotHijackedByCwdFile:
 class TestRequestsImportedLazily:
     """`requests` must not be imported at module scope in preflight.py.
 
-    utils/validation.py imports preflight, and utils/__init__.py imports
-    that, so a module-scope `import requests` here made `import Auto3D.utils`
-    hard-fail without `requests` installed -- even though every other heavy
-    import in this module (aimnet.calculators.model_registry) is already
-    deferred into a function body. `requests` arrives only transitively via
-    aimnet's own dependency, so this module must not assume it is present
-    before entering a function.
+    `resolve_engine_name` is a pure offline dict read against a bundled YAML,
+    and config validation calls it on every run, so importing this module must
+    not require a network library -- even though every other heavy import here
+    (aimnet.calculators.model_registry) is already deferred into a function
+    body. `requests` arrives only transitively via aimnet's own dependency, so
+    this module must not assume it is present before entering a function.
+
+    (The original framing was narrower: `utils/validation.py` imported preflight
+    at module scope and `utils/__init__.py` imported that, so a module-scope
+    `import requests` here made `import Auto3D.utils` hard-fail. Both of those
+    edges are gone -- the barrel is empty and the preflight import is
+    function-scope -- but the requirement on this module is unchanged.)
     """
 
     def test_no_module_scope_requests_import(self):

--- a/tests/test_model_wrapper.py
+++ b/tests/test_model_wrapper.py
@@ -159,16 +159,15 @@ class TestEnForceANIForwardBatched:
         assert mock_adapter.forward.call_count == 3
 
 
-class TestEnForceANIBackwardCompatibility:
-    """Tests for backward compatibility with legacy API."""
+class TestEnForceANIImportPath:
+    """``model_wrapper`` is the one home of ``EnForce_ANI``.
 
-
-    def test_enforce_ani_import_from_batchopt(self):
-        """EnForce_ANI should be importable from batchopt for backward compatibility."""
-        from Auto3D.batch_opt.batchopt import EnForce_ANI as EnForce_ANI_batchopt
-
-        # Should be the same class
-        assert EnForce_ANI_batchopt is EnForce_ANI
+    A companion test used to assert the same class was reachable as
+    ``from Auto3D.batch_opt.batchopt import EnForce_ANI``, which pinned the
+    compat barrel in place. ``batchopt`` still imports the class -- it uses it --
+    but no first-party module may reach it through there, which
+    ``tests/test_import_boundaries.py`` now enforces statically.
+    """
 
     def test_enforce_ani_import_from_model_wrapper(self):
         """EnForce_ANI should be importable from model_wrapper."""

--- a/tests/test_optimization_engine.py
+++ b/tests/test_optimization_engine.py
@@ -608,22 +608,26 @@ class TestNStepsIntegration:
         assert (state['fmax'] < 999.0).all()
 
 
-class TestNStepsBackwardCompatibility:
-    """Tests for backward compatibility of n_steps function."""
+class TestOptimizationEngineImportPaths:
+    """This module is the home of ``n_steps`` and ``print_stats``.
 
-    def test_n_steps_importable_from_batchopt(self):
-        """n_steps should be importable from batchopt for backward compatibility."""
-        from Auto3D.batch_opt.batchopt import n_steps as n_steps_batchopt
+    Two tests here used to assert both names were also reachable through
+    ``Auto3D.batch_opt.batchopt``, which is what kept that compat barrel alive.
+    ``print_stats`` is no longer imported there at all (nothing in ``batchopt``
+    called it); ``n_steps`` still is, because ``batchopt`` uses it, but reaching
+    it that way is forbidden by ``tests/test_import_boundaries.py``.
+    """
 
-        # Should be the same function
-        assert n_steps_batchopt is n_steps
+    def test_n_steps_and_print_stats_live_here(self):
+        from Auto3D.batch_opt.optimization_engine import (
+            n_steps as n_steps_home,
+        )
+        from Auto3D.batch_opt.optimization_engine import (
+            print_stats as print_stats_home,
+        )
 
-    def test_print_stats_importable_from_batchopt(self):
-        """print_stats should be importable from batchopt for backward compatibility."""
-        from Auto3D.batch_opt.batchopt import print_stats as print_stats_batchopt
-
-        # Should be the same function
-        assert print_stats_batchopt is print_stats
+        assert n_steps_home is n_steps
+        assert print_stats_home is print_stats
 
 
 class TestPrintStatsBackwardCompatibility:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@ import warnings
 from rdkit import Chem
 import Auto3D
 from Auto3D.config import Auto3DOptions
-from Auto3D.utils import check_input
-from Auto3D.utils import check_connectivity
+from Auto3D.utils.chemistry import check_connectivity
+from Auto3D.utils.validation import check_input
 from Auto3D.utils.file_ops import find_smiles_not_in_sdf
 
 

--- a/tests/test_utils_chemistry.py
+++ b/tests/test_utils_chemistry.py
@@ -310,24 +310,24 @@ class TestCheckConnectivity:
 
 
 class TestModuleImports:
-    """Test that module can be imported from different paths."""
+    """Every name has exactly one import path: the module that defines it.
+
+    There used to be a second test here importing the same names out of the
+    ``Auto3D.utils`` package barrel, asserting that both paths worked. The
+    barrel is gone (``tests/test_import_boundaries.py`` now forbids it), so the
+    two-paths-for-one-name shape it pinned is the thing being prevented rather
+    than checked.
+    """
 
     def test_import_from_utils_chemistry(self):
         """Test direct import from Auto3D.utils.chemistry."""
-        from Auto3D.utils.chemistry import get_mol_charge, min_pairwise_distance, check_connectivity
-        assert callable(get_mol_charge)
-        assert callable(min_pairwise_distance)
-        assert callable(check_connectivity)
-
-    def test_import_from_utils_package(self):
-        """Test import from Auto3D.utils package."""
-        from Auto3D.utils import (
+        from Auto3D.utils.chemistry import (
             HARTREE_TO_EV,
-            hartree2ev,
-            get_mol_charge,
-            min_pairwise_distance,
-            get_rmsd,
             check_connectivity,
+            get_mol_charge,
+            get_rmsd,
+            hartree2ev,
+            min_pairwise_distance,
         )
         assert HARTREE_TO_EV == hartree2ev
         assert callable(get_mol_charge)


### PR DESCRIPTION
Wave 3: the `utils` barrel is gone and `utils/` is a leaf package. Three findings that had
to move together, because all three are about which module a name is imported from.

## `utils/__init__.py` re-exported 41 names

The recorded cause — "names missing from `__all__`" — was **stale**. The file's imports and
its `__all__` were an exact bijection.

The real defect is inconsistency. Five of eight submodules were re-exported and three were
not, so `energy`, `convergence` and `stereo_check` had no barrel presence at all. Meanwhile
`check_connectivity` was reached through the barrel in `filtering.py:13` and through its own
module in `ranking.py:12` — two sibling files, two different paths to the same function.

`utils/__init__.py` is now docstring-only, documenting what each of the eight modules owns.
The 14 barrel import lines across 12 files name the defining module instead. An **AST** test,
scoped to `src/Auto3D/**`, asserts no first-party module imports through it again — AST
rather than regex, so it cannot be fooled by a mention in a comment or string.

Full 41-name mapping table (old barrel path → new dotted path) is in the CHANGELOG.

## `batchopt.py`'s compat barrel was narrower than recorded

Only `print_stats` was a pure re-export; it is deleted. `EnForce_ANI` and `n_steps` are
genuinely used in-module and stay imported, now with a comment saying they are not
re-exports so the next reader doesn't delete them.

Its consumers were exactly two: `SPE.py:9` and `ASE/thermo.py:26`, both now pointing at
`batch_opt.model_wrapper`. The finding also named `ASE/geometry.py`, `auto3D.py` and
`workflow_workers.py` — those are **wrong**. They import `optimizing`, which is *defined*
there, and are untouched.

## `utils/` is now a leaf

Both `Auto3D.models.*` imports in `validation.py` move to function scope. It was the only
non-leaf module in the package. A **subprocess** tripwire asserts that importing
`Auto3D.utils.validation` loads no `Auto3D.models` module — it was red for the stated reason,
pulling in six of them.

### `import torch` in `validation.py` stays at module level, deliberately

22 test sites patch `Auto3D.utils.validation.torch.cuda.is_available`. Deferring that import
breaks all 22 at once — confirmed by *performing* the mutation and counting, not by
reasoning about it. A test now pins the import scope so the next person doesn't rediscover
this the expensive way. M43 was about the `models/` import, not about torch; conflating the
two is the cheap-looking shortcut to an import-cost number that this test now blocks.

## The public-surface rule, corrected

The rule proposed for this phase was "public iff in `Auto3D.__all__` **and** in `api.rst`".
That is wrong, and implementing it literally would have been a mistake: `api.rst` documents
24 entries, **ten of which are `Auto3D.exceptions.*`**, none of which belong at top level.
`api.rst` documents *dotted paths*; `__all__` is the top-level barrel. They are not the same
set and never were.

So the implication is enforced one way only — **exported ⟹ documented**, plus every
documented path must resolve. Both directions are enforced by test, and `api.rst` now states
the rule in prose. `__all__` is unchanged at 13 names.

Under that rule, the four names that were inconsistent resolve as:

| name | decision | why |
|---|---|---|
| `get_device` | stays `api.rst`-only | documented and referenced as `Auto3D.model_factory.get_device` (5× in the migration guide). Its apparent notebook uses are `torch.cuda.get_device_*`, a different thing. A top-level alias would mint a second supported path for nothing. |
| `CustomNNP` | stays `api.rst`-only | the migration guide names `from Auto3D.models import CustomNNP` as the *removed* form and `Auto3D.models.contract.CustomNNP` as the survivor. A third path would contradict it. |
| `IsomerEngineFactory` | stays `api.rst`-only | the one reserved package-path exception, which `isomers/__init__.py`'s docstring already teaches. |
| `generate_conformers` | **added to `api.rst`** | it has no defining module — it exists only as the top-level alias `__init__.py` calls canonical. Deleting the intended-canonical name to satisfy a docs list is the wrong direction. |

## Found while implementing, and not swept under the rug

**Two more package barrels violate the rule:** `cli/__init__.py` (6 names) and
`models/__init__.py` (7 names). Neither is documented at its package path. Both are out of
scope here, so `test_only_documented_subpackages_define_all` freezes the allowed set at
`{isomers, cli, models}` with a comment recording the latter two as debt rather than
blessing them. Removing one means deleting it from that frozen set, and nobody can add a
fourth by accident.

**Three comments this change falsified**, corrected minimally — mechanism updated, conclusion
kept. Two lazy imports (`models/species.py`, `models/preflight.py`) were justified by
"`import Auto3D.utils` reaches this module", which is no longer true, as was a test docstring.
Left as-is they would have invited someone to un-defer `rdkit` and `requests` and quietly
undo wave 1's import-cost win.

## Verification

- 1357 passed, 9 skipped, 1 xfailed, ruff clean. (+11 boundary tests, −3 barrel-pinning tests.)
- The remaining xfail is the `E_tot` filter divergence, still owned by a later cluster.
- Four seeds — 12345, 1351916419, 20260804, 7 — all 1357.
- The documented order-sensitive trio run in order
  (`test_lazy_torchani_import` → `test_torch_config` → `test_thermo_helpers`): 111 passed.
  This is the change most likely to break module identity, since it rewrites import sources
  across 12 modules.
- All eight tripwires confirmed red first for their stated reasons; all eight mutations
  verified red and restored under sha256 check.
