### PR TITLE
docs: retarget the migration guide and version strings at 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   startup banner also moved after validation, so an unrunnable config is no
   longer announced as running.
 
+- **`from Auto3D.utils import <name>` no longer resolves for 41 names, and
+  `utils/chemistry.py` and `utils/file_ops.py` are gone.** `Auto3D/utils/__init__.py`
+  re-exported 41 names drawn from five of its eight modules, so three modules had
+  no way in and the same function was reachable by two different paths in sibling
+  files. It is now docstring-only. The two largest modules — 849 and 580 lines,
+  each holding several unrelated responsibilities — were split.
+
+  Import each name from the module that now defines it:
+
+  | new home | names |
+  |---|---|
+  | `Auto3D.constants` | `EV_TO_KCAL_PER_MOL`, `HARTREE_TO_EV`, `HARTREE_TO_KCAL_PER_MOL` |
+  | `Auto3D.utils.energy` | `ev2kcalpermol`, `hartree2ev`, `hartree2kcalpermol` |
+  | `Auto3D.utils.connectivity` | `amend_mol`, `check_connectivity`, `get_mol_connectivity` |
+  | `Auto3D.utils.geometry` | `get_rmsd`, `min_pairwise_distance` |
+  | `Auto3D.utils.molprops` | `get_mol_charge` |
+  | `Auto3D.utils.smi_io` | `combine_smi`, `hash_enumerated_smi_IDs`, `hash_taut_smi` |
+  | `Auto3D.utils.sdf_io` | `SDF2chunks`, `guess_file_type`, `reorder_sdf` |
+  | `Auto3D.utils.stereochemistry` | `amend_configuration`, `amend_configuration_w`, `check_value`, `count_unspecified_stereo`, `create_enantiomer`, `enantiomer`, `enantiomer_helper`, `get_stereo_info`, `no_enantiomer`, `no_enantiomer_helper`, `remove_enantiomers` |
+  | `Auto3D.utils.validation` | `check_input`, `check_sdf_format`, `check_smi_format`, `check_valid_configuration` |
+  | `Auto3D.utils.logging_config` | `configure_logging`, `get_logger` |
+  | `Auto3D.clash_relief` | `relieve_clash` |
+  | `Auto3D.id_mapping` | `decode_ids`, `encode_ids` |
+  | `Auto3D.job_layout` | `create_chunk_meta_names`, `housekeeping` |
+
+  `filter_unique` is **deleted**, not moved — see the single-filter entry above.
+
+  Also gone: `Auto3D.utils.__all__`; `batch_opt.batchopt.print_stats` (now
+  `batch_opt.optimization_engine.print_stats`); and two attributes that were
+  never in any `__all__` but were reachable as module-scope imports,
+  `Auto3D.utils.validation.load_custom_nnp` and `.resolve_engine_name` (now
+  `Auto3D.models.loading.load_custom_nnp` and
+  `Auto3D.models.preflight.resolve_engine_name`).
+
+  **If you installed from PyPI or conda-forge this table is unlikely to affect
+  you**: 2.3.1's `Auto3D.utils` was a single module with a different surface, so
+  those imports need rewriting regardless. The 41-name barrel only ever existed
+  in git-tag installs of 3.x.
+
 - **One exit-code scheme, used by every command.** `cli/errors.py` has mapped
   exception types to differentiated exit codes since 3.x -- 0 success, 1
   generic, 2 configuration/input, 3 dependency, 4 GPU, 5 model, plus 6 for a
@@ -192,7 +231,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`auto3d run` names the molecules it lost.** The results summary reported
   only a count (`1 failed`), so an interactive user who saw exit 6 had to
   rerun with `--json` to learn which molecule was missing.
-  `migration-4.0.rst` already said the summary listed them. It now does: the
+  `migration-3.0.rst` already said the summary listed them. It now does: the
   names are printed under the summary, in full with `-v`.
 
 - **The CLI refuses to overwrite an existing output file; pass `-f`/`--force`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,7 +48,7 @@ Contents
 
    installation
    migration
-   migration-4.0
+   migration-3.0
    usage
    cli
    advanced_usage

--- a/docs/source/migration-3.0.rst
+++ b/docs/source/migration-3.0.rst
@@ -1,8 +1,24 @@
-Migrating to Auto3D 4.0
+Migrating to Auto3D 3.0
 =======================
 
 This release corrects defects that produced silently wrong results. Read the
 "Results that change" section even if you use no removed API.
