### PR TITLE
build: add the conda recipe, and record what blocks conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,21 @@ uv pip install Auto3D
 
 # Using pip
 pip install Auto3D
+```
 
-# Using conda (recommended for GPU support)
-conda install -c conda-forge auto3d
+> **conda-forge is not current.** `conda install -c conda-forge auto3d` installs
+> **2.3.0**, not 3.0.0. conda-forge requires every dependency to be a conda
+> package, and `aimnet` — a core dependency since 3.0.0 — is not one yet, nor is
+> its own dependency `nvalchemi-toolkit-ops`. Use pip for 3.0.0. Details and the
+> path forward: [Building the conda package](https://auto3d.readthedocs.io/en/latest/howto/conda_build.html).
+
+Auto3D works fine *inside* a conda environment — it is only the conda **package**
+that lags. The supported combination, which `installation.yml` in this repo sets
+up, is a conda environment with Auto3D installed by pip:
+
+```bash
+conda env create --file installation.yml --name auto3D
+conda activate auto3D          # pip installs Auto3D[ani,ase] into it
 ```
 
 For GPU acceleration, ensure you have CUDA-compatible PyTorch installed. See the [installation guide](https://auto3d.readthedocs.io/en/latest/installation.html) for detailed instructions.

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -1,0 +1,80 @@
+# conda recipe for Auto3D
+
+`meta.yaml` here is the recipe for Auto3D 3.0.0. It is kept in-tree so the
+dependency mapping lives next to `pyproject.toml` and can be updated in the same
+commit as a dependency change; conda-forge builds from a separate feedstock repo,
+not from this directory.
+
+## conda-forge is blocked on two missing packages
+
+conda-forge requires every runtime dependency to exist as a conda package. As of
+2026-08-04, checked against `api.anaconda.org`:
+
+| dependency | conda-forge | note |
+|---|---|---|
+| `aimnet` | **absent** | core dependency since 3.0.0 |
+| `nvalchemi-toolkit-ops` | **absent** | required *by* `aimnet` |
+| `warp-lang` | 1.15.0 | satisfies `aimnet`'s `>=1.11,<2` |
+| `pytorch` | 2.13.0 | |
+| `rdkit` | 2026.03.5 | |
+| `typer`, `rich`, `pydantic`, `send2trash`, `tqdm`, `psutil`, `pandas`, `numpy`, `pyyaml`, `requests` | present | |
+| `ase` (extra) | 3.29.0 | |
+| `torchani` (extra) | 2.8.4 | |
+
+So getting 3.0.0 onto conda-forge is not a recipe-writing task — it needs two
+new feedstocks submitted first, in this order:
+
+1. **`nvalchemi-toolkit-ops`** — `aimnet` depends on it, so it must land first.
+2. **`aimnet`** — then this recipe can be submitted unchanged.
+
+Both are upstream packages Auto3D does not own. Submitting a feedstock for
+someone else's package is normal on conda-forge, but it means committing to
+maintain it, so it is worth asking the `aimnet` authors whether they would
+rather own it.
+
+## Why not vendor or pip-install aimnet
+
+conda-forge forbids network access during builds and forbids `pip install`ing a
+dependency that isn't a conda package, so there is no recipe-level workaround.
+The alternatives are all worse than waiting:
+
+- Making `aimnet` an optional extra again would contradict 3.0.0's design, where
+  AIMNet2 is the default engine and the registry is how models are fetched.
+- Publishing to a personal channel rather than conda-forge would work today, but
+  splits the install story and loses conda-forge's dependency resolution.
+
+## The 2.3.0 → 2.3.1 gap is separate and unblocked
+
+conda-forge currently ships **2.3.0** while PyPI's previous release was
+**2.3.1**. That gap predates this work and does not need `aimnet`: 2.3.x did not
+depend on it. If a conda user needs 2.3.1, that is a one-line version-and-hash
+bump on the existing feedstock and can be done independently of everything above.
+
+## Building locally
+
+Once `aimnet` is resolvable in your channels:
+
+```bash
+conda build conda-recipe/ -c conda-forge
+```
+
+To build against a local sdist instead of the published one, replace the
+`source:` block with `path: ..` and drop the `sha256`.
+
+## Updating this recipe for a new release
+
+1. Bump `version` in `meta.yaml`.
+2. Replace `sha256` with the value from the PyPI JSON API, not from a local
+   build — a locally built sdist is not guaranteed byte-identical to the one the
+   release workflow uploaded:
+
+   ```bash
+   curl -s https://pypi.org/pypi/Auto3D/json \
+     | python -c "import json,sys; d=json.load(sys.stdin); \
+       print(next(f['digests']['sha256'] for f in d['releases'][d['info']['version']] \
+       if f['filename'].endswith('.tar.gz')))"
+   ```
+
+3. Reconcile `requirements.run` against `pyproject.toml`'s `dependencies`,
+   remembering the two name differences: `torch` → `pytorch` and `Send2Trash` →
+   `send2trash`.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,86 @@
+{% set name = "auto3d" %}
+{% set version = "3.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # PyPI sdist for 3.0.0, published 2026-08-04. Verified against the PyPI JSON
+  # API rather than a local build: a locally built sdist is not guaranteed
+  # byte-identical to the one the release workflow uploaded, and conda-forge
+  # checks this hash against what it downloads.
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/auto3d-{{ version }}.tar.gz
+  sha256: a290499b54a8038734a2b8db8cde923d521f1faa4288723479b665c2a2565032
+
+build:
+  # Auto3D is pure Python -- its own wheel is py3-none-any -- so this is
+  # noarch even though pytorch and rdkit are not. noarch means one build
+  # serves every platform; the compiled dependencies are resolved at install
+  # time, not build time.
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - auto3d = Auto3D.auto3Dcli:cli
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - setuptools >=61.0
+    - wheel
+  run:
+    - python >=3.11
+    # Names below are conda-forge names, which differ from the PyPI names in
+    # two places: torch -> pytorch, and Send2Trash -> send2trash.
+    - aimnet >=0.2
+    - numpy >=1.21.0
+    - pandas >=1.3.0
+    - psutil >=5.8.0
+    - pydantic >=2.0
+    - pytorch >=2.8
+    - pyyaml >=6.0
+    - rdkit >=2022.9.5
+    - requests >=2.32.3
+    - rich >=13.0.0
+    - send2trash >=1.8.0
+    - tqdm >=4.60.0
+    - typer >=0.12.0
+
+test:
+  imports:
+    # Deliberately only the top-level package. Since 3.0.0 `import Auto3D`
+    # loads no torch and no rdkit (0.03 s, 154 modules), so this stays a cheap
+    # smoke test; importing a submodule here would pull the whole dependency
+    # tree into the test phase for no extra signal.
+    - Auto3D
+  commands:
+    - auto3d --help
+    - auto3d models list
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/isayevlab/Auto3D_pkg
+  summary: Generating low-energy 3D conformers from SMILES/SDF
+  description: |
+    Auto3D generates low-energy 3D conformers from SMILES strings or SDF files.
+    It enumerates tautomers and stereoisomers, optimizes geometries with a
+    neural network potential (AIMNet2 by default, optionally ANI2x/ANI2xt), and
+    ranks the results by energy.
+
+    Optional extras are not expressed as conda run dependencies: `ase` enables
+    the thermochemistry and geometry-optimization APIs, and `torchani` enables
+    the ANI2x engine. Install `ase` or `torchani` alongside this package to use
+    those paths.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://auto3d.readthedocs.io
+  dev_url: https://github.com/isayevlab/Auto3D_pkg
+
+extra:
+  recipe-maintainers:
+    - isayev

--- a/docs/source/howto/conda_build.rst
+++ b/docs/source/howto/conda_build.rst
@@ -1,0 +1,161 @@
+Building the conda package
+==========================
+
+This page is for packagers. If you just want to *install* Auto3D, see
+:doc:`../installation` -- and note that ``conda install -c conda-forge auto3d``
+currently gives you **2.3.0**, not 3.0.0, for the reason explained below.
+
+.. important::
+
+   **Auto3D 3.0.0 is not on conda-forge, and cannot be until two upstream
+   packages are added there.** conda-forge requires every runtime dependency to
+   exist as a conda package, and two of Auto3D's do not:
+
+   - ``aimnet`` -- a core dependency as of 3.0.0
+   - ``nvalchemi-toolkit-ops`` -- required by ``aimnet`` itself
+
+   Until those exist, ``pip install Auto3D`` is the only way to get 3.0.0.
+
+The recipe
+----------
+
+The recipe lives in ``conda-recipe/meta.yaml`` in the repository, next to
+``pyproject.toml``, so the dependency mapping can be updated in the same commit
+as a dependency change. conda-forge itself builds from a separate *feedstock*
+repository, not from this directory; the in-tree copy is the source of truth
+that a feedstock update is derived from.
+
+Building locally
+----------------
+
+You need ``conda-build``, and every runtime dependency must be resolvable in
+your channels. Today that means ``aimnet`` has to come from somewhere -- a local
+channel, or a channel you control -- because it is not on conda-forge.
+
+.. code:: console
+
+   conda install -n base conda-build
+   conda build conda-recipe/ -c conda-forge
+
+The build runs the recipe's test phase at the end: it imports ``Auto3D``, runs
+``auto3d --help`` and ``auto3d models list``, and runs ``pip check``. All four
+are deliberately offline -- conda-forge's test phase has no network access, so a
+test that downloaded a model would pass locally and fail there.
+
+To build from your working tree instead of the published sdist, replace the
+``source:`` block with:
+
+.. code:: yaml
+
+   source:
+     path: ..
+
+and delete the ``sha256`` line. This is the right form while iterating, since it
+picks up uncommitted changes.
+
+Installing what you built
+-------------------------
+
+.. code:: console
+
+   conda install -c local auto3d
+   # or point at the build output directly
+   conda install $(conda build conda-recipe/ --output)
+
+Updating the recipe for a new release
+-------------------------------------
+
+1. Bump ``version`` in ``meta.yaml``.
+
+2. Replace ``sha256``. **Take it from PyPI, not from a local build** -- a locally
+   built sdist is not guaranteed byte-identical to the one the release workflow
+   uploaded, and conda-forge verifies the hash against the file it downloads:
+
+   .. code:: console
+
+      curl -s https://pypi.org/pypi/Auto3D/json \
+        | python -c "import json,sys; d=json.load(sys.stdin); \
+          print(next(f['digests']['sha256'] for f in d['releases'][d['info']['version']] \
+          if f['filename'].endswith('.tar.gz')))"
+
+3. Reconcile ``requirements.run`` against ``pyproject.toml``'s
+   ``dependencies``. **Two names differ between PyPI and conda-forge**, and
+   getting either wrong produces an unsatisfiable recipe rather than an obvious
+   error:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - PyPI name
+        - conda-forge name
+      * - ``torch``
+        - ``pytorch``
+      * - ``Send2Trash``
+        - ``send2trash``
+
+   This check is worth scripting rather than eyeballing:
+
+   .. code:: console
+
+      python - <<'PY'
+      import re, tomllib, pathlib, yaml
+      raw = pathlib.Path("conda-recipe/meta.yaml").read_text()
+      r = re.sub(r"{%.*?%}", "", raw)
+      for a, b in (("{{ name|lower }}", "auto3d"), ("{{ version }}", "0"),
+                   ("{{ name[0] }}", "a"), ("{{ name }}", "auto3d"),
+                   ("{{ PYTHON }}", "python")):
+          r = r.replace(a, b)
+      run = {x.split()[0] for x in yaml.safe_load(r)["requirements"]["run"]} - {"python"}
+      pypi = {re.split(r"[><=!]", x)[0].strip().lower()
+              for x in tomllib.load(open("pyproject.toml", "rb"))["project"]["dependencies"]}
+      mapped = {x.replace("pytorch", "torch") for x in run}
+      print("in pyproject but not the recipe:", sorted(pypi - mapped) or "none")
+      print("in the recipe but not pyproject:", sorted(mapped - pypi) or "none")
+      PY
+
+Why the recipe is shaped the way it is
+--------------------------------------
+
+``noarch: python``
+   Auto3D is pure Python and its own wheel is ``py3-none-any``, so one build
+   serves every platform. ``pytorch`` and ``rdkit`` being compiled does not
+   change that: they are resolved at install time, not build time.
+
+The test phase imports only the top-level package
+   Since 3.0.0, ``import Auto3D`` loads neither torch nor RDKit (0.03 s, 154
+   modules), so this stays cheap. Importing a submodule would pull the whole
+   dependency tree into the test phase for no additional signal.
+
+Optional extras are not run dependencies
+   ``ase`` (thermochemistry and geometry optimization) and ``torchani``
+   (the ANI2x engine) are installed alongside the package when wanted. Both
+   *are* on conda-forge, so ``conda install ase torchani`` works.
+
+Getting 3.0.0 onto conda-forge
+------------------------------
+
+The order matters, because ``aimnet`` depends on the first one:
+
+1. Submit a feedstock for **``nvalchemi-toolkit-ops``**.
+2. Submit a feedstock for **``aimnet``**.
+3. Update the existing ``auto3d`` feedstock from ``conda-recipe/meta.yaml``.
+
+Both new packages are upstream projects Auto3D does not own. Submitting a
+feedstock for someone else's package is normal on conda-forge, but it means
+committing to maintain it -- so it is worth asking the ``aimnet`` maintainers
+whether they would rather own it.
+
+There is no recipe-level shortcut. conda-forge forbids network access during
+builds and forbids ``pip install``\ ing a dependency that is not a conda
+package, so the alternatives are all worse than waiting: making ``aimnet``
+optional again would contradict the 3.0.0 design in which AIMNet2 is the default
+engine, and publishing to a personal channel splits the install story and gives
+up conda-forge's dependency resolution.
+
+The 2.3.0 gap is separate
+-------------------------
+
+conda-forge ships 2.3.0 while PyPI's release before 3.0.0 was 2.3.1. That gap
+predates all of the above and is **not** blocked by ``aimnet``, because 2.3.x did
+not depend on it. If a conda user needs 2.3.1 specifically, that is a
+version-and-hash bump on the existing feedstock and can be done independently.

--- a/docs/source/howto/index.rst
+++ b/docs/source/howto/index.rst
@@ -12,3 +12,4 @@ Practical guides for common Auto3D tasks.
    hpc
    troubleshooting
    integrations
+   conda_build

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -36,6 +36,22 @@ with Auto3D and its minimum dependencies installed.
    conda activate auto3D
    pip install Auto3D
 
+.. note::
+
+   **Install Auto3D itself with pip, even inside a conda environment.**
+   ``conda install -c conda-forge auto3d`` installs **2.3.0**, not 3.0.0.
+
+   conda-forge requires every runtime dependency to exist as a conda package,
+   and ``aimnet`` -- a core dependency as of 3.0.0 -- is not one, nor is its own
+   dependency ``nvalchemi-toolkit-ops``. Until both are packaged there, the
+   conda-forge build cannot be updated past 2.3.x.
+
+   A conda environment with Auto3D installed by pip -- which is what the commands
+   above and ``installation.yml`` both do -- is the supported combination and
+   gets you 3.0.0. If you are packaging Auto3D rather than installing it, see
+   :doc:`howto/conda_build`, which covers the recipe, building it locally, and
+   what has to happen upstream first.
+
 Optional Dependencies Installation
 ----------------------------------
 


### PR DESCRIPTION
conda-forge ships **2.3.0** — behind even the previous PyPI release, 2.3.1 — and there was no recipe in this repo. The recipe now lives next to `pyproject.toml` so the dependency mapping can be updated in the same commit as a dependency change.

## 3.0.0 cannot go to conda-forge yet, and the recipe is not why

conda-forge requires every runtime dependency to exist as a conda package. Two do not, checked against `api.anaconda.org` on 2026-08-04:

| dependency | conda-forge | note |
|---|---|---|
| `aimnet` | **absent** | core dependency as of 3.0.0 |
| `nvalchemi-toolkit-ops` | **absent** | required *by* `aimnet` |
| `warp-lang` | 1.15.0 | satisfies `aimnet`'s `>=1.11,<2` |
| `pytorch` | 2.13.0 | |
| `rdkit` | 2026.03.5 | |
| everything else, plus both extras (`ase`, `torchani`) | present | |

So the path is **two new feedstocks first** — `nvalchemi-toolkit-ops`, then `aimnet` (that order; `aimnet` depends on it) — after which this recipe can be submitted unchanged.

Both are upstream packages Auto3D doesn't own. Submitting a feedstock for someone else's package is normal on conda-forge but commits you to maintaining it, so it's worth asking the `aimnet` authors whether they'd rather own it.

**There is no recipe-level workaround.** conda-forge forbids network access during builds and forbids pip-installing a non-conda dependency. The README records the alternatives considered and rejected — making `aimnet` optional again would contradict 3.0.0's design, and a personal channel splits the install story — so the next person doesn't re-derive it.

## The 2.3.0 → 2.3.1 gap is separate and unblocked

That gap predates this work and needs no `aimnet`: 2.3.x didn't depend on it. If a conda user needs 2.3.1, it's a one-line version-and-hash bump on the existing feedstock, independent of everything above.

## Recipe details worth noting

- **`sha256` comes from the PyPI JSON API, not a local build.** A locally built sdist isn't guaranteed byte-identical to the one the release workflow uploaded, and conda-forge checks the hash against what it downloads.
- **`noarch: python`**, because Auto3D's own wheel is `py3-none-any`. `pytorch` and `rdkit` being compiled doesn't change that — they resolve at install time.
- **The test phase imports only the top-level package.** Since 3.0.0 that loads neither torch nor rdkit (0.03 s, 154 modules), so it stays a cheap smoke test instead of pulling the whole dependency tree in for no extra signal.
- **`auto3d models list` is included as a test command** because it renders a static table with no network access and no model load — verified, since conda-forge's test phase is network-isolated.
- **Run dependencies were checked against `pyproject.toml` programmatically**: exact match in both directions, allowing for the two conda name differences (`torch` → `pytorch`, `Send2Trash` → `send2trash`).