### PR TITLE
refactor!: close the last two package barrels and the deferred findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Build the adapter **inside** the worker process — an adapter must not cross a
   `spawn` boundary. `ModelAdapter` loses `device` and gains `to_species` and
   `energy`; `Auto3D.model_factory.BaseModelAdapter` is no longer re-exported.
-  `Auto3D.models` still re-exports `ModelAdapter`.
+  `Auto3D.models` no longer re-exports `ModelAdapter` either: import it from
+  `Auto3D.models.contract`. Re-exporting the *internal* interface one level
+  shallower than the public one is the confusion `contract.py` exists to end.
 
   `CustomNNP` — the *public* custom-NNP contract — is unchanged, and remains
   `forward(species, coords, charges) -> energies`. It does lose
@@ -739,8 +741,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   calls it. The old `Auto3D.NNPModel` was a second, never-consulted copy in
   `config.py`; it was `@runtime_checkable` and exported in `__all__`, so it
   looked authoritative while nothing in Auto3D ever checked a model against it.
-  Replace `from Auto3D import NNPModel` with `from Auto3D.models import
-  CustomNNP`.
+  Replace `from Auto3D import NNPModel` with
+  `from Auto3D.models.contract import CustomNNP`.
 
   **The signature is unchanged**: a custom NNP still implements
   `forward(species, coords, charges) -> energies`, species first, returning an

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -16,6 +16,15 @@ Both directions are enforced by ``tests/test_import_boundaries.py``: every path
 listed here must resolve, and nothing may be exported from ``Auto3D.__all__``
 without appearing here.
 
+No package ``__init__.py`` re-exports a name, and that is enforced too. The one
+exception is ``Auto3D.isomers.IsomerEngineFactory`` below, whose documented
+dotted path *is* the package path -- so the re-export is the public surface
+rather than a convenience alias for it. ``Auto3D.cli`` (six names) and
+``Auto3D.models`` (seven) were the last two package barrels; both are empty as of
+4.0, and none of their thirteen names was documented here. Import from the module
+that defines each one: ``Auto3D.cli.app``, ``Auto3D.cli.console``,
+``Auto3D.models.adapter``, ``Auto3D.models.contract``.
+
 Core Functions
 --------------
 
@@ -70,6 +79,13 @@ rejected before any conformer work starts:
    :toctree: generated
 
    Auto3D.models.contract.CustomNNP