+
+.. note::
+
+   **If you installed Auto3D from PyPI or conda-forge, every change on this
+   page applies to you.** The latest published release was 2.3.1; the ``v3.0.0``
+   and ``v3.5.0`` git tags were never published to either index, so no
+   ``pip install`` or ``conda install`` has ever produced them.
+
+   Code examples below are labelled ``# before`` and ``# 3.0`` rather than by
+   version number, because "before" covers both 2.3.1 and those unpublished
+   tags. Where a change applies *only* to someone who installed from an
+   unpublished tag, it says so.
+
+   ``utils.chemistry`` and ``utils.file_ops`` are named throughout this guide as
+   the modules a name used to live in. Both were split up in this release; see
+   the CHANGELOG's mapping table for where each name now lives.
 
 Results that change
 --------------------
@@ -289,10 +305,10 @@ property:
 
 .. code:: python
 
-   # 3.x -- raised if any record in the file had failed
+   # before -- raised if any record in the file had failed
    g = mol.GetProp("G_hartree")
 
-   # 4.0
+   # 3.0
    if mol.GetProp("Thermo_failed") == "":
        g = mol.GetProp("G_hartree")
 
@@ -572,10 +588,10 @@ API changes
 
 .. code:: python
 
-   # 3.x
+   # before
    coords, species, charges = pad_from_mols(mols, model_name, device)
 
-   # 4.0
+   # 3.0
    coords, species, charges, atom_mask = pad_from_mols(mols, adapter, device)
 
 ``atom_mask`` is ``(batch, max_atoms)`` bool, ``True`` for real atoms. Use it
@@ -591,10 +607,10 @@ Use ``pad_from_mols``.
 
 .. code:: python
 
-   # 3.x
+   # before
    from Auto3D import NNPModel
 
-   # 4.0
+   # 3.0
    from Auto3D.models import CustomNNP
 
 There were two descriptions of the custom-NNP interface in 3.x. ``NNPModel``
@@ -669,11 +685,11 @@ Species conversion moved
 
 .. code:: python
 
-   # 3.x
+   # before
    from Auto3D.utils import getidx, ANI2XT_INDEX
    index = getidx(atomic_number, model="ANI2xt")
 
-   # 4.0
+   # 3.0
    from Auto3D.models.species import to_ani2xt_species, ANI2XT_INDEX
    indices = to_ani2xt_species(atomic_numbers)            # whole molecule at once
 
@@ -682,11 +698,11 @@ Species conversion moved
 
 .. code:: python
 
-   # 3.x
+   # before
    n_steps(state, n, opttol, patience, energy_tol=1e-3, energy_patience=3)
    config = OptimizationConfig(opt_steps=1000, energy_tol=1e-3)
 
-   # 4.0
+   # 3.0
    n_steps(state, n, opttol, patience)
    config = OptimizationConfig(opt_steps=1000)
 
@@ -717,10 +733,10 @@ tolerance) is a different parameter and is unchanged.
 
 .. code:: python
 
-   # 3.x -- both silently ignored
+   # before -- both silently ignored
    model = create_model("AIMNET", device, use_ensemble=True)
 
-   # 4.0
+   # 3.0
    model = create_model("AIMNET", device)
 
 ``AUTO3D_USE_ENSEMBLE`` is no longer read. Passing either argument now raises
@@ -731,10 +747,10 @@ tolerance) is a different parameter and is unchanged.
 
 .. code:: python
 
-   # 3.x
+   # before
    opt = optimizing(in_f, out_f, "AIMNET", device, config)
 
-   # 4.0
+   # 3.0
    from Auto3D.model_factory import create_model
    opt = optimizing(in_f, out_f, adapter=create_model("AIMNET", device),
                     device=device, config=config)
@@ -762,11 +778,11 @@ error. ``model_name`` is now a required keyword-only argument on both.
 
 .. code:: python
 
-   # 3.x -- silently wrong for ANI2xt if omitted
+   # before -- silently wrong for ANI2xt if omitted
    calc = Calculator(model, charge=0)
    inp = mol2aimnet_input(mol, device)
 
-   # 4.0 -- required
+   # 3.0 -- required
    calc = Calculator(model, charge=0, model_name="ANI2xt")
    inp = mol2aimnet_input(mol, device, model_name="ANI2xt")
 
