### PR TITLE
release: 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Auto3D will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - unreleased
+## [3.0.0] - 2026-08-04
 
 ### Breaking Changes
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,11 @@
 graft src/Auto3D
+
+# `graft` is recursive and unconditional, so without these the sdist and wheel
+# pick up whatever the build tree happens to contain. Building in a checkout
+# that has been used -- which is every real build -- put 69 __pycache__/*.pyc
+# files into the first 3.0.0 wheel: CPython 3.13 bytecode shipped inside a
+# py3-none-any wheel, stale for any other interpreter and pure bloat for this
+# one. Bytecode is generated at install time; it never belongs in a
+# distribution.
+global-exclude *.py[cod]
+global-exclude __pycache__/*

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -55,6 +55,36 @@ def test_no_jpt_package_data():
     assert not any("jpt" in g for g in pd), pd
 
 
+def test_manifest_excludes_bytecode():
+    """``MANIFEST.in`` must exclude compiled bytecode from the distributions.
+
+    ``graft src/Auto3D`` is recursive and unconditional, so on its own it ships
+    whatever the build tree contains. Building 3.0.0 from a checkout that had
+    been used -- which is every real build -- put **69** ``__pycache__/*.pyc``
+    files into a ``py3-none-any`` wheel: CPython 3.13 bytecode, stale for any
+    other interpreter, and 0.36 MB of nothing for this one. Bytecode is
+    generated at install time and never belongs in a distribution.
+
+    This is a source check rather than a built-artifact check on purpose: a test
+    that ran ``python -m build`` would add tens of seconds to the fast tier to
+    re-derive a property the manifest already states. What it guards is someone
+    trimming these two lines back to the bare ``graft``, which is what created
+    the problem.
+    """
+    manifest = (ROOT / "MANIFEST.in").read_text()
+    patterns = [
+        line.split(None, 1)[1].strip()
+        for line in manifest.splitlines()
+        if line.strip().startswith("global-exclude")
+    ]
+    assert "*.py[cod]" in patterns, (
+        f"MANIFEST.in must global-exclude '*.py[cod]'; found {patterns}"
+    )
+    assert any("__pycache__" in p for p in patterns), (
+        f"MANIFEST.in must global-exclude __pycache__ contents; found {patterns}"
+    )
+
+
 def test_torchani_floor_is_2_8():
     deps = _pyproject()["project"]["optional-dependencies"]["ani"]
     assert any("torchani>=2.8" in d.replace(" ", "") for d in deps), deps


### PR DESCRIPTION
Dates the CHANGELOG heading, and fixes a packaging defect found while inspecting the artifacts it describes.

## A latent packaging defect, not introduced by this release

`MANIFEST.in` was a bare `graft src/Auto3D`. `graft` is recursive and unconditional, so it ships whatever the build tree happens to contain — and the first 3.0.0 wheel carried **69 `__pycache__/*.pyc` files**: CPython 3.13 bytecode inside a `py3-none-any` wheel, stale for every other interpreter and 0.36 MB of nothing for this one. Bytecode is generated at install time and never belongs in a distribution.

This would have happened on any build from a checkout that had been used, which is every real build — so it likely affects earlier releases too.

Rebuilt: **146 → 77 wheel entries**, no bytecode in either artifact. A test pins the two exclude lines, mutation-verified by reverting to the bare `graft`.

## Artifacts verified beyond `twine check`

A PyPI upload cannot be undone, so the artifacts were inspected rather than trusted:

| check | result |
|---|---|
| modules on disk vs. in wheel | 69 / 69 — none missing, none extra |
| the 13 modules this release created | all present |
| the 3 modules it deleted | all absent |
| bundled ANI2xt checkpoint | present |
| `console_scripts` entry point | `auto3d = Auto3D.auto3Dcli:cli` |
| tests / caches / scratch dirs in wheel | none |
| `twine check` | passed, both artifacts |

## Verification

1646 passed, 9 skipped, 0 xfailed, ruff clean — run with `CUDA_VISIBLE_DEVICES=""` so it matches CI's CPU-only environment rather than this box's eight visible GPUs. That distinction mattered: it caught two tests earlier today that passed locally and failed on CI.

## Not in this PR

The `v3.0.0` tag and the GitHub release. Publishing the release is what triggers `publish.yml` → PyPI, and that is the maintainer's action.