+
+This is the only public name in the ``Auto3D.models`` package, and the path above
+is the only way to import it. ``from Auto3D.models import CustomNNP`` worked
+through a package barrel until 4.0 and no longer resolves. The barrel also placed
+the *internal* adapter interface (``Auto3D.models.contract.ModelAdapter``, which
+only Auto3D's own adapters implement) at a shallower path than this one; both now
+sit in ``contract``, and neither is reachable from ``Auto3D.models`` itself.
 
 Isomer Generation
 -----------------

--- a/docs/source/howto/custom_nnp.rst
+++ b/docs/source/howto/custom_nnp.rst
@@ -111,7 +111,7 @@ Your custom model must:
    Auto3D obtains forces by differentiating that energy with respect to
    ``coords``, so your model must not return forces.
 
-   Do not confuse this with ``Auto3D.models.adapter.ModelAdapter``, Auto3D's
+   Do not confuse this with ``Auto3D.models.contract.ModelAdapter``, Auto3D's
    *internal* interface, which is ``forward(coords, species, charges) ->
    (energies, forces)`` -- the reverse argument order. Only Auto3D's own
    adapters implement that one. A model written against it is rejected at load.

--- a/docs/source/migration-3.0.rst
+++ b/docs/source/migration-3.0.rst
@@ -611,7 +611,7 @@ Use ``pad_from_mols``.
    from Auto3D import NNPModel
 
    # 3.0
-   from Auto3D.models import CustomNNP
+   from Auto3D.models.contract import CustomNNP
 
 There were two descriptions of the custom-NNP interface in 3.x. ``NNPModel``
 lived in ``config.py``, was ``@runtime_checkable``, and was exported in

--- a/src/Auto3D/batch_opt/model_wrapper.py
+++ b/src/Auto3D/batch_opt/model_wrapper.py
@@ -176,17 +176,43 @@ class EnForce_ANI(nn.Module):
         batch_size = max(1, self.batchsize_atoms // N)
 
         def _run(batch_idx: torch.Tensor, bsize: int) -> None:
-            # Process a slice of molecules; on CUDA OOM, free the cache and retry
+            # Process slices of molecules; on CUDA OOM, free the cache and retry
             # the failing slice with a halved batch. A single molecule that still
             # OOMs cannot be split further (an NNP needs the whole molecule), so
             # raise a clear, actionable error instead of crashing opaquely.
-            for sub in batch_idx.split(bsize):
+            #
+            # `bsize` is a local variable that SHRINKS and STAYS SHRUNK for the
+            # rest of this call once an OOM is observed (audit M37): the old
+            # code recursed on just the failing slice at a halved size but kept
+            # splitting every OTHER remaining slice at the original `bsize`,
+            # repeating the same OOM-and-recurse cycle for each one. A `while`
+            # loop over `remaining` (re-queuing the failed slice at the front
+            # instead of recursing) makes the smaller size the new default for
+            # everything that has not run yet.
+            remaining = batch_idx
+            while remaining.numel() > 0:
+                sub, remaining = remaining[:bsize], remaining[bsize:]
+                oom = False
                 try:
                     _e, _f = self(
                         coord[sub], numbers[sub], charges[sub],
                         atom_mask=None if atom_mask is None else atom_mask[sub],
                     )
                 except torch.cuda.OutOfMemoryError:
+                    oom = True
+                if oom:
+                    # empty_cache() and the retry run AFTER the except block,
+                    # not inside it: while an `except` clause is executing, the
+                    # OOM'd exception is still `sys.exc_info()`'s "currently
+                    # handled exception", and its traceback keeps every local
+                    # of the failed forward -- including its activations --
+                    # reachable. empty_cache() can only release already-free
+                    # blocks, so calling it there could not reclaim the memory
+                    # the retry needed (audit M37). CPython clears the
+                    # currently-handled exception as soon as the `except`
+                    # clause is left, which happens above (no `continue`/
+                    # `raise` inside it), so by the time control reaches here
+                    # nothing from the failed forward is still referenced.
                     if torch.cuda.is_available():
                         torch.cuda.empty_cache()
                     if sub.numel() == 1:
@@ -194,7 +220,8 @@ class EnForce_ANI(nn.Module):
                             f"A single molecule with {N} atoms exhausted GPU memory even "
                             f"at batch size 1. Reduce batchsize_atoms or use a smaller model."
                         )
-                    _run(sub, max(1, sub.numel() // 2))
+                    bsize = max(1, sub.numel() // 2)
+                    remaining = torch.cat([sub, remaining])
                     continue
                 e_list.append(_e)
                 f_list.append(_f)

--- a/src/Auto3D/chunk_manager.py
+++ b/src/Auto3D/chunk_manager.py
@@ -5,13 +5,14 @@ of input data into chunks for parallel processing.
 """
 from __future__ import annotations
 
-import math
+import os
+import shutil
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pandas as pd
 import psutil
-import torch
 
 from Auto3D.utils.logging_config import get_logger
 from Auto3D.utils.sdf_io import SDF2chunks
@@ -22,6 +23,97 @@ if TYPE_CHECKING:
     from Auto3D.config import Auto3DOptions
 
 logger = get_logger(__name__)
+
+# Ceiling for the memory-scaled `batchsize_atoms` multiplier (audit M36). A
+# bare `batchsize_atoms * memory_gb` has no upper bound: on an 80 GB GPU the
+# documented default (1024 atoms/GB) scales to 81,920 atoms in a single NN
+# forward call, which -- combined with `optimizing.BUCKET_MAX_COUNT = 1024`
+# molecules per bucket -- can mean one flattened AIMNet2 call over an entire
+# max-size bucket. 1024 * 16 matches `EnForce_ANI`'s own default
+# `batchsize_atoms` (batch_opt/model_wrapper.py), i.e. the ceiling already
+# considered a safe single-call size everywhere else `EnForce_ANI` is
+# constructed without an explicit override.
+_MAX_SCALED_BATCHSIZE_ATOMS = 1024 * 16
+
+
+def _gpu_free_memory_gb(gpu_idx: int) -> int | None:
+    """Free memory (GB, floor) for one GPU, without initializing a CUDA context.
+
+    This orchestrator process never runs a model -- it only sizes chunks
+    before workers are spawned. Two torch.cuda calls look like the obvious
+    way to answer "how much memory does this GPU have", and both are wrong
+    here:
+
+    * ``torch.cuda.get_device_properties()`` calls ``torch.cuda._lazy_init()``
+      directly (see ``torch/cuda/__init__.py``), which runs
+      ``torch._C._cuda_init()`` and brings up the full CUDA runtime state
+      (caching allocator, streams, RNG) for the calling process.
+    * ``torch.cuda.mem_get_info()`` does not call ``_lazy_init()`` itself, but
+      it reaches the CUDA Runtime's ``cudaMemGetInfo``, which -- like nearly
+      every runtime call that touches a specific device -- lazily creates
+      that device's primary CUDA context if one does not already exist. It
+      swaps "total memory" for "free memory" (the other half of this finding)
+      without avoiding the context-creation hazard.
+
+    ``nvidia-smi`` is a separate process built on NVML, Nvidia's *management*
+    library, which is deliberately decoupled from the CUDA driver/runtime for
+    exactly this reason -- it is the same property ``torch.cuda.
+    is_available()``/``device_count()`` use internally to offer an
+    NVML-based check that "will NOT poison fork" (see the ``_nvml_based_avail``
+    path in ``torch/cuda/__init__.py``). Shelling out to it is the only way
+    this process can answer the question without paying the cost the question
+    is trying to measure.
+
+    ``gpu_idx`` is a **CUDA-visible** index, which is not an ``nvidia-smi``
+    index. PyTorch numbers devices after ``CUDA_VISIBLE_DEVICES`` remapping,
+    while ``nvidia-smi -i`` numbers physical cards: under
+    ``CUDA_VISIBLE_DEVICES=4,5``, ``gpu_idx=0`` is physical GPU 4, so passing 0
+    straight through would report a different card's free memory and size every
+    chunk from it. Shared multi-GPU boxes -- the environment this scaling exists
+    for -- are exactly where that is set, so the index is translated first. An
+    entry may be a UUID rather than an ordinal (``CUDA_VISIBLE_DEVICES=GPU-abc...``),
+    which ``-i`` also accepts, so entries are passed through as-is.
+
+    Returns:
+        Free memory in whole GB (floored, minimum 1), or ``None`` if
+        ``nvidia-smi`` is unavailable, times out, or returns something
+        unparsable (no NVIDIA driver, non-NVIDIA GPU, sandboxed/minimal
+        container), or if ``CUDA_VISIBLE_DEVICES`` does not contain
+        ``gpu_idx``. Never raises, and never touches ``torch.cuda``.
+    """
+    exe = shutil.which("nvidia-smi")
+    if exe is None:
+        return None
+
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible is None:
+        smi_id = str(gpu_idx)
+    else:
+        entries = [e.strip() for e in visible.split(",") if e.strip()]
+        if gpu_idx >= len(entries):
+            # The caller asked for a device CUDA cannot see. Reporting some
+            # other card's memory would be worse than declining to guess;
+            # get_device() raises GPUError for this case anyway.
+            return None
+        smi_id = entries[gpu_idx]
+
+    try:
+        result = subprocess.run(
+            [
+                exe,
+                "-i", smi_id,
+                "--query-gpu=memory.free",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        free_mib = float(result.stdout.strip().splitlines()[0])
+    except (OSError, subprocess.SubprocessError, ValueError, IndexError):
+        return None
+    return max(1, int(free_mib / 1024))
 
 
 class ChunkManager:
@@ -73,11 +165,24 @@ class ChunkManager:
             else:
                 gpu_idx = self.config.gpu_idx[0]
                 num_jobs = len(self.config.gpu_idx)
-            memory_gb = int(
-                math.ceil(
-                    torch.cuda.get_device_properties(gpu_idx).total_memory / (1024**3)
+            free_gb = _gpu_free_memory_gb(gpu_idx)
+            if free_gb is None:
+                # nvidia-smi unavailable/unparsable (no NVIDIA driver,
+                # non-NVIDIA GPU, minimal container). Fall back to a
+                # conservative default instead of reaching for torch.cuda,
+                # which would trade an unmeasured multiplier for the exact
+                # parent-process CUDA context this function exists to avoid
+                # (audit M36). 1 GB keeps batchsize_atoms/chunk_size at their
+                # unscaled defaults, matching what an explicit --memory=1
+                # would do.
+                self._log_info(
+                    "nvidia-smi unavailable; could not detect GPU memory. "
+                    "Using unscaled batchsize_atoms/chunk_size. Pass "
+                    "`memory=<GB>` to size chunks explicitly."
                 )
-            )
+                memory_gb = 1
+            else:
+                memory_gb = free_gb
         else:
             memory_gb = int(psutil.virtual_memory().total / (1024**3))
 
@@ -98,7 +203,17 @@ class ChunkManager:
         # mutating self.config: the config is shared with the caller and the
         # optimization workers, and mutating it in place would compound the
         # multiplier on repeated main() calls (review findings #35/#36).
-        self.scaled_batchsize_atoms = self.config.batchsize_atoms * memory_gb
+        #
+        # Clamped to _MAX_SCALED_BATCHSIZE_ATOMS (audit M36) but never below
+        # the caller's own unscaled batchsize_atoms: the cap bounds what
+        # memory-scaling can produce, it does not second-guess an explicit,
+        # already-large user setting that made no use of scaling at all
+        # (e.g. a fixed `memory=1`).
+        scaled = self.config.batchsize_atoms * memory_gb
+        self.scaled_batchsize_atoms = max(
+            self.config.batchsize_atoms,
+            min(scaled, _MAX_SCALED_BATCHSIZE_ATOMS),
+        )
 
         # Read input data
         if self.input_format == "smi":

--- a/src/Auto3D/cli/__init__.py
+++ b/src/Auto3D/cli/__init__.py
@@ -1,13 +1,14 @@
-"""Modern CLI for Auto3D using Typer and Rich."""
+"""Modern CLI for Auto3D using Typer and Rich.
 
-from Auto3D.cli.app import app
-from Auto3D.cli.console import console, print_banner, print_error, print_success, print_warning
+This package re-exports nothing. ``docs/source/api.rst`` documents no
+``Auto3D.cli`` name, so nothing here is public: import from the module that
+defines it (``Auto3D.cli.app`` for the Typer application, ``Auto3D.cli.console``
+for the output helpers) and expect it to move.
 
-__all__ = [
-    "app",
-    "console",
-    "print_banner",
-    "print_error",
-    "print_success",
-    "print_warning",
-]
+Emptying this barrel also removed a name collision it created. It bound ``app``
+(the Typer instance from ``Auto3D.cli.app``) and ``console`` (the Rich console
+from ``Auto3D.cli.console``) *over the modules of the same names*, so
+``from Auto3D.cli import app`` yielded the Typer object once ``__init__`` had run
+and the module otherwise. Both names now resolve to their modules,
+unambiguously.
+"""

--- a/src/Auto3D/isomer_engine.py
+++ b/src/Auto3D/isomer_engine.py
@@ -70,8 +70,18 @@ def _contradicts_reference_stereo(reference: Chem.Mol, tautomer: Chem.Mol) -> bo
     return Chem.MolToSmiles(tautomer) != Chem.MolToSmiles(reference)
 
 
-class TautomerEngine:
-    """Enumerate possible tautomers for input molecules.
+class RDKitOrOEChemTautomerEngine:
+    """Enumerate possible tautomers for input molecules, on either backend.
+
+    Named for its backends, like ``RDKitIsomer``/``RDKitSdfIsomer`` beside it,
+    and *not* ``TautomerEngine``: that name belongs to the role Protocol in
+    :mod:`Auto3D.isomers.base`, which this class structurally satisfies. The two
+    shared the name until 4.0, which forced :mod:`Auto3D.isomers.factory` to
+    import this one under a local alias to keep them apart within a single file
+    -- a per-file workaround for a package-wide collision, and one whose alias
+    said "Omega" although tautomers come from ``oequacpac`` and Omega is the
+    conformer generator. ``run()`` dispatches on ``mode``, so one class covers
+    both backends.
 
     Args:
         mode: Tautomer engine to use: 'rdkit' or 'oechem'.
@@ -744,7 +754,10 @@ def _oe_isomer_in_owned_cwd(
     return 0
 
 
-# Backward compatibility aliases
-tautomer_engine = TautomerEngine
+# Backward compatibility aliases. ``tautomer_engine`` (a 2.x-era alias of the
+# class now called ``RDKitOrOEChemTautomerEngine``) was removed in 4.0: it had
+# zero importers anywhere in the repo, is documented at no public path, and
+# keeping it would have preserved the ``TautomerEngine`` name collision under a
+# second spelling that no test exercised. The two below still have importers.
 rd_isomer = RDKitIsomer
 rd_isomer_sdf = RDKitSdfIsomer

--- a/src/Auto3D/isomers/__init__.py
+++ b/src/Auto3D/isomers/__init__.py
@@ -5,12 +5,14 @@ backends (RDKit, OpenEye Omega) through the Strategy Pattern.
 
 ``IsomerEngineFactory`` is the one name re-exported here, because
 ``docs/source/api.rst`` documents it at this package path
-(``Auto3D.isomers.IsomerEngineFactory``) and that path is the public one. Every
-other name in this package -- ``create_isomer_engine``,
-``create_tautomer_engine``, and the ``IsomerEngine``/``TautomerEngine``
-protocols -- is imported from the module that defines it
-(``Auto3D.isomers.factory``, ``Auto3D.isomers.base``), so that no name here has
-two supported spellings.
+(``Auto3D.isomers.IsomerEngineFactory``) and that path is the public one -- which
+makes this the only ``__init__.py`` in ``Auto3D`` allowed to re-export anything.
+Every other name in this package -- ``create_tautomer_engine`` and the
+``IsomerEngine``/``TautomerEngine`` protocols -- is imported from the module that
+defines it (``Auto3D.isomers.factory``, ``Auto3D.isomers.base``), so that no name
+here has two supported spellings. A ``create_isomer_engine`` free function was
+the exception until 4.0 and is deleted; see ``factory.py``'s docstring for why
+``create_tautomer_engine`` beside it was kept.
 
 Example:
     >>> from Auto3D.isomers import IsomerEngineFactory

--- a/src/Auto3D/isomers/factory.py
+++ b/src/Auto3D/isomers/factory.py
@@ -1,15 +1,34 @@
-"""Factory classes and functions for creating isomer engines."""
+"""Factory for isomer engines, and the one free function that has no factory.
+
+Two constructors, deliberately asymmetric:
+
+* :meth:`IsomerEngineFactory.create` is the only supported way to build an
+  isomer engine. A module-level ``create_isomer_engine`` wrapper existed
+  alongside it until 4.0 and was deleted: it had zero ``src/`` callers (both
+  production sites -- ``auto3D.py`` and ``workflow_workers.py`` -- call the
+  classmethod), was documented at no public path, and had already *diverged*
+  from what it wrapped by omitting ``input_format``, so it could not express the
+  ``rdkit`` -> ``rdkit_sdf`` auto-selection below. A second spelling of the one
+  documented public path (``Auto3D.isomers.IsomerEngineFactory``) that no
+  production code used and could no longer reach the full surface was maintenance
+  with no consumer.
+
+* :func:`create_tautomer_engine` stays, because it is not a duplicate of
+  anything. It is the *only* constructor for a tautomer engine -- there is no
+  ``IsomerEngineFactory`` classmethod for tautomers -- and
+  ``Auto3D.processors.TautomerProcessor`` calls it. It is also the boundary that
+  keeps ``processors.py`` from importing ``Auto3D.isomer_engine`` directly, which
+  is what its own tests monkeypatch.
+"""
 from __future__ import annotations
 
 from collections.abc import Callable
 
 from Auto3D.isomer_engine import (
     RDKitIsomer,
+    RDKitOrOEChemTautomerEngine,
     RDKitSdfIsomer,
     oe_isomer,
-)
-from Auto3D.isomer_engine import (
-    TautomerEngine as _RDKitOrOmegaTautomerEngine,
 )
 from Auto3D.isomers.base import IsomerEngine, TautomerEngine
 
@@ -189,85 +208,6 @@ class IsomerEngineFactory:
         return _DeferredIsomerEngine(build_and_run, output_path)
 
 
-def create_isomer_engine(
-    engine_type: str,
-    input_path: str,
-    output_path: str,
-    *,
-    smiles_enumerated: str = "",
-    smiles_reduced: str = "",
-    smiles_hashed: str = "",
-    job_dir: str = "",
-    max_confs: int | None = None,
-    threshold: float = 0.3,
-    n_jobs: int = 4,
-    enumerate_isomers: bool = True,
-    mode: str = "classic",
-    use_parallel_embedding: bool = False,
-    parallel_embedding_threshold: int = 10,
-    parallel_workers: int = 4,
-) -> IsomerEngine:
-    """Create an isomer engine based on the specified type.
-
-    This is a convenience wrapper around IsomerEngineFactory.create().
-
-    Args:
-        engine_type: Engine type ('rdkit', 'rdkit_sdf', or 'omega').
-        input_path: Path to input file.
-        output_path: Path for output SDF file.
-        smiles_enumerated: Path for enumerated SMILES (rdkit only).
-        smiles_reduced: Path for reduced SMILES (rdkit only).
-        smiles_hashed: Path for hashed SMILES (rdkit only).
-        job_dir: Working directory (rdkit only).
-        max_confs: Maximum conformers per molecule.
-        threshold: RMSD threshold for duplicate removal.
-        n_jobs: Number of parallel jobs.
-        enumerate_isomers: Whether to enumerate stereoisomers.
-        mode: Omega mode ('classic', 'macrocycle', etc.) for omega engine.
-        use_parallel_embedding: Whether to use parallel conformer embedding
-            (rdkit only). Default False.
-        parallel_embedding_threshold: Minimum molecules for parallel embedding
-            (rdkit only). Default 10.
-        parallel_workers: Number of worker processes for parallel embedding
-            (rdkit only). Default 4.
-
-    Returns:
-        Configured isomer engine instance.
-
-    Raises:
-        ValueError: If engine_type is not recognized.
-
-    Example:
-        >>> engine = create_isomer_engine(
-        ...     "rdkit",
-        ...     input_path="input.smi",
-        ...     output_path="output.sdf",
-        ...     smiles_enumerated="enum.smi",
-        ...     smiles_reduced="reduced.smi",
-        ...     smiles_hashed="hashed.smi",
-        ...     job_dir="/path/to/job",
-        ... )
-        >>> output = engine.run()
-    """
-    return IsomerEngineFactory.create(
-        engine_type=engine_type,
-        input_path=input_path,
-        output_path=output_path,
-        smiles_enumerated=smiles_enumerated,
-        smiles_reduced=smiles_reduced,
-        smiles_hashed=smiles_hashed,
-        job_dir=job_dir,
-        max_confs=max_confs,
-        threshold=threshold,
-        n_jobs=n_jobs,
-        enumerate_isomers=enumerate_isomers,
-        mode=mode,
-        use_parallel_embedding=use_parallel_embedding,
-        parallel_embedding_threshold=parallel_embedding_threshold,
-        parallel_workers=parallel_workers,
-    )
-
-
 def create_tautomer_engine(
     engine_type: str,
     input_path: str,
@@ -295,7 +235,7 @@ def create_tautomer_engine(
     engine_type = engine_type.lower()
 
     if engine_type in ("rdkit", "oechem"):
-        return _RDKitOrOmegaTautomerEngine(
+        return RDKitOrOEChemTautomerEngine(
             mode=engine_type,
             input_f=input_path,
             out=output_path,

--- a/src/Auto3D/model_factory.py
+++ b/src/Auto3D/model_factory.py
@@ -28,7 +28,8 @@ if TYPE_CHECKING:
     # `_adapters` is the sole exception, because it really is a registry of
     # Auto3D's own classes. Kept behind TYPE_CHECKING so
     # `Auto3D.model_factory.BaseModelAdapter` is no longer an incidental
-    # re-export -- import it from Auto3D.models.
+    # re-export -- import it from Auto3D.models.adapter, which defines it
+    # (`Auto3D.models` re-exports nothing).
     from Auto3D.models.adapter import BaseModelAdapter
     from Auto3D.models.contract import ModelAdapter
 

--- a/src/Auto3D/models/__init__.py
+++ b/src/Auto3D/models/__init__.py
@@ -1,5 +1,11 @@
 """Model contracts, adapters and neural network potentials for Auto3D.
 
+This package re-exports nothing. ``docs/source/api.rst`` documents exactly one
+name out of it -- :class:`Auto3D.models.contract.CustomNNP` -- at that module
+path, so that is the only public name here and the only supported way to import
+it. Everything else (the adapters, the internal adapter interface, the loaders)
+is internal: import it from the module that defines it and expect it to move.
+
 Both contracts live in :mod:`Auto3D.models.contract`:
 
 * :class:`~Auto3D.models.contract.CustomNNP` -- what a user's own NNP must
@@ -9,22 +15,10 @@ Both contracts live in :mod:`Auto3D.models.contract`:
 
 The two take ``species`` and ``coords`` in opposite order, deliberately and
 permanently. Read that module's docstring before touching either.
-"""
-from Auto3D.models.adapter import (
-    AIMNet2Adapter,
-    ANI2xAdapter,
-    ANI2xtAdapter,
-    BaseModelAdapter,
-    CustomModelAdapter,
-)
-from Auto3D.models.contract import CustomNNP, ModelAdapter
 
-__all__ = [
-    "CustomNNP",
-    "ModelAdapter",
-    "BaseModelAdapter",
-    "AIMNet2Adapter",
-    "ANI2xAdapter",
-    "ANI2xtAdapter",
-    "CustomModelAdapter",
-]
+``ModelAdapter`` used to be re-exported here while ``CustomNNP`` was documented
+one level deeper, which put the internal interface at a *shallower* path than
+the public one and made ``Auto3D.models.ModelAdapter`` look like the surface a
+user implements. Both now sit side by side in ``contract``, one import away, and
+neither is reachable from this package's namespace.
+"""

--- a/src/Auto3D/workflow.py
+++ b/src/Auto3D/workflow.py
@@ -7,11 +7,12 @@ import shutil
 import time
 from dataclasses import replace
 from datetime import datetime
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
 from logging.handlers import QueueHandler
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import Auto3D
 from Auto3D.chunk_manager import ChunkManager
 from Auto3D.config import Auto3DOptions, optimizer_worker_indices
 from Auto3D.exceptions import ConfigurationError, FileFormatError, OptimizationError
@@ -24,6 +25,7 @@ from Auto3D.utils.reconciliation import find_ids_not_in_sdf, find_smiles_not_in_
 from Auto3D.utils.sdf_io import reorder_sdf
 from Auto3D.utils.validation import check_input, check_valid_configuration
 from Auto3D.workflow_workers import (
+    ProgressEvent,
     isomer_wrapper,
     logger_process,
     optim_rank_wrapper,
@@ -35,6 +37,24 @@ if TYPE_CHECKING:
     from multiprocessing import Queue
 
 logger = get_logger(__name__)
+
+
+def _package_version() -> str:
+    """Read the installed ``Auto3D`` distribution version.
+
+    Used only for the run-log banner (see ``_log_banner``). This duplicates
+    ``Auto3D.__init__._detect_version`` rather than reading
+    ``Auto3D.__version__`` off the package -- the orchestrator (core layer)
+    used to do ``import Auto3D`` purely to reach that one attribute, which
+    was flagged as a needless self-import of this module's own package root
+    (review Minor #35). ``importlib.metadata`` is the single source of truth
+    either way; this just reads it directly instead of through the parent
+    package's namespace.
+    """
+    try:
+        return _dist_version("Auto3D")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 class WorkflowOrchestrator:
@@ -52,16 +72,18 @@ class WorkflowOrchestrator:
     def __init__(
         self,
         config: Auto3DOptions,
-        progress_callback: Callable[[dict], None] | None = None,
+        progress_callback: Callable[[ProgressEvent], None] | None = None,
     ) -> None:
         """Initialize the orchestrator with configuration.
 
         Args:
             config: Auto3D configuration options.
             progress_callback: Optional callable invoked (in the main process)
-                with per-step optimizer progress events for a live display. When
-                None (the default, and every library/test caller) the pipeline
-                runs exactly as before -- no progress queue, plain blocking joins.
+                with per-step optimizer progress events (see
+                ``Auto3D.workflow_workers.ProgressEvent`` for the payload
+                schema) for a live display. When None (the default, and every
+                library/test caller) the pipeline runs exactly as before -- no
+                progress queue, plain blocking joins.
         """
         self.config = config
         self.progress_callback = progress_callback
@@ -343,7 +365,7 @@ class WorkflowOrchestrator:
             f"        / \\     _   _  | |_    ___   |___ /  |  _ \\ \n"
             f"       / _ \\   | | | | | __|  / _ \\    |_ \\  | | | |\n"
             f"      / ___ \\  | |_| | | |_  | (_) |  ___) | | |_| |\n"
-            f"     /_/   \\_\\  \\__,_|  \\__|  \\___/  |____/  |____/  {Auto3D.__version__}\n"
+            f"     /_/   \\_\\  \\__,_|  \\__|  \\___/  |____/  |____/  {_package_version()}\n"
             f"              // Generating low-energy 3D structures"
         )
 
@@ -469,7 +491,7 @@ class WorkflowOrchestrator:
             (self.logger.warning if warning else self.logger.info)(msg)
 
     def _supervise_with_progress(
-        self, p1: mp.Process, p2s: list[mp.Process], progress_queue: Queue[dict]
+        self, p1: mp.Process, p2s: list[mp.Process], progress_queue: Queue[ProgressEvent]
     ) -> None:
         """Drain progress events to the callback while workers run, then join.
 
@@ -501,7 +523,7 @@ class WorkflowOrchestrator:
             p2.join()
             self._check_exit(p2, "Optimization")
 
-    def _emit_progress(self, event: dict) -> None:
+    def _emit_progress(self, event: ProgressEvent) -> None:
         """Forward one progress event to the callback; never raise."""
         if self.progress_callback is None:
             return

--- a/src/Auto3D/workflow_workers.py
+++ b/src/Auto3D/workflow_workers.py
@@ -15,7 +15,7 @@ import sys
 import tarfile
 from logging.handlers import QueueHandler
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import torch
 from rdkit import Chem
@@ -51,6 +51,33 @@ if TYPE_CHECKING:
 # is exact-prefix and case-sensitive), so a single log call is only ever
 # routed through one of them and nothing is ever delivered twice.
 _RUN_LOG_LOGGER_NAMES = ("auto3d", "Auto3D")
+
+
+class ProgressEvent(TypedDict):
+    """Schema of one live-progress event for the ``auto3d run`` display.
+
+    Emitted (without ``job``) by ``batch_opt.optimization_engine._emit_progress``
+    every 10 optimizer steps and once at the end; enriched with ``job`` right
+    here, in the closure built in ``optim_rank_wrapper``, before being put on
+    the cross-process progress queue that ``WorkflowOrchestrator`` drains
+    (``workflow.py``'s ``_supervise_with_progress``/``_emit_progress``) and
+    hands to the caller's ``progress_callback``.
+
+    Review Minor #40: this schema used to be restated in three separate
+    docstrings (``auto3D.py``, ``workflow.py``, ``optimization_engine.py``)
+    with nothing pinning them to agree. This TypedDict is the one place that
+    now does; ``optimization_engine.py``'s own dict literal is out of this
+    module's ownership and still untyped at the point it is constructed, but
+    every consumer downstream of this module (``workflow.py``, and this
+    module's own queue) is typed against it.
+    """
+
+    job: int
+    step: int
+    total: int
+    converged: int
+    dropped: int
+    active: int
 
 
 def _worker_stdout_to_stderr() -> contextlib.AbstractContextManager[object]:
@@ -191,7 +218,7 @@ def optim_rank_wrapper(
     queue: Queue[tuple[str, str, str, int] | str],
     logging_queue: Queue[LogRecord | None],
     gpu_idx: int,
-    progress_queue: Queue[dict] | None = None,
+    progress_queue: Queue[ProgressEvent] | None = None,
 ) -> list[list[Chem.Mol]]:
     with _worker_stdout_to_stderr():
         #prepare logging
@@ -228,7 +255,7 @@ def optim_rank_wrapper(
                 if progress_queue is not None:
                     def progress_cb(event, _q=progress_queue, _job=job):
                         try:
-                            _q.put({**event, "job": _job})
+                            _q.put(cast(ProgressEvent, {**event, "job": _job}))
                         except Exception:
                             pass
                 # HARD CONSTRAINT: the adapter is built HERE, inside the spawned

--- a/tests/test_auto3Dcli.py
+++ b/tests/test_auto3Dcli.py
@@ -1,0 +1,98 @@
+"""Tests for ``Auto3D.auto3Dcli`` -- the legacy ``auto3d <config.yaml>`` entry point.
+
+Review Minor #27: the legacy path used to construct ``Auto3DOptions(**parameters)``
+directly from a raw ``yaml.safe_load``, so an unrecognized key (a typo like
+``optimising_engine``) surfaced as a bare
+``TypeError: __init__() got an unexpected keyword argument '...'`` with no exit
+code and no hint -- while the modern ``auto3d run INPUT -c config.yaml`` path
+already reported the same mistake as a pydantic-backed ``ConfigurationError``
+naming the field, at exit code 2.
+
+``_run_legacy_yaml`` (see ``tests/test_legacy_yaml_parity.py`` for the broader
+ingestion-parity suite covering the four *malformed-shape* cases) now ingests
+through ``Auto3D.cli.config_schema.load_yaml_config``/``build_cli_config`` --
+the exact ``CLIConfig`` (``extra="forbid"``) the modern path already used --
+so this specific "unknown key" case is fixed as a side effect. This module
+pins that directly: it is a distinct case from the four already covered
+(empty file / top-level list / top-level scalar / YAML syntax error), since an
+unknown key is a well-formed *mapping* that only pydantic's ``extra="forbid"``
+rejects.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_unknown_key_reports_named_configuration_error(tmp_path, monkeypatch):
+    """A typo'd key must surface as ``ConfigurationError`` naming the field,
+    not a bare ``TypeError``.
+
+    Mutation check (performed by hand, not re-run here since it would require
+    editing production code): reverting ``_run_legacy_yaml`` to construct
+    ``Auto3DOptions(**parameters)`` directly from the raw YAML dict -- the
+    pre-fix shape -- makes ``Auto3DOptions(path=..., k=1,
+    optimising_engine=...)`` raise a bare ``TypeError`` instead (verified
+    interactively: ``Auto3DOptions.__init__() got an unexpected keyword
+    argument 'optimising_engine'``), which this test would not accept as
+    passing.
+    """
+    from Auto3D.auto3Dcli import _run_legacy_yaml
+    from Auto3D.cli import errors as errors_mod
+    from Auto3D.exceptions import ConfigurationError
+
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("path: mols.smi\nk: 1\noptimising_engine: AIMNET\n")
+
+    seen: list[BaseException] = []
+    real_handle_error = errors_mod.handle_error
+
+    def spy(error, *args, **kwargs):
+        seen.append(error)
+        return real_handle_error(error, *args, **kwargs)
+
+    monkeypatch.setattr(errors_mod, "handle_error", spy)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run_legacy_yaml(str(cfg))
+
+    assert seen, "expected the failure to route through handle_error"
+    error = seen[-1]
+    assert isinstance(error, ConfigurationError), (
+        f"expected ConfigurationError, got {type(error).__name__}: {error}"
+    )
+    assert "optimising_engine" in str(error), str(error)
+    assert exc_info.value.code == 2
+
+
+def test_unknown_key_reports_same_verdict_as_the_modern_path(tmp_path, monkeypatch):
+    """Same shape, same verdict, through ``auto3d run INPUT -c cfg.yaml``.
+
+    Complements ``test_legacy_yaml_parity.py``'s malformed-shape parity suite
+    with the "well-formed mapping, unknown key" shape it does not cover.
+    """
+    from Auto3D.cli.commands import run as run_mod
+
+    smi = tmp_path / "mols.smi"
+    smi.write_text("CCO m1\n")
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("k: 1\noptimising_engine: AIMNET\n")
+
+    seen: list[BaseException] = []
+    real_handle_error = run_mod.handle_error
+
+    def spy(error, *args, **kwargs):
+        seen.append(error)
+        return real_handle_error(error, *args, **kwargs)
+
+    monkeypatch.setattr(run_mod, "handle_error", spy)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_mod.execute_run(input_file=smi, config_file=cfg, quiet=True)
+
+    assert seen, "expected the failure to route through handle_error"
+    from Auto3D.exceptions import ConfigurationError
+
+    assert isinstance(seen[-1], ConfigurationError), type(seen[-1])
+    assert exc_info.value.code == 2

--- a/tests/test_chunk_manager.py
+++ b/tests/test_chunk_manager.py
@@ -288,6 +288,15 @@ class TestCalculateMemoryNeverTouchesCuda:
 
         monkeypatch.setattr(torch.cuda, "get_device_properties", _poison)
         monkeypatch.setattr(torch.cuda, "mem_get_info", _poison)
+        # Delete CUDA_VISIBLE_DEVICES so gpu_idx=0 is a valid visible device.
+        # Without this the test reads whatever the ambient environment happens
+        # to hold: it passes in CI (unset) and on a plain workstation, but
+        # CUDA_VISIBLE_DEVICES="" means *no* visible devices, so device 0 is
+        # outside the visible set, _gpu_free_memory_gb correctly declines to
+        # measure, and memory_gb falls back to 1 instead of the mocked 8. The
+        # subject here is "does the GPU path avoid torch.cuda", not device
+        # visibility, so the variable is pinned rather than inherited.
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         # Exercise the real nvidia-smi code path (not the "missing binary"
         # short-circuit) without touching the real subprocess or torch.cuda.
         monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/nvidia-smi")

--- a/tests/test_chunk_manager.py
+++ b/tests/test_chunk_manager.py
@@ -1,6 +1,8 @@
 """Tests for Auto3D.chunk_manager module."""
 from __future__ import annotations
 
+import shutil
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -54,7 +56,13 @@ class TestCalculateMemoryAndChunks:
         assert num_jobs == 1  # Single job when memory is manually set
 
     def test_single_gpu_returns_one_job(self, tmp_path):
-        """Should return num_jobs=1 for single GPU index."""
+        """Should return num_jobs=1 for single GPU index.
+
+        Mocks Auto3D.chunk_manager._gpu_free_memory_gb (the nvidia-smi-backed
+        query), not torch.cuda.get_device_properties -- that call was removed
+        by the M36 fix specifically so this orchestrator never initializes a
+        CUDA context (audit M36).
+        """
         config = Auto3DOptions(path="test.smi", k=1, use_gpu=True, gpu_idx=0)
         manager = ChunkManager(
             config=config,
@@ -64,14 +72,19 @@ class TestCalculateMemoryAndChunks:
             workflow_logger=None,
         )
 
-        with patch("torch.cuda.get_device_properties") as mock_props:
-            mock_props.return_value = MagicMock(total_memory=8 * 1024**3)
+        with patch("Auto3D.chunk_manager._gpu_free_memory_gb", return_value=8):
             memory_gb, chunk_size, num_jobs = manager.calculate_memory_and_chunks()
 
         assert num_jobs == 1
+        assert memory_gb == 8
 
     def test_multiple_gpus_returns_gpu_count(self, tmp_path):
-        """Should return num_jobs equal to GPU count for multiple GPUs."""
+        """Should return num_jobs equal to GPU count for multiple GPUs.
+
+        Mocks Auto3D.chunk_manager._gpu_free_memory_gb rather than
+        torch.cuda.get_device_properties for the same reason as
+        test_single_gpu_returns_one_job above (audit M36).
+        """
         config = Auto3DOptions(path="test.smi", k=1, use_gpu=True, gpu_idx=[0, 1, 2])
         manager = ChunkManager(
             config=config,
@@ -81,11 +94,11 @@ class TestCalculateMemoryAndChunks:
             workflow_logger=None,
         )
 
-        with patch("torch.cuda.get_device_properties") as mock_props:
-            mock_props.return_value = MagicMock(total_memory=8 * 1024**3)
+        with patch("Auto3D.chunk_manager._gpu_free_memory_gb", return_value=8):
             memory_gb, chunk_size, num_jobs = manager.calculate_memory_and_chunks()
 
         assert num_jobs == 3
+        assert memory_gb == 8
 
     def test_cpu_uses_system_memory(self, tmp_path):
         """Should use system memory when use_gpu=False."""
@@ -119,6 +132,255 @@ class TestCalculateMemoryAndChunks:
         memory_gb, chunk_size, num_jobs = manager.calculate_memory_and_chunks()
 
         assert chunk_size == 4 * 100  # 400
+
+
+class TestGpuFreeMemoryGb:
+    """Tests for chunk_manager._gpu_free_memory_gb (audit M36).
+
+    This helper exists specifically so ChunkManager never has to call
+    torch.cuda.get_device_properties/mem_get_info from the parent process --
+    both initialize a CUDA context (the former directly via
+    torch.cuda._lazy_init, the latter via the CUDA runtime's implicit primary
+    context creation). Every test here mocks shutil.which/subprocess.run so
+    the real nvidia-smi binary is never invoked and no real GPU state is
+    touched, on this box or any other.
+    """
+
+    def test_parses_nvidia_smi_output(self, monkeypatch):
+        """A well-formed nvidia-smi CSV line is parsed to whole GB (floored).
+
+        ``CUDA_VISIBLE_DEVICES`` is deleted rather than left alone: with it set,
+        the index is translated (see the remapping tests below), so a test that
+        inherited the developer's or CI runner's value would assert a different
+        thing depending on where it ran.
+        """
+        from Auto3D.chunk_manager import _gpu_free_memory_gb
+
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/nvidia-smi")
+        recorded = {}
+
+        def fake_run(cmd, **kwargs):
+            recorded["cmd"] = cmd
+            return MagicMock(stdout="8191\n", returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = _gpu_free_memory_gb(2)
+
+        assert result == 7  # floor(8191 MiB / 1024)
+        assert "-i" in recorded["cmd"] and "2" in recorded["cmd"]
+
+    def test_cuda_visible_devices_index_is_translated(self, monkeypatch):
+        """``gpu_idx`` is a CUDA-visible index; ``nvidia-smi -i`` is physical.
+
+        Without the translation this reports a *different card's* free memory
+        and sizes every chunk from it. Under ``CUDA_VISIBLE_DEVICES=4,5``,
+        ``gpu_idx=1`` is physical GPU 5, so ``-i 5`` must be queried -- not
+        ``-i 1``, which is a card CUDA cannot even see from this process.
+
+        Shared multi-GPU machines are both where this variable is set and the
+        only place the memory scaling matters, so the wrong-card case is the
+        common case, not the exotic one.
+        """
+        from Auto3D.chunk_manager import _gpu_free_memory_gb
+
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/nvidia-smi")
+        recorded = {}
+
+        def fake_run(cmd, **kwargs):
+            recorded["cmd"] = cmd
+            return MagicMock(stdout="16384\n", returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert _gpu_free_memory_gb(1) == 16
+        assert recorded["cmd"][recorded["cmd"].index("-i") + 1] == "5"
+
+    def test_uuid_entries_are_passed_through(self, monkeypatch):
+        """``CUDA_VISIBLE_DEVICES`` may hold UUIDs, which ``-i`` also accepts."""
+        from Auto3D.chunk_manager import _gpu_free_memory_gb
+
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-aaa,GPU-bbb")
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/nvidia-smi")
+        recorded = {}
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda cmd, **kw: (recorded.__setitem__("cmd", cmd),
+                               MagicMock(stdout="4096\n", returncode=0))[1],
+        )
+
+        assert _gpu_free_memory_gb(1) == 4
+        assert recorded["cmd"][recorded["cmd"].index("-i") + 1] == "GPU-bbb"
+
+    def test_index_outside_cuda_visible_devices_declines_to_guess(self, monkeypatch):
+        """A device CUDA cannot see returns None instead of another card's memory.
+
+        Reporting some other GPU's free memory would be worse than falling back
+        to the conservative default, because it looks like a successful
+        measurement.
+        """
+        from Auto3D.chunk_manager import _gpu_free_memory_gb
+
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/nvidia-smi")
+        called = []
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: called.append(1))
+
+        assert _gpu_free_memory_gb(7) is None
+        assert not called, "nvidia-smi must not be invoked for an invisible device"
+
+    def test_returns_none_when_nvidia_smi_missing(self, monkeypatch):
+        """No nvidia-smi on PATH -> None, and subprocess.run is never called."""
+        from Auto3D.chunk_manager import _gpu_free_memory_gb
+
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+
+        def fail_run(*a, **k):
+            raise AssertionError("subprocess.run must not be called when "
+                                  "nvidia-smi is not on PATH")
+
+        monkeypatch.setattr(subprocess, "run", fail_run)
+
+        assert _gpu_free_memory_gb(0) is None
+
+    def test_returns_none_on_unparsable_output(self, monkeypatch):
+        """Garbage/empty stdout is swallowed, not raised."""
+        from Auto3D.chunk_manager import _gpu_free_memory_gb
+
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/nvidia-smi")
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: MagicMock(stdout="not-a-number\n")
+        )
+
+        assert _gpu_free_memory_gb(0) is None
+
+    def test_returns_none_when_subprocess_raises(self, monkeypatch):
+        """A nonzero exit / timeout is swallowed, not propagated."""
+        from Auto3D.chunk_manager import _gpu_free_memory_gb
+
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/nvidia-smi")
+
+        def raising_run(*a, **k):
+            raise subprocess.CalledProcessError(1, "nvidia-smi")
+
+        monkeypatch.setattr(subprocess, "run", raising_run)
+
+        assert _gpu_free_memory_gb(0) is None
+
+
+class TestCalculateMemoryNeverTouchesCuda:
+    """M36: the parent process must never initialize a CUDA context just to
+    size a chunk. torch.cuda.get_device_properties and torch.cuda.mem_get_info
+    are poisoned to fail loudly if called at all, rather than silently
+    succeeding against whatever real GPU state this box happens to have.
+    """
+
+    def test_gpu_path_never_calls_torch_cuda_query_functions(self, tmp_path, monkeypatch):
+        import torch
+
+        def _poison(*a, **k):
+            raise AssertionError(
+                "calculate_memory_and_chunks must not touch torch.cuda for a "
+                "memory query (audit M36)"
+            )
+
+        monkeypatch.setattr(torch.cuda, "get_device_properties", _poison)
+        monkeypatch.setattr(torch.cuda, "mem_get_info", _poison)
+        # Exercise the real nvidia-smi code path (not the "missing binary"
+        # short-circuit) without touching the real subprocess or torch.cuda.
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/nvidia-smi")
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: MagicMock(stdout="8192\n")
+        )
+
+        config = Auto3DOptions(path="test.smi", k=1, use_gpu=True, gpu_idx=0)
+        manager = ChunkManager(
+            config=config,
+            input_path=Path(tmp_path / "input.smi"),
+            input_format="smi",
+            job_dir=tmp_path,
+            workflow_logger=None,
+        )
+
+        memory_gb, chunk_size, num_jobs = manager.calculate_memory_and_chunks()
+        assert memory_gb == 8
+
+    def test_gpu_path_falls_back_without_cuda_when_nvidia_smi_absent(
+        self, tmp_path, monkeypatch
+    ):
+        """No nvidia-smi -> a conservative default, still with no CUDA touch."""
+        import torch
+
+        def _poison(*a, **k):
+            raise AssertionError("must not touch torch.cuda (audit M36)")
+
+        monkeypatch.setattr(torch.cuda, "get_device_properties", _poison)
+        monkeypatch.setattr(torch.cuda, "mem_get_info", _poison)
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+
+        config = Auto3DOptions(path="test.smi", k=1, use_gpu=True, gpu_idx=0)
+        manager = ChunkManager(
+            config=config,
+            input_path=Path(tmp_path / "input.smi"),
+            input_format="smi",
+            job_dir=tmp_path,
+            workflow_logger=None,
+        )
+
+        memory_gb, chunk_size, num_jobs = manager.calculate_memory_and_chunks()
+        assert memory_gb == 1  # conservative fallback, not a crash
+
+
+class TestScaledBatchsizeAtomsClamp:
+    """M36: the memory multiplier must not scale batchsize_atoms without
+    bound (a bare `batchsize_atoms * memory_gb` reaches 81,920 atoms/call on
+    an 80 GB GPU at the documented default)."""
+
+    def test_large_memory_is_clamped(self, tmp_path, monkeypatch):
+        input_file = tmp_path / "test_encoded.smi"
+        input_file.write_text("CCO ethanol\n")
+
+        config = Auto3DOptions(
+            path=str(tmp_path / "test.smi"), k=1, use_gpu=True, gpu_idx=0,
+            batchsize_atoms=1024,
+        )
+        manager = ChunkManager(
+            config=config,
+            input_path=input_file,
+            input_format="smi",
+            job_dir=tmp_path,
+            workflow_logger=None,
+        )
+
+        with patch("Auto3D.chunk_manager._gpu_free_memory_gb", return_value=80):
+            manager.prepare_chunks()
+
+        # Unclamped this would be 1024 * 80 = 81920.
+        assert manager.scaled_batchsize_atoms == 1024 * 16
+
+    def test_clamp_never_reduces_an_explicit_large_setting(self, tmp_path):
+        """The clamp bounds the SCALING, not an explicit user choice already
+        above the ceiling with no scaling in play (memory=1)."""
+        input_file = tmp_path / "test_encoded.smi"
+        input_file.write_text("CCO ethanol\n")
+
+        config = Auto3DOptions(
+            path=str(tmp_path / "test.smi"), k=1, memory=1,
+            batchsize_atoms=20_000,
+        )
+        manager = ChunkManager(
+            config=config,
+            input_path=input_file,
+            input_format="smi",
+            job_dir=tmp_path,
+            workflow_logger=None,
+        )
+
+        manager.prepare_chunks()
+
+        assert manager.scaled_batchsize_atoms == 20_000
 
 
 class TestCreateChunkFiles:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,12 +160,18 @@ def test_validate_subcommand_help():
 
 # =============================================================================
 # Tests for CLI module imports
+#
+# Each name is imported from the module that defines it. `Auto3D.cli` used to
+# re-export all five; it re-exports nothing now, and `app`/`console` there are
+# the *modules*, not the Typer application and the Rich console. See
+# tests/test_import_boundaries.py::test_cli_app_and_console_names_resolve_to_their_modules.
 # =============================================================================
 
 
 def test_cli_module_imports():
-    """CLI module should export key components."""
-    from Auto3D.cli import app, console, print_success, print_error, print_warning
+    """The CLI's key components exist at their defining module paths."""
+    from Auto3D.cli.app import app
+    from Auto3D.cli.console import console, print_error, print_success, print_warning
 
     assert app is not None
     assert console is not None
@@ -176,16 +182,18 @@ def test_cli_module_imports():
 
 def test_cli_module_app_is_typer():
     """CLI app should be a Typer instance."""
-    from Auto3D.cli import app
     import typer
+
+    from Auto3D.cli.app import app
 
     assert isinstance(app, typer.Typer)
 
 
 def test_cli_module_console_is_rich():
     """CLI console should be a Rich Console instance."""
-    from Auto3D.cli import console
     from rich.console import Console
+
+    from Auto3D.cli.console import console
 
     assert isinstance(console, Console)
 

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -398,12 +398,44 @@ def test_every_exported_name_is_documented_in_api_rst():
 
 SRC_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src" / "Auto3D"
 
+def _submodules(package: str) -> frozenset[str]:
+    """Names that are *modules* inside ``package``, not re-exports.
+
+    Both halves matter: ``from Auto3D.models import adapter`` names a module and
+    ``from Auto3D.cli import commands`` names a subpackage, and neither is a
+    barrel import. Computed rather than listed so a new submodule cannot be
+    mistaken for a re-export the day it is added.
+    """
+    root = SRC_ROOT.joinpath(*package.split("."))
+    return frozenset(
+        {p.stem for p in root.glob("*.py") if p.stem != "__init__"}
+        | {d.name for d in root.iterdir() if (d / "__init__.py").exists()}
+    )
+
+
 # ``from Auto3D.utils import energy`` -- naming a submodule -- stays legal;
 # it is a module reference, not a re-export. ``from Auto3D.utils import
 # hartree2ev`` does not.
-UTILS_SUBMODULES = frozenset(
-    p.stem for p in (SRC_ROOT / "utils").glob("*.py") if p.stem != "__init__"
-)
+UTILS_SUBMODULES = _submodules("utils")
+
+# Every package that must not re-export a name, and the submodule names that are
+# therefore the *only* legal thing to pull out of it. ``cli`` and ``models``
+# joined ``utils`` here when their barrels were emptied; ``isomers`` is absent
+# because api.rst documents ``Auto3D.isomers.IsomerEngineFactory`` at the package
+# path, which makes that one re-export the public surface rather than a barrel.
+#
+# ``cli`` is the sharp case. Its barrel bound ``app`` (the Typer object) *over*
+# ``Auto3D.cli.app`` (the module of the same name) and ``console`` over
+# ``Auto3D.cli.console``, so ``from Auto3D.cli import app`` returned different
+# kinds of object depending on whether ``__init__`` had run its imports yet.
+# Emptying the barrel makes both names resolve to the module, unambiguously --
+# which is why the two are pinned as modules below rather than merely asserted
+# absent.
+CLOSED_BARRELS = {
+    "Auto3D.utils": UTILS_SUBMODULES,
+    "Auto3D.cli": _submodules("cli"),
+    "Auto3D.models": _submodules("models"),
+}
 
 # Names ``batch_opt/batchopt.py`` re-exported for backward compatibility. Two
 # of them (``EnForce_ANI``, ``n_steps``) the module genuinely uses, so they
@@ -412,13 +444,17 @@ UTILS_SUBMODULES = frozenset(
 BATCHOPT_REEXPORTS = frozenset({"EnForce_ANI", "n_steps", "print_stats"})
 
 # The only subpackage whose api.rst-documented dotted path *is* the package
-# path, and therefore the only one allowed to re-export. ``cli`` and ``models``
-# still carry an ``__all__`` and are known remaining barrels: neither is
-# documented at its package path (api.rst documents
-# ``Auto3D.models.contract.CustomNNP``, and no ``Auto3D.cli`` name at all), so
-# both are debt this set records rather than blesses. Removing one means
-# deleting it from here, not adding it.
-SUBPACKAGES_WITH_ALL = frozenset({"isomers", "cli", "models"})
+# path, and therefore the only one allowed to re-export:
+# ``Auto3D.isomers.IsomerEngineFactory``.
+#
+# This set previously also held ``cli`` (6 names) and ``models`` (7 names),
+# recorded as debt rather than blessed. Both barrels are now empty, so both are
+# gone from here. Neither was documented at its package path -- api.rst
+# documents ``Auto3D.models.contract.CustomNNP`` and no ``Auto3D.cli`` name at
+# all -- and every consumer of the thirteen names now imports from the module
+# that defines it. Adding a name back means documenting it at the package path
+# in api.rst first; growing this set is how that shows up in review.
+SUBPACKAGES_WITH_ALL = frozenset({"isomers"})
 
 
 def _source_files() -> list[pathlib.Path]:
@@ -725,3 +761,176 @@ def test_validation_imports_torch_at_module_scope():
         "monkeypatches targeting Auto3D.utils.validation.torch.* will silently "
         "target nothing"
     )
+
+
+# --------------------------------------------------------------------------- #
+# The cli/ and models/ barrels: both halves
+# --------------------------------------------------------------------------- #
+#
+# Same two-part shape as the ``utils`` demolition above -- the names are gone,
+# *and* nobody imports through the package -- for the same reason: removing only
+# the consumers leaves a live barrel for the next contributor, and removing only
+# the barrel is caught by the type checker at best.
+
+CLI_REEXPORTS = ("print_banner", "print_error", "print_success", "print_warning")
+
+MODELS_REEXPORTS = (
+    "CustomNNP",
+    "ModelAdapter",
+    "BaseModelAdapter",
+    "AIMNet2Adapter",
+    "ANI2xAdapter",
+    "ANI2xtAdapter",
+    "CustomModelAdapter",
+)
+
+
+def test_no_src_module_imports_through_a_closed_barrel():
+    """No first-party module pulls a *name* out of ``utils``/``cli``/``models``.
+
+    One AST scan over all three, because they fail the same way and a
+    per-package copy of this loop is how the third one gets forgotten. A
+    submodule reference (``from Auto3D.models import adapter``) is a module
+    reference and stays legal; a name reference does not.
+    """
+    offenders = []
+    for path in _source_files():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            module = _absolute_module(node, path)
+            allowed = CLOSED_BARRELS.get(module)
+            if allowed is None:
+                continue
+            names = [a.name for a in node.names if a.name not in allowed]
+            if names:
+                offenders.append(
+                    f"{path.relative_to(SRC_ROOT.parent)}:{node.lineno}: "
+                    f"from {module} import {names}"
+                )
+    assert not offenders, (
+        "imports through a closed package barrel (import from the defining "
+        "module instead):\n" + "\n".join(offenders)
+    )
+
+
+def test_cli_package_exposes_no_names():
+    """``Auto3D.cli`` re-exports nothing.
+
+    The four print helpers are checked with the ``from ... import name`` form
+    because that is what consumers wrote and it is the form that raises
+    ``ImportError``. ``app`` and ``console`` are deliberately *not* in that list:
+    each is also a submodule name, so the import always succeeds -- what changed
+    is *what it binds*, which the next test pins.
+    """
+    cli = importlib.import_module("Auto3D.cli")
+    assert not hasattr(cli, "__all__"), (
+        f"Auto3D.cli still declares __all__: {getattr(cli, '__all__', None)}"
+    )
+    for name in CLI_REEXPORTS:
+        with pytest.raises(ImportError):
+            exec(f"from Auto3D.cli import {name}", {})  # noqa: S102
+
+
+def test_cli_app_and_console_names_resolve_to_their_modules():
+    """The collision the barrel created, pinned in the resolved direction.
+
+    ``cli/__init__.py`` bound the Typer instance ``app`` and the Rich
+    ``console`` object over the ``Auto3D.cli.app`` and ``Auto3D.cli.console``
+    *modules*, so one dotted path named two different kinds of object and which
+    one a caller got depended on import order. With the barrel gone the module
+    wins, always. A future re-export of either name would shadow a module again
+    and is what this catches.
+    """
+    import inspect
+
+    namespace: dict[str, object] = {}
+    exec("from Auto3D.cli import app, console", namespace)  # noqa: S102
+    assert inspect.ismodule(namespace["app"]), (
+        "Auto3D.cli.app is shadowed by a re-exported object; the Typer app is "
+        "Auto3D.cli.app.app"
+    )
+    assert inspect.ismodule(namespace["console"]), (
+        "Auto3D.cli.console is shadowed by a re-exported object; the Rich "
+        "console is Auto3D.cli.console.console"
+    )
+
+
+def test_models_package_exposes_no_names():
+    """``Auto3D.models`` re-exports nothing, including ``ModelAdapter``.
+
+    ``ModelAdapter`` is the load-bearing one. It is the *internal* adapter
+    interface -- ``Auto3D.models.contract``'s own docstring says users never
+    implement it -- and api.rst documents only ``CustomNNP``, the user-facing
+    contract, out of that module. Re-exporting the internal interface one level
+    up from the public one put the two confusable names at sibling depth, which
+    is the exact confusion ``contract.py`` exists to prevent.
+    """
+    models = importlib.import_module("Auto3D.models")
+    assert not hasattr(models, "__all__"), (
+        f"Auto3D.models still declares __all__: {getattr(models, '__all__', None)}"
+    )
+    for name in MODELS_REEXPORTS:
+        with pytest.raises(ImportError):
+            exec(f"from Auto3D.models import {name}", {})  # noqa: S102
+
+
+def test_models_submodule_imports_still_work():
+    """Emptying the barrel must not break ``from Auto3D.models import adapter``.
+
+    ``tests/test_species_module.py`` uses exactly this form, and an
+    ``__init__.py`` that imports nothing is the condition under which it is easy
+    to assume otherwise.
+    """
+    from Auto3D.models import adapter, contract
+
+    assert adapter.BaseModelAdapter is not None
+    assert contract.CustomNNP is not None
+
+
+# --------------------------------------------------------------------------- #
+# One name, one meaning: the TautomerEngine collision
+# --------------------------------------------------------------------------- #
+
+def test_only_one_class_in_the_package_is_named_tautomer_engine():
+    """``TautomerEngine`` names the Protocol in ``isomers/base.py``, nothing else.
+
+    Two unrelated things carried this name: the role Protocol in
+    ``Auto3D.isomers.base`` and a concrete two-backend implementation in
+    ``Auto3D.isomer_engine``. ``isomers/factory.py`` imported the concrete one
+    ``as _RDKitOrOmegaTautomerEngine`` to keep them apart *within one file* --
+    a local workaround for a package-wide collision, and one that also named the
+    wrong OpenEye tool (tautomers come from ``oequacpac``, not Omega). The
+    implementation is now ``RDKitOrOEChemTautomerEngine``, matching the
+    backend-named convention its siblings ``RDKitIsomer``/``RDKitSdfIsomer``
+    already follow, and the Protocol keeps the role name so it stays symmetric
+    with ``IsomerEngine`` beside it.
+
+    Static, so it holds for a class nobody imports yet.
+    """
+    definitions = []
+    for path in _source_files():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "TautomerEngine":
+                definitions.append(f"{path.relative_to(SRC_ROOT.parent)}:{node.lineno}")
+    assert definitions == ["Auto3D/isomers/base.py:33"], (
+        f"TautomerEngine is defined at: {definitions}"
+    )
+
+
+def test_isomer_engine_no_longer_binds_either_tautomer_engine_spelling():
+    """The runtime half: the colliding name and its 2.x alias are both gone.
+
+    ``tautomer_engine`` was a 2.x-era lowercase alias of the same class with
+    zero importers anywhere in the repo, so keeping it would have preserved the
+    collision under a second spelling that no test would have exercised.
+    """
+    isomer_engine = importlib.import_module("Auto3D.isomer_engine")
+    for name in ("TautomerEngine", "tautomer_engine"):
+        assert not hasattr(isomer_engine, name), (
+            f"Auto3D.isomer_engine still binds {name}; the implementation is "
+            "RDKitOrOEChemTautomerEngine and the Protocol is "
+            "Auto3D.isomers.base.TautomerEngine"
+        )

--- a/tests/test_isomer_engine_hardening.py
+++ b/tests/test_isomer_engine_hardening.py
@@ -15,7 +15,11 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 
 from Auto3D.constants import EV_TO_HARTREE
-from Auto3D.isomer_engine import RDKitIsomer, RDKitSdfIsomer, TautomerEngine
+from Auto3D.isomer_engine import (
+    RDKitIsomer,
+    RDKitOrOEChemTautomerEngine,
+    RDKitSdfIsomer,
+)
 from Auto3D.utils.molprops import calculate_conformer_count
 
 
@@ -98,11 +102,13 @@ class TestInvalidSmilesDoesNotAbort:
         assert "bad" not in names
 
     def test_tautomer_rd_taut_skips_invalid(self, tmp_path):
-        """TautomerEngine.rd_taut must skip invalid SMILES, not abort."""
+        """RDKitOrOEChemTautomerEngine.rd_taut must skip invalid SMILES, not abort."""
         infile = tmp_path / "in.smi"
         outfile = tmp_path / "out.smi"
         infile.write_text("CCO valid_mol\nC(C invalid_mol\n")
-        eng = TautomerEngine("rdkit", str(infile), str(outfile), pKaNorm=False)
+        eng = RDKitOrOEChemTautomerEngine(
+            "rdkit", str(infile), str(outfile), pKaNorm=False
+        )
         eng.rd_taut()  # must not raise
         text = outfile.read_text()
         assert "valid_mol" in text

--- a/tests/test_isomers.py
+++ b/tests/test_isomers.py
@@ -15,7 +15,7 @@ import pytest
 
 from Auto3D.isomers import IsomerEngineFactory
 from Auto3D.isomers.base import IsomerEngine, TautomerEngine
-from Auto3D.isomers.factory import create_isomer_engine, create_tautomer_engine
+from Auto3D.isomers.factory import create_tautomer_engine
 
 
 @pytest.fixture
@@ -254,13 +254,20 @@ class TestCreateKwargMapping:
         assert spies["omega"]["mode"] == "classic"
 
 
-class TestCreateIsomerEngine:
-    """Tests for create_isomer_engine factory function."""
+class TestCreateEngineTypeResolution:
+    """Engine-name resolution in ``IsomerEngineFactory.create``.
+
+    These tests drove a module-level ``create_isomer_engine`` wrapper until 4.0.
+    The wrapper is gone -- zero ``src/`` callers, no documented path, and it had
+    already lost ``input_format`` -- so they now call the classmethod directly,
+    which is what production calls (``auto3D.py``, ``workflow_workers.py``) and
+    the only path api.rst documents.
+    """
 
     def test_unknown_engine_raises_error(self):
         """Test that unknown engine type raises ValueError."""
         with pytest.raises(ValueError, match="Unknown isomer engine type"):
-            create_isomer_engine(
+            IsomerEngineFactory.create(
                 "unknown_engine",
                 input_path="/input.smi",
                 output_path="/output.sdf",
@@ -276,7 +283,7 @@ class TestCreateIsomerEngine:
         """
         for name in ("RDKit", "RDKIT", "rdkit"):
             spies.clear()
-            create_isomer_engine(
+            IsomerEngineFactory.create(
                 name,
                 input_path="/input.smi",
                 output_path="/output.sdf",
@@ -288,7 +295,7 @@ class TestCreateIsomerEngine:
 
     def test_omega_engine_reaches_oe_isomer(self, spies):
         """Test that 'omega' drives oe_isomer."""
-        create_isomer_engine(
+        IsomerEngineFactory.create(
             "omega",
             input_path="/input.smi",
             output_path="/output.sdf",
@@ -302,7 +309,7 @@ class TestCreateIsomerEngine:
 
     def test_omega_engine_with_custom_mode(self, spies):
         """Test omega engine with custom mode."""
-        create_isomer_engine(
+        IsomerEngineFactory.create(
             "omega",
             input_path="/input.smi",
             output_path="/output.sdf",
@@ -315,12 +322,12 @@ class TestCreateIsomerEngine:
         assert spies["omega"]["mode"] == "macrocycle"
 
 
-class TestCreateIsomerEngineParallelEmbedding:
-    """Tests for parallel embedding support in create_isomer_engine."""
+class TestCreateParallelEmbedding:
+    """Parallel-embedding arguments reach ``RDKitIsomer`` through ``create``."""
 
     def test_rdkit_engine_parallel_embedding_default_off(self, spies):
         """Test that parallel embedding is off by default."""
-        create_isomer_engine(
+        IsomerEngineFactory.create(
             "rdkit",
             input_path="/input.smi",
             output_path="/output.sdf",
@@ -334,7 +341,7 @@ class TestCreateIsomerEngineParallelEmbedding:
 
     def test_rdkit_engine_parallel_embedding_enabled(self, spies):
         """Test that parallel embedding can be enabled."""
-        create_isomer_engine(
+        IsomerEngineFactory.create(
             "rdkit",
             input_path="/input.smi",
             output_path="/output.sdf",
@@ -377,7 +384,7 @@ class TestCreateIsomerEngineParallelEmbedding:
 
         monkeypatch.setattr(embedding_mod, "embed_conformers_parallel", spy)
 
-        engine = create_isomer_engine(
+        engine = IsomerEngineFactory.create(
             "rdkit",
             input_path=str(smi),
             output_path=str(tmp_path / "output.sdf"),
@@ -415,17 +422,32 @@ class TestCreateTautomerEngine:
         rdkit-backed engine as lowercase "rdkit" -- not merely fail to crash
         on an already-invalid name, which "UNKNOWN" could never distinguish.
         """
-        from Auto3D.isomer_engine import TautomerEngine as TautEngine
+        from Auto3D.isomer_engine import RDKitOrOEChemTautomerEngine
 
         engine = create_tautomer_engine(
             "RDKIT", input_path="/input.smi", output_path="/output.smi"
         )
-        assert isinstance(engine, TautEngine)
+        assert isinstance(engine, RDKitOrOEChemTautomerEngine)
         assert engine.mode == "rdkit"
 
 
 class TestIsomerEngineFactory:
     """Tests for IsomerEngineFactory class."""
+
+    def test_the_module_level_wrapper_is_gone(self):
+        """``create_isomer_engine`` is deleted, not deprecated.
+
+        A clean sweep rather than a shim: it was a second spelling of
+        ``IsomerEngineFactory.create``, the one path api.rst documents, with no
+        ``src/`` caller and a signature that had already fallen behind by
+        dropping ``input_format``. ``create_tautomer_engine`` beside it is
+        deliberately kept -- it duplicates nothing and ``Auto3D.processors``
+        calls it -- so the asymmetry is asserted, not just the deletion.
+        """
+        import Auto3D.isomers.factory as factory
+
+        assert not hasattr(factory, "create_isomer_engine")
+        assert callable(factory.create_tautomer_engine)
 
     def test_available_engines(self):
         """Test that available_engines returns expected list."""

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -65,14 +65,26 @@ class TestModelAdapterProtocol:
 
         assert not hasattr(adapter_mod, "ModelAdapter")
 
-    def test_the_package_still_re_exports_it(self):
-        from Auto3D.models import ModelAdapter as reexported
-        from Auto3D.models.contract import ModelAdapter as canonical
+    def test_the_package_does_not_re_export_it(self):
+        """``Auto3D.models.contract`` is the only path, in both directions.
 
-        assert reexported is canonical
-        assert "ModelAdapter" in __import__(
-            "Auto3D.models", fromlist=["__all__"]
-        ).__all__
+        This test previously asserted the opposite -- that ``Auto3D.models``
+        re-exported the name. That re-export put the *internal* adapter
+        interface at a shallower path than the *public* custom-NNP contract
+        (``Auto3D.models.contract.CustomNNP``, api.rst's only entry from this
+        package), which is the precise confusion ``contract.py`` was created to
+        end. ``Auto3D.models`` re-exports nothing now; see
+        ``tests/test_import_boundaries.py::test_models_package_exposes_no_names``
+        for the other six names that went with it.
+        """
+        import importlib
+
+        import pytest
+
+        models = importlib.import_module("Auto3D.models")
+        assert not hasattr(models, "__all__")
+        with pytest.raises(ImportError):
+            exec("from Auto3D.models import ModelAdapter", {})  # noqa: S102
 
     def test_device_is_not_part_of_the_contract(self):
         """Dropped deliberately.

--- a/tests/test_model_wrapper.py
+++ b/tests/test_model_wrapper.py
@@ -235,16 +235,26 @@ def test_forward_batched_retries_on_oom():
     assert f.shape == coord.shape
 
 
-def test_empty_cache_runs_with_exception_context_cleared():
+def test_empty_cache_runs_with_exception_context_cleared(monkeypatch):
     """M37: empty_cache()/the retry must run AFTER the except block has been
     left, not while the OOM exception (and everything its traceback keeps
     alive, including the failed forward's activations) is still the
     currently-handled exception -- otherwise empty_cache() can only release
-    already-free blocks and cannot reclaim what the retry needs."""
+    already-free blocks and cannot reclaim what the retry needs.
+
+    ``torch.cuda.is_available`` is forced True. The call under test is guarded
+    by it -- correctly, since ``empty_cache()`` has nothing to do without CUDA
+    -- so on a CPU-only machine the spy below is never invoked and this test
+    passes for no reason, or fails on a missing key. Without the patch it
+    asserts something only on a GPU box: it passed locally on an 8-GPU host and
+    failed all three CPU-only CI jobs with ``KeyError``. Nothing here touches a
+    real device; the guard is the only thing being satisfied.
+    """
     import sys
 
     from tests.helpers_adapter import FakeAdapter
 
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     seen = {}
 
     class _OOMAdapter(FakeAdapter):

--- a/tests/test_model_wrapper.py
+++ b/tests/test_model_wrapper.py
@@ -235,6 +235,82 @@ def test_forward_batched_retries_on_oom():
     assert f.shape == coord.shape
 
 
+def test_empty_cache_runs_with_exception_context_cleared():
+    """M37: empty_cache()/the retry must run AFTER the except block has been
+    left, not while the OOM exception (and everything its traceback keeps
+    alive, including the failed forward's activations) is still the
+    currently-handled exception -- otherwise empty_cache() can only release
+    already-free blocks and cannot reclaim what the retry needs."""
+    import sys
+
+    from tests.helpers_adapter import FakeAdapter
+
+    seen = {}
+
+    class _OOMAdapter(FakeAdapter):
+        def forward(self, coord, numbers, charges, atom_mask=None):
+            if coord.shape[0] > 1:
+                raise torch.cuda.OutOfMemoryError("simulated OOM")
+            return coord.pow(2).sum(dim=(1, 2)), torch.zeros_like(coord)
+
+    wrapper = EnForce_ANI(_OOMAdapter(), batchsize_atoms=10_000)
+
+    real_empty_cache = torch.cuda.empty_cache
+
+    def spy_empty_cache():
+        seen["exc_info_at_empty_cache"] = sys.exc_info()
+        return real_empty_cache()
+
+    torch.cuda.empty_cache = spy_empty_cache
+    try:
+        coord = torch.randn(4, 3, 3)
+        numbers = torch.tensor([[1, 6, -1]] * 4)
+        charges = torch.zeros(4)
+        wrapper.forward_batched(coord, numbers, charges)
+    finally:
+        torch.cuda.empty_cache = real_empty_cache
+
+    assert seen["exc_info_at_empty_cache"] == (None, None, None), (
+        "empty_cache() ran while the OOM exception was still the currently "
+        "handled exception -- its traceback (and the failed forward's "
+        "activations) were still reachable."
+    )
+
+
+def test_bsize_shrinkage_persists_for_remainder_of_batch():
+    """M37: once a slice OOMs and is halved, LATER slices in the same
+    forward_batched call must reuse the shrunk size, not repeat the same
+    OOM-and-recurse cycle at the original (pre-OOM) size for every remaining
+    slice."""
+    from tests.helpers_adapter import FakeAdapter
+
+    calls = []
+
+    class _OOMAdapter(FakeAdapter):
+        def forward(self, coord, numbers, charges, atom_mask=None):
+            calls.append(coord.shape[0])
+            if coord.shape[0] > 2:
+                raise torch.cuda.OutOfMemoryError("simulated OOM")
+            return coord.pow(2).sum(dim=(1, 2)), torch.zeros_like(coord)
+
+    # 8 molecules, batchsize_atoms=12 // 3 atoms/mol -> initial bsize=4,
+    # splitting the 8 molecules into two top-level size-4 slices. Both
+    # top-level slices OOM (size 4 > 2) under the *original* size.
+    wrapper = EnForce_ANI(_OOMAdapter(), batchsize_atoms=12)
+    coord = torch.randn(8, 3, 3)
+    numbers = torch.tensor([[1, 6, -1]] * 8)
+    charges = torch.zeros(8)
+
+    e, f = wrapper.forward_batched(coord, numbers, charges)
+
+    assert e.shape == (8,)
+    oom_triggering_calls = [c for c in calls if c > 2]
+    assert len(oom_triggering_calls) == 1, (
+        "the shrunk batch size must persist for the rest of the call -- "
+        f"expected exactly one OOM-triggering (>2) call, got sizes {calls}"
+    )
+
+
 def test_a_model_name_in_the_batchsize_slot_is_rejected():
     """The removed API's shape must fail loudly, not become a bad batch size.
 

--- a/tests/test_sdf_isomer_enumeration.py
+++ b/tests/test_sdf_isomer_enumeration.py
@@ -1,7 +1,8 @@
 """The SDF input path enumerates stereoisomers like the SMILES path.
 
 Every test drives the production ``rdkit_sdf`` engine through
-``create_isomer_engine``, not RDKit in isolation, and inspects the SDF file
+``IsomerEngineFactory.create`` -- the same path ``auto3D.py`` and
+``workflow_workers.py`` use -- not RDKit in isolation, and inspects the SDF file
 Auto3D actually writes.
 """
 from __future__ import annotations
@@ -9,7 +10,7 @@ from __future__ import annotations
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
-from Auto3D.isomers.factory import create_isomer_engine
+from Auto3D.isomers import IsomerEngineFactory
 
 
 def _write_sdf(path, smiles: str, name: str, three_d: bool) -> None:
@@ -30,7 +31,7 @@ def _run_engine(job_dir, smiles, name, three_d, **kwargs):
     output_sdf = job_dir / f"{name}_out.sdf"
     _write_sdf(input_sdf, smiles, name, three_d)
 
-    engine = create_isomer_engine(
+    engine = IsomerEngineFactory.create(
         "rdkit_sdf",
         input_path=str(input_sdf),
         output_path=str(output_sdf),
@@ -71,7 +72,7 @@ class TestUnspecifiedCentersEnumerate:
         input_sdf = job_dir / "threonine_in.sdf"
         output_sdf = job_dir / "threonine_out.sdf"
         _write_sdf(input_sdf, "CC(O)C(N)C(=O)O", "threonine", three_d=False)
-        create_isomer_engine(
+        IsomerEngineFactory.create(
             "rdkit_sdf",
             input_path=str(input_sdf),
             output_path=str(output_sdf),
@@ -109,7 +110,7 @@ class TestUnspecifiedCentersEnumerate:
         input_sdf = job_dir / "threonine3_in.sdf"
         output_sdf = job_dir / "threonine3_out.sdf"
         _write_sdf(input_sdf, "CC(O)C(N)C(=O)O", "threonine", three_d=False)
-        create_isomer_engine(
+        IsomerEngineFactory.create(
             "rdkit_sdf",
             input_path=str(input_sdf),
             output_path=str(output_sdf),

--- a/tests/test_stereo_identity.py
+++ b/tests/test_stereo_identity.py
@@ -60,7 +60,8 @@ class TestTautomerStereoPreservation:
         """At least one output tautomer must retain the input's specified center.
 
         This drives Auto3D's real ``rdkit`` tautomer engine -- the same
-        ``TautomerEngine.rd_taut()`` the pipeline dispatches to, reached via
+        ``RDKitOrOEChemTautomerEngine.rd_taut()`` the pipeline dispatches to,
+        reached via
         ``Auto3D.isomers.factory.create_tautomer_engine`` -- rather than a
         bare RDKit ``TautomerEnumerator``, so the defect is attributed to
         Auto3D's tautomer path and not to RDKit in isolation.
@@ -103,7 +104,7 @@ class TestSdfInputStereo:
         record for alanine to disk and feeds it through the production
         ``rdkit_sdf`` engine -- the same ``RDKitSdfIsomer.run()`` the pipeline
         dispatches to for SDF input --
-        via ``Auto3D.isomers.factory.create_isomer_engine``. It then inspects
+        via ``Auto3D.isomers.IsomerEngineFactory.create``. It then inspects
         the SDF file Auto3D actually writes, grouped by species name (the
         conformer-index suffix stripped). Either the two configurations must
         come out as distinct, internally consistent species, or ambiguous
@@ -113,7 +114,7 @@ class TestSdfInputStereo:
         """
         from rdkit.Chem import AllChem
 
-        from Auto3D.isomers.factory import create_isomer_engine
+        from Auto3D.isomers import IsomerEngineFactory
 
         # Alanine drawn flat (2D), with no stereo specified anywhere: no
         # wedge/hash bonds, no parity flags in the mol block.
@@ -126,7 +127,7 @@ class TestSdfInputStereo:
             writer.write(mol)
 
         output_sdf = job_dir / "alanine_enumerated.sdf"
-        engine = create_isomer_engine(
+        engine = IsomerEngineFactory.create(
             "rdkit_sdf",
             input_path=str(input_sdf),
             output_path=str(output_sdf),

--- a/tests/test_tautomer_stereo.py
+++ b/tests/test_tautomer_stereo.py
@@ -14,7 +14,7 @@ from Auto3D.isomers.factory import create_tautomer_engine
 
 
 def _run_rd_taut(job_dir, smiles: str) -> list[str]:
-    """Drive TautomerEngine.rd_taut() and return the output SMILES."""
+    """Drive RDKitOrOEChemTautomerEngine.rd_taut() and return the output SMILES."""
     in_smi = job_dir / "taut_in.smi"
     in_smi.write_text(f"{smiles} probe\n")
     out_smi = job_dir / "taut_out.smi"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -826,17 +826,54 @@ class TestFinalizeOutputReconciliation:
         orch._finalize_output(start_time=0.0)
         assert orch.failures == ["mol_c"], orch.failures
 
-    def test_workflow_uses_the_canonical_reconciliation_functions(self):
-        """Guard against a regression to a hand-rolled duplicate: workflow.py
-        must call the exact functions tested in test_utils_reconciliation.py, not a
-        reimplementation that could silently diverge from them."""
-        import Auto3D.utils.reconciliation as reconciliation
-        import Auto3D.workflow as workflow
+    def test_workflow_uses_the_canonical_reconciliation_functions(
+        self, monkeypatch, tmp_path
+    ):
+        """Guard against a regression to a hand-rolled duplicate: `_reconcile_output`
+        must actually call the imported `find_smiles_not_in_sdf`/`find_ids_not_in_sdf`
+        at its call site, not merely import them.
 
-        assert (
-            workflow.find_smiles_not_in_sdf is reconciliation.find_smiles_not_in_sdf
+        An identity check on the module attribute alone
+        (`workflow.find_smiles_not_in_sdf is reconciliation.find_smiles_not_in_sdf`)
+        cannot catch a regression to a private reimplementation: the import
+        binding survives untouched even if `_reconcile_output` is changed to
+        call a different, local function instead, since nothing then
+        references the import at all. Spying on the name actually resolved in
+        `workflow`'s module globals at call time closes that gap: it fails if
+        `_reconcile_output` stops dispatching through it, whether or not the
+        unused import is still there.
+        """
+        import Auto3D.workflow as workflow
+        from Auto3D.config import Auto3DOptions
+        from Auto3D.workflow import WorkflowOrchestrator
+
+        smi_calls = []
+        id_calls = []
+        monkeypatch.setattr(
+            workflow,
+            "find_smiles_not_in_sdf",
+            lambda *a, **kw: smi_calls.append((a, kw)) or [],
         )
-        assert workflow.find_ids_not_in_sdf is reconciliation.find_ids_not_in_sdf
+        monkeypatch.setattr(
+            workflow,
+            "find_ids_not_in_sdf",
+            lambda *a, **kw: id_calls.append((a, kw)) or [],
+        )
+
+        config = Auto3DOptions(path=str(tmp_path / "in.smi"), k=1, use_gpu=False)
+        orch = WorkflowOrchestrator(config)
+        orch.logger = None
+
+        config.input_format = "smi"
+        orch._reconcile_output(str(tmp_path / "out.sdf"))
+        assert smi_calls, "find_smiles_not_in_sdf was not called from _reconcile_output"
+        assert not id_calls
+
+        smi_calls.clear()
+        config.input_format = "sdf"
+        orch._reconcile_output(str(tmp_path / "out.sdf"))
+        assert id_calls, "find_ids_not_in_sdf was not called from _reconcile_output"
+        assert not smi_calls
 
 
 def test_main_propagates_orchestrator_failures_into_workflow_result(monkeypatch, tmp_path):


### PR DESCRIPTION
The remainder each earlier wave deliberately deferred, with a stated reason that has since cleared.

## The last two package barrels

`cli/__init__.py` and `models/__init__.py` were the two remaining violations of the public-surface rule. An earlier phase couldn't fix them in scope and **froze them in a test rather than blessing them** — which is what made this finishable. `SUBPACKAGES_WITH_ALL` is now `frozenset({"isomers"})`, the single `api.rst`-documented package path.

**`cli/__init__.py` had a defect beyond re-exporting:** it bound `app` and `console` **over the submodules of the same names**, so `from Auto3D.cli import app` returned a Typer object *or* a module depending on whether `__init__` had already run. Both now resolve to their modules, pinned by a test.

**`Auto3D.models` no longer re-exports `ModelAdapter`.** Re-exporting the *internal* interface one level shallower than the public `CustomNNP` is exactly the confusion `contract.py` exists to end. The test that froze that re-export is **inverted rather than deleted** — it now asserts the import raises. Two CHANGELOG lines and one how-to that contradicted this were corrected; all were in the unreleased section, so no published surface breaks.

**`TautomerEngine` collision resolved** by renaming the concrete class to `RDKitOrOEChemTautomerEngine`, freeing the role name for the Protocol and keeping `isomers/base.py`'s `IsomerEngine`/`TautomerEngine` pair symmetric. That promotes `factory.py`'s local disambiguation alias to the global name and corrects its factual error on the way — tautomers come from `oequacpac`, not Omega. The 2.x `tautomer_engine` alias had **zero importers repo-wide** and is gone; keeping it would preserve the collision under a spelling nothing exercises.

**`create_isomer_engine` deleted.** Zero `src/` callers, absent from `api.rst`, and **already diverged**: it omitted `input_format`, so it could not reach `create()`'s `rdkit` → `rdkit_sdf` auto-selection. `create_tautomer_engine` stays, with the asymmetry recorded where it lives.

## Parent-process CUDA initialization

`ChunkManager` called `torch.cuda.get_device_properties` from the orchestrator to size chunks, **before any worker is spawned**. That calls `_lazy_init` and brings up the full CUDA runtime — allocator, streams, RNG — in a process that never runs a model.

**`torch.cuda.mem_get_info` is not the fix, though it looks like it.** Its Python wrapper skips `_lazy_init`, but it reaches `cudaMemGetInfo`, which lazily creates the device's primary context anyway. Only NVML avoids it — the same property `torch.cuda.is_available()`'s NVML path documents as not poisoning fork. So the query goes through `nvidia-smi`, and reports **free** rather than total memory, which was the other half of the finding. Scaling is clamped so a large card cannot produce a runaway batch size, without ever lowering an explicit user setting.

### The index bug this fix introduced, and the test for it

`nvidia-smi -i` takes **physical** indices; `gpu_idx` is **CUDA-visible**. Under `CUDA_VISIBLE_DEVICES=4,5`, an untranslated `gpu_idx=1` queries physical GPU 1 — a card this process cannot see — and sizes every chunk from its free memory. Shared multi-GPU machines are both where that variable is set and the only place this scaling matters, so the wrong-card case is the *common* one. The index is now translated first; an index outside the visible set returns no measurement rather than another card's. UUID entries are passed through, since `-i` accepts them.

Four tests cover it, mutation-verified. The pre-existing test also had `CUDA_VISIBLE_DEVICES` left uncontrolled, so its assertion depended on the machine it ran on; it now deletes the variable explicitly.

## Also

- The OOM retry in `model_wrapper` ran `empty_cache()` and retried **while the exception was still live**, and the outer loop then reused the original unshrunk batch size for later slices. The shrunk size now persists.
- The legacy YAML path's unknown-key handling turns out to have been **fixed already** by the loader consolidation. It now has tests pinning that, verified by reverting to the pre-fix shape and watching them fail with the bare `TypeError` the finding described.
- `workflow.py` imported the whole `Auto3D` package to read `__version__` for a log banner.
- The progress-event dict, whose schema was restated in three docstrings, is now a `TypedDict`.
- A test asserted `workflow.find_smiles_not_in_sdf is reconciliation.find_smiles_not_in_sdf` — module-attribute identity, which says nothing about whether `_reconcile_output` calls it. It now spies through the real call for both the `.smi` and `.sdf` branches.

## Closed without fixing, with reasons

- **M38 — not needed.** Nothing in `src/` calls `.cuda()` or `set_device`; every tensor factory passes `device=` explicitly or derives from an existing tensor. The installed `aimnet` and `torchani` were checked for stray `.cuda()` too. Adding one would be a no-op with a new `CUDA_VISIBLE_DEVICES` failure mode.
- **M39 — blocked, not half-done.** The energy-only path needs `ModelAdapter.forward`'s contract changed, and bucketing reuse needs `_make_buckets`. Wrapping the call in `no_grad()` would break the adapter's internal `autograd.grad`. Deferred with B1 phase 3, which touches the same contract.
- **No `ase` upper bound.** Every other dependency is lower-bound-only, and the one deprecated API used has survived seven minor versions with no removal signal. The `DeprecationWarning` filter the finding said was missing **already exists**.

## Verification

1645 passed, 9 skipped, 0 xfailed, ruff clean.