@@ -1114,9 +1130,9 @@ gave ``auto3d config validate`` exit ``1`` and ``auto3d run -c`` exit ``2``:
 
 .. code:: console
 
-   $ auto3d config validate cfg.yaml; echo $?     # 3.x
+   $ auto3d config validate cfg.yaml; echo $?     # before
    1
-   $ auto3d run mols.smi -c cfg.yaml; echo $?     # 3.x
+   $ auto3d run mols.smi -c cfg.yaml; echo $?     # before
    2
 
 Both are ``2`` in 4.0. The full scheme, with one table now in
@@ -1294,7 +1310,7 @@ configuration disagreed about whether the run had succeeded:
 
 .. code:: console
 
-   $ auto3d params.yaml; echo $?                       # 3.x and early 4.0
+   $ auto3d params.yaml; echo $?                       # before and early 4.0
    OK Output: /data/mols_20260801-101500-123456/mols_out.sdf
    0
    $ auto3d run mols.smi -c params.yaml; echo $?       # same run, same result

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -189,7 +189,7 @@ New environment variables for runtime configuration:
 
    ``AUTO3D_USE_ENSEMBLE`` and the ``use_ensemble`` argument, deprecated (and
    already a no-op) since v3.5, were removed entirely in v4.0 -- passing
-   ``use_ensemble`` now raises ``TypeError``. See :doc:`migration-4.0` for the
+   ``use_ensemble`` now raises ``TypeError``. See :doc:`migration-3.0` for the
    full list of v4.0 breaking changes. A single AIMNet2 registry model is
    always used; pick a specific registry name (for example ``aimnet2-2025``)
    for different accuracy/speed tradeoffs.

--- a/src/Auto3D/ASE/thermo.py
+++ b/src/Auto3D/ASE/thermo.py
@@ -55,7 +55,7 @@ __all__ = ["calc_thermo"]
 
 #: SD property carrying the success/failure verdict for one thermo record.
 #: ``""`` means publishable; any non-empty value names the failure. This is the
-#: filter CHANGELOG.md and docs/source/migration-4.0.rst document.
+#: filter CHANGELOG.md and docs/source/migration-3.0.rst document.
 THERMO_FAILED_PROP = "Thermo_failed"
 
 #: ``Thermo_failed`` value for a geometry confirmed to be a first-order saddle

--- a/src/Auto3D/batch_opt/batchopt.py
+++ b/src/Auto3D/batch_opt/batchopt.py
@@ -399,7 +399,7 @@ class optimizing:
             # through logging.getLogger("auto3d") directly instead -- the
             # same fix Auto3D.clash_relief.relieve_clash already uses --
             # because this count is documented as user-visible in the log
-            # (CHANGELOG.md, docs/source/migration-4.0.rst).
+            # (CHANGELOG.md, docs/source/migration-3.0.rst).
             logging.getLogger("auto3d").warning(
                 f"{n_stereo_changed} conformer(s) changed stereochemistry during "
                 "optimization and will be excluded from the results."

--- a/src/Auto3D/cli/commands/run.py
+++ b/src/Auto3D/cli/commands/run.py
@@ -292,7 +292,7 @@ def execute_run(
                 console.print()
                 print_results_summary(results)
                 # The summary panel carries only a *count* of missing
-                # molecules. `migration-4.0.rst` says the summary lists them,
+                # molecules. `migration-3.0.rst` says the summary lists them,
                 # and `--json` does -- but the human path named none of them,
                 # so an interactive user who saw "1 failed" and exit 6 had no
                 # way to learn which molecule it was without rerunning with

--- a/tests/test_SPE.py
+++ b/tests/test_SPE.py
@@ -15,7 +15,7 @@ skip_ani2xt_test = False
 # have swept it in with everything else regardless of what it actually does.
 #
 # Every calc_spe call below passes use_gpu=False on purpose. calc_spe's
-# `use_gpu` default is True, and Auto3D 4.0 made "GPU requested but no CUDA
+# `use_gpu` default is True, and Auto3D 3.0 made "GPU requested but no CUDA
 # device visible" FATAL rather than a silent CPU fallback
 # (Auto3D.utils.validation.check_gpu_requested, called first thing inside
 # calc_spe). The slow CI job runs on ubuntu-latest -- CPU-only, like every

--- a/tests/test_cli_config_schema.py
+++ b/tests/test_cli_config_schema.py
@@ -339,7 +339,7 @@ def test_shipped_legacy_v2_parameters_yaml_loads():
 def test_shipped_legacy_v2_tauto_yaml_raises_configuration_error():
     """``docs/legacy-v2/tauto.yaml`` carries keys from a removed feature and
     must be rejected as an ``Auto3D.exceptions.ConfigurationError``, naming
-    them -- exactly what CHANGELOG.md and docs/source/migration-4.0.rst now
+    them -- exactly what CHANGELOG.md and docs/source/migration-3.0.rst now
     tell 4.0 users to catch.
 
     Both documents previously said this raised a field-named

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,7 +158,7 @@ class TestChunkMeta:
 def test_optimization_config_exposes_no_energy_criterion_knobs():
     """The energy-stability knobs are gone, not merely defaulted (audit M1).
 
-    ``test_energy_tol_above_fp32_noise`` stood here until 4.0.0 and asserted
+    ``test_energy_tol_above_fp32_noise`` stood here until 3.0.0 and asserted
     that ``DEFAULT_ENERGY_TOL >= 1e-3`` so the criterion would be "live". It
     never was: the criterion also required ``fmax < opttol``, which is exactly
     where the force criterion had already converged the structure, so no value

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -492,7 +492,7 @@ class TestTheSurvivingFilterKeepsTheLegacyVerdicts:
     deleted (cluster B5 phase 4a).
 
     Auto3D carried two conformer filters with the same duplicate criterion, each
-    acting as the other's oracle, until 4.1.0. These cases were run against BOTH
+    acting as the other's oracle, until 3.0.0. These cases were run against BOTH
     and are asserted here as literals so the surviving filter's verdicts stay
     pinned now that there is nothing left to compare against.
     """

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -287,7 +287,7 @@ def test_unknown_attribute_raises_attribute_error():
 # (``Auto3D.exceptions.*``); none of those is in ``__all__`` and none should be.
 # api.rst documents *dotted paths*, and the rest of the docs consistently
 # reference these names that way -- ``Auto3D.model_factory.get_device``,
-# ``Auto3D.models.contract.CustomNNP`` (migration-4.0.rst calls that "the
+# ``Auto3D.models.contract.CustomNNP`` (migration-3.0.rst calls that "the
 # surviving one", against the removed ``from Auto3D.models import CustomNNP``),
 # ``Auto3D.isomers.IsomerEngineFactory``. Promoting those into ``__all__`` would
 # mint a *second* supported path for each and contradict the migration guide, so
@@ -391,7 +391,7 @@ def test_every_exported_name_is_documented_in_api_rst():
 #
 # Static, and specifically AST rather than a regex over the text. A regex
 # matches the historical ``from Auto3D.utils import ...`` snippets that live on
-# purpose in ``docs/plans/**`` and in ``docs/source/migration-4.0.rst`` (where
+# purpose in ``docs/plans/**`` and in ``docs/source/migration-3.0.rst`` (where
 # the barrel import is the deliberate *before* half of a before/after pair), so
 # a regex-based check could be "satisfied" by falsifying the migration guide.
 # Everything below is scoped to ``src/Auto3D/**`` only.

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -104,7 +104,7 @@ class TestConformerRankerWithOptimizedFiltering:
 
         That equivalence is the entire justification for partitioning the energy
         axis at all, and it used to be asserted by comparing against the legacy
-        all-pairs filter (deleted in 4.1.0). Asserted directly now.
+        all-pairs filter (deleted in 3.0.0). Asserted directly now.
         """
         from Auto3D.ranking import ConformerRanker
 

--- a/tests/test_stereo_postopt.py
+++ b/tests/test_stereo_postopt.py
@@ -178,7 +178,7 @@ class TestFiltersExcludeStereoChangedRecords:
     def test_the_filter_reports_stereochemistry_as_the_drop_reason(self):
         """Not just that it dropped, but that it says why.
 
-        Until 4.1.0 the two conformer filters returned a bare list, so
+        Until 3.0.0 the two conformer filters returned a bare list, so
         ``ranking`` reported a stereo-changed species as "No structure
         converged" -- pointing the reader at the optimizer settings for a
         problem in the input's stereo definitions.

--- a/tests/test_stereochemistry_validation.py
+++ b/tests/test_stereochemistry_validation.py
@@ -120,7 +120,7 @@ class TestEnantiomerValidation:
     def test_enantiomer_empty_lists_returns_false(self):
         """Two molecules with no stereo centers are not an enantiomeric pair.
 
-        This asserted ``True`` until 4.0.0, matching the implementation's
+        This asserted ``True`` until 3.0.0, matching the implementation's
         vacuous result: the comparison loop never executed and ``indicator``
         kept its ``True`` initial value. A molecule with no stereo centers is
         its own mirror image, so it has no enantiomer to be paired with, and

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -22,7 +22,7 @@ from tests.helpers_pipeline_output import (
 # test_SPE.py twin, test_calc_spe_uses_model_factory, had the same defect).
 #
 # Every opt_geometry/calc_thermo call below passes use_gpu=False on purpose.
-# Both default to use_gpu=True, and Auto3D 4.0 made "GPU requested but no CUDA
+# Both default to use_gpu=True, and Auto3D 3.0 made "GPU requested but no CUDA
 # device visible" FATAL rather than a silent CPU fallback
 # (Auto3D.utils.validation.check_gpu_requested, called first thing inside each
 # function). The slow CI job runs on ubuntu-latest -- CPU-only, like every

--- a/tests/test_thermo_transition_state.py
+++ b/tests/test_thermo_transition_state.py
@@ -3,7 +3,7 @@
 ``analyze_vibrations`` already identifies a first-order saddle point and records
 ``Is_transition_state``, but the record still received ``G_hartree``, was
 appended to ``out_mols``, and was stamped ``Thermo_failed = ""`` -- the property
-CHANGELOG.md and docs/source/migration-4.0.rst document as *the* success filter.
+CHANGELOG.md and docs/source/migration-3.0.rst document as *the* success filter.
 A saddle point was therefore indistinguishable from a minimum to every
 documented way of reading the output.
 


### PR DESCRIPTION
Release preparation: the migration guide and the version strings, retargeted from the 4.0.0
this release was originally going to be at the 3.0.0 it actually is.

## Why the guide needed more than a rename

It compared a `# 3.x` column against a `# 4.0` one. Shipping as 3.0.0 makes that incoherent —
it would compare "3.x" to "3.0" — and it was aimed at the wrong audience regardless:
**PyPI's latest is 2.3.1**, so almost every real upgrader comes from 2.x, while the "3.x" the
guide describes are git tags that were never published to any index.

Examples are now labelled `# before` and `# 3.0`. "Before" honestly covers both 2.3.1 and the
unpublished tags, because the same change applies to a reader coming from either. A note at
the top states that, and states that anyone who installed with pip or conda gets every change
on the page.

`migration-4.0.rst` → `migration-3.0.rst`, with the toctree entry, the cross-reference from
`migration.rst`, and the seven source and test comments that cite it by filename all
repointed.

Twelve docstrings across `src/` and `tests/` dated their changes to 4.0.0 or 4.1.0.

## The barrel mapping table, derived rather than reused

The CHANGELOG gains the `Auto3D.utils` barrel mapping: 41 removed names, grouped by the module
that now defines each one.

**The table generated when the barrel was deleted is deliberately not the one used here.** It
pointed at `utils/chemistry.py` and `utils/file_ops.py` — both of which were deleted one wave
later — so pasting it would have shipped a migration table naming modules that do not exist.
That is the worst kind of documentation bug: it fails only for the user who follows the
instructions.

This table is derived by walking the current source with an AST pass for each name's
definition site: **41 names across 13 modules**, with `filter_unique` deleted outright rather
than moved. Also recorded: `Auto3D.utils.__all__`, `batch_opt.batchopt.print_stats`, and two
attributes that were never in any `__all__` but were reachable as module-scope imports
(`Auto3D.utils.validation.load_custom_nnp` and `.resolve_engine_name`).

The table carries the mitigating fact too: 2.3.1's `Auto3D.utils` was a single module with a
different surface, so a pip user rewrites those imports regardless. The 41-name barrel only
ever existed in git-tag installs of 3.x.

## Not in this PR

The `[3.0.0]` CHANGELOG heading still reads `unreleased`, and no tag is created. Dating that
heading is a claim that the release happened, so it belongs with the actual publish — along
with deleting the two stale draft GitHub releases (`v3.5.0` and `v3.0.0`, both pointing at
deleted tags) and publishing the real one, which is what triggers `publish.yml`.

## Verification

1622 passed, 9 skipped, 0 xfailed, ruff clean. The renamed guide parses, and CI's Sphinx build
is what checks the toctree and the cross-reference